### PR TITLE
Loading in a script file now works in Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+build
+dist
+cmd2.egg-info
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ __pycache__
 build
 dist
 cmd2.egg-info
+.idea
+.cache
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -52,10 +52,10 @@ except NameError:
 # Python 3 compatability hack due to no built-in file keyword in Python 3
 # Due to two occurences of isinstance(<foo>, file) checking to see if something is of file type
 try:
+    file
+except NameError:
     import io
     file = io.TextIOWrapper
-except ImportError:
-    pass # Python2
 
 if sys.version_info[0] == 2:
     pyparsing.ParserElement.enablePackrat()

--- a/cmd2.py
+++ b/cmd2.py
@@ -49,6 +49,14 @@ try:
 except NameError:
     raw_input = input
 
+# Python 3 compatability hack due to no built-in file keyword in Python 3
+# Due to two occurences of isinstance(<foo>, file) checking to see if something is of file type
+try:
+    import io
+    file = io.TextIOWrapper
+except ImportError:
+    pass # Python2
+
 if sys.version_info[0] == 2:
     pyparsing.ParserElement.enablePackrat()
 


### PR DESCRIPTION
This code fixes a bug where you weren't able to load in a script file on Python 3.  I tested it on both Python 3.5 and 2.7 and it worked fine on both.