### PR TITLE
subprocess.mswindows does not exist in python3.5

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -184,7 +184,7 @@ pastebufferr = """Redirecting to or from paste buffer requires %s
 to be installed on operating system.
 %s"""
 
-if subprocess.mswindows:
+if sys.platform == "win32":
     try:
         import win32clipboard
         def get_paste_buffer():


### PR DESCRIPTION
Am hoping that the sys.platform (https://docs.python.org/2/library/sys.html#sys.platform) check is sufficient, though perhaps there was a reason this was not done initially.