### PR TITLE
Fixed example.py and exampleSession.txt as well as README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,14 +88,16 @@ Example cmd2 application (example/example.py) ::
 
     '''A sample application for cmd2.'''
 
-    from cmd2 import Cmd, make_option, options, Cmd2TestCase
-    import unittest, optparse, sys
+    from cmd2 import Cmd, make_option, options
 
     class CmdLineApp(Cmd):
         multilineCommands = ['orate']
         Cmd.shortcuts.update({'&': 'speak'})
         maxrepeats = 3
         Cmd.settable.append('maxrepeats')
+
+        # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
+        # default_to_shell = True
 
         @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
                   make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),
@@ -118,24 +120,14 @@ Example cmd2 application (example/example.py) ::
         do_say = do_speak     # now "say" is a synonym for "speak"
         do_orate = do_speak   # another synonym, but this one takes multi-line input
 
-    class TestMyAppCase(Cmd2TestCase):
-        CmdApp = CmdLineApp
-        transcriptFileName = 'exampleSession.txt'
-
-    parser = optparse.OptionParser()
-    parser.add_option('-t', '--test', dest='unittests', action='store_true', default=False, help='Run unit test suite')
-    (callopts, callargs) = parser.parse_args()
-    if callopts.unittests:
-        sys.argv = [sys.argv[0]]  # the --test argument upsets unittest.main()
-        unittest.main()
-    else:
-        app = CmdLineApp()
-        app.cmdloop()
+    if __name__ == '__main__':
+        c = CmdLineApp()
+        c.cmdloop()
 
 The following is a sample session running example.py.
-Thanks to `TestMyAppCase(Cmd2TestCase)`, it also serves as a test
+Thanks to Cmd2's built-in transcript testing capability, it also serves as a test
 suite for example.py when saved as `exampleSession.txt`.
-Running `python example.py -t` will run all the commands in the
+Running `python example.py -t exampleSession.txt` will run all the commands in the
 transcript against `example.py`, verifying that the output produced
 matches the transcript.
 
@@ -145,12 +137,13 @@ example/exampleSession.txt::
 
     Documented commands (type help <topic>):
     ========================================
-    _load  edit  history  li    load   pause  run   say  shell      show
-    ed     hi    l        list  orate  r      save  set  shortcuts  speak
+    _load           ed    history  list   pause  run   set        show
+    _relative_load  edit  l        load   py     save  shell      speak
+    cmdenvironment  hi    li       orate  r      say   shortcuts
 
     Undocumented commands:
     ======================
-    EOF  cmdenvironment  eof  exit  help  q  quit
+    EOF  eof  exit  help  q  quit
 
     (Cmd) help say
     Repeats what you tell me to.
@@ -170,10 +163,19 @@ example/exampleSession.txt::
     OODNIGHT, GRACIEGAY
     OODNIGHT, GRACIEGAY
     (Cmd) set
-    prompt: (Cmd)
-    editor: gedit
+    abbrev: True
+    case_insensitive: True
+    colors: True
+    continuation_prompt: >
+    debug: False
+    default_file_name: command.txt
     echo: False
+    editor: gedit
+    feedback_to_output: False
     maxrepeats: 3
+    prompt: (Cmd)
+    quiet: False
+    timing: False
     (Cmd) set maxrepeats 5
     maxrepeats - was: 3
     now: 5
@@ -200,6 +202,7 @@ example/exampleSession.txt::
     say -ps --repeat=5 goodnight, Gracie
     (Cmd) run 4
     say -ps --repeat=5 goodnight, Gracie
+
     OODNIGHT, GRACIEGAY
     OODNIGHT, GRACIEGAY
     OODNIGHT, GRACIEGAY
@@ -209,17 +212,14 @@ example/exampleSession.txt::
     > seven releases ago
     > our BDFL
     > blah blah blah
-    >
-    >
-    Four score and seven releases ago our BDFL blah blah blah
+    Four score and
+    seven releases ago
+    our BDFL
+    blah blah blah
     (Cmd) & look, a shortcut!
     look, a shortcut!
