### PR TITLE
Added testing on Mac OS X with Python 2.7 and for Python 3.6 on Linux and fixed Windows AppVeyor tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-os:
-  - linux
-  - osx
 sudo: false  # enable container-based build
 install:
   - pip install tox
@@ -10,17 +7,29 @@ script:
 # workaround for https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
     include:
-        - python: 2.6
-          env: TOXENV=py26
-        - python: 2.7
+        - os: linux
+          python: 2.7
           env: TOXENV=py27
-        - python: 3.3
+        - os: linux
+          python: 3.3
           env: TOXENV=py33
-        - python: 3.4
+        - os: linux
+          python: 3.4
           env: TOXENV=py34
-        - python: 3.5
+        - os: linux
+          python: 3.5
           env: TOXENV=py35
-        - python: 3.6
+        - os: linux
+          python: 3.6
           env: TOXENV=py36
-        - python: pypy
+        - os: linux
+          python: pypy
           env: TOXENV=pypy
+        - os: osx
+          python: 2.7
+          env: TOXENV=py27
+        - os: osx
+          python: 3.5
+          env: TOXENV=py35
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ matrix:
           language: generic
           env: TOXENV=py36
 before_install: |
-  if [ $TRAVIS_OS_NAME == "osx" ] && [ $TOXENV == "py36"]; then
+  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    if [[ $TOXENV == "py36" ]]; then
       brew update
       brew install python3
+    fi
   fi
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ matrix:
           python: pypy
           env: TOXENV=pypy
         - os: osx
-          python: 2.7
+          language: generic
           env: TOXENV=py27
         - os: osx
-          python: 3.5
+          language: generic
           env: TOXENV=py35
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,12 @@ matrix:
           python: pypy
           env: TOXENV=pypy
         - os: osx
-          sudo: true
-          python: 2.7
-          env: TOXENV=py27
+          language: objective-c
+          env:
+            - TOXENV=py27
+            - PYENV_VERSION=2.7.12
         - os: osx
-          sudo: true
-          python: 3.5
-          env: TOXENV=py35
+          language: objective-c
+          env:
+            - TOXENV=py35
+            - PYENV_VERSION=3.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: python
 sudo: false  # enable container-based build
-install:
-  - pip install tox
-script:
-  - tox
-# workaround for https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
     include:
         - os: linux
@@ -26,12 +21,17 @@ matrix:
           python: pypy
           env: TOXENV=pypy
         - os: osx
-          language: objective-c
-          env:
-            - TOXENV=py27
-            - PYENV_VERSION=2.7.12
+          language: generic
+          env: TOXENV=py27
         - os: osx
-          language: objective-c
-          env:
-            - TOXENV=py35
-            - PYENV_VERSION=3.5.2
+          language: generic
+          env: TOXENV=py36
+before_install: |
+  if [ $TRAVIS_OS_NAME == "osx" ] && [ $TOXENV == "py36"]; then
+      brew update
+      brew install python3
+  fi
+install:
+  - pip install tox
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ matrix:
           python: pypy
           env: TOXENV=pypy
         - os: osx
-          language: generic
+          sudo: true
+          python: 2.7
           env: TOXENV=py27
         - os: osx
-          language: generic
+          sudo: true
+          python: 3.5
           env: TOXENV=py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os:
+  - linux
+  - osx
 sudo: false  # enable container-based build
 install:
   - pip install tox
@@ -7,6 +10,8 @@ script:
 # workaround for https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
     include:
+        - python 2.6
+          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
         - python: 3.3
@@ -15,5 +20,7 @@ matrix:
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
         - python: pypy
           env: TOXENV=pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 # workaround for https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
     include:
-        - python 2.6
+        - python: 2.6
           env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false  # enable container-based build
+sudo: false  # enable container-based build for fast boot times on Linux
 matrix:
     include:
         - os: linux
@@ -23,16 +23,6 @@ matrix:
         - os: osx
           language: generic
           env: TOXENV=py27
-        - os: osx
-          language: generic
-          env: TOXENV=py36
-before_install: |
-  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    if [[ $TOXENV == "py36" ]]; then
-      brew update
-      brew install python3
-    fi
-  fi
 install:
   - pip install tox
 script:

--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,11 @@ cmd2
 ----
 
 .. image:: https://secure.travis-ci.org/python-cmd2/cmd2.png?branch=master
-   :target: http://travis-ci.org/python-cmd2/cmd2
+   :target: https://travis-ci.org/python-cmd2/cmd2
    :alt: Build status
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/python-cmd2/cmd2
-   :target: http://travis-ci.org/python-cmd2/cmd2
+   :target: https://ci.appveyor.com/project/FedericoCeratto/cmd2
    :alt: Appveyor build status
 
 .. image:: https://img.shields.io/pypi/dm/cmd2.svg?style=plastic

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -6,7 +6,6 @@
 # Released under MIT license, see LICENSE file
 
 import mock
-import pytest
 from conftest import run_cmd, _normalize
 from six import StringIO
 
@@ -72,11 +71,15 @@ def notest_base_(base_app):
 
 
 def test_base_show(base_app):
+    import sys
     out = run_cmd(base_app, 'show')
+    expect_colors = True
+    if sys.platform.startswith('win'):
+        expect_colors = False
     expected = _normalize("""
 abbrev: True
 case_insensitive: True
-colors: True
+colors: {}
 continuation_prompt: >
 debug: False
 default_file_name: command.txt
@@ -85,7 +88,7 @@ feedback_to_output: False
 prompt: (Cmd)
 quiet: False
 timing: False
-""")
+""".format(expect_colors))
     # ignore "editor: vi" (could be others)
     out = [l for l in out if not l.startswith('editor: ')]
     assert out == expected


### PR DESCRIPTION
Attempting to get Mac OS X testing to work with Travis C for Python 2.7 and 3.6.  Also adding Python 3.6 to the Linux tests.