-    (Cmd) say put this in a file > myfile.txt
-    (Cmd) say < myfile.txt
-    put this in a file
     (Cmd) set prompt "---> "
     prompt - was: (Cmd)
     now: --->
     ---> say goodbye
     goodbye
-

--- a/example/example.py
+++ b/example/example.py
@@ -1,26 +1,36 @@
+#!/usr/bin/env python
 # coding=utf-8
 """A sample application for cmd2.
+
+Thanks to cmd2's built-in transtript testing capability, it also serves as a test suite for example.py when used with
+ the exampleSession.txt transcript.
+
+Running `python example.py -t exampleSession.txt` will run all the commands in the transcript against example.py,
+verifying that the output produced matches the transcript.
 """
 
 from cmd2 import Cmd, make_option, options
 
 
 class CmdLineApp(Cmd):
+    """ Example cmd2 application. """
     multilineCommands = ['orate']
-    Cmd.shortcuts.update({'&': 'speak', 'h': 'hello'})
+    Cmd.shortcuts.update({'&': 'speak'})
     maxrepeats = 3
-    redirector = '->'
-    Cmd.settable.append('maxrepeats   Max number of `--repeat`s allowed')
+    Cmd.settable.append('maxrepeats')
+
+    # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
+    # default_to_shell = True
 
     @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
               make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),
               make_option('-r', '--repeat', type="int", help="output [n] times")
-              ], arg_desc='(text to say)')
+              ])
     def do_speak(self, arg, opts=None):
         """Repeats what you tell me to."""
         arg = ''.join(arg)
         if opts.piglatin:
-            arg = '%s%say' % (arg[1:].rstrip(), arg[0])
+            arg = '%s%say' % (arg[1:], arg[0])
         if opts.shout:
             arg = arg.upper()
         repetitions = opts.repeat or 1
@@ -34,5 +44,6 @@ class CmdLineApp(Cmd):
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
 
-c = CmdLineApp()
-c.cmdloop()
+if __name__ == '__main__':
+    c = CmdLineApp()
+    c.cmdloop()

--- a/example/exampleSession.txt
+++ b/example/exampleSession.txt
@@ -12,7 +12,7 @@ EOF  eof  exit  help  q  quit
 
 (Cmd) help say
 Repeats what you tell me to.
-Usage: speak [options] (text to say)
+Usage: speak [options] arg
 
 Options:
   -h, --help            show this help message and exit
@@ -31,14 +31,14 @@ OODNIGHT, GRACIEGAY
 abbrev: True
 case_insensitive: True
 colors: True
-continuation_prompt: > 
+continuation_prompt: >
 debug: False
 default_file_name: command.txt
 echo: False
-editor: /\w*/
+editor: gedit
 feedback_to_output: False
 maxrepeats: 3
-prompt: (Cmd) 
+prompt: (Cmd)
 quiet: False
 timing: False
 (Cmd) set maxrepeats 5
@@ -67,6 +67,7 @@ set maxrepeats 5
 say -ps --repeat=5 goodnight, Gracie
 (Cmd) run 4
 say -ps --repeat=5 goodnight, Gracie
+
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY
@@ -75,15 +76,13 @@ OODNIGHT, GRACIEGAY
 (Cmd) orate Four score and
 > seven releases ago
 > our BDFL
-> 
+> blah blah blah
 Four score and
 seven releases ago
 our BDFL
+blah blah blah
 (Cmd) & look, a shortcut!
 look, a shortcut!
-(Cmd) say put this in a file > myfile.txt
-(Cmd) say < myfile.txt
-put this in a file
 (Cmd) set prompt "---> "
 prompt - was: (Cmd)
 now: --->


### PR DESCRIPTION
Fixed example.py and exampleSession.txt so that the example runs and the test passes when running "python example.py -t exampleSession.txt".

Also made the front-page documentation consistent so it references the actual code and text in this modified example.