### PR TITLE
Remove command aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,22 +6,18 @@ cmd2
    :target: https://travis-ci.org/python-cmd2/cmd2
    :alt: Build status
 
-.. image:: https://ci.appveyor.com/api/projects/status/github/python-cmd2/cmd2
+.. image:: https://ci.appveyor.com/api/projects/status/github/python-cmd2/cmd2?branch=master
    :target: https://ci.appveyor.com/project/FedericoCeratto/cmd2
    :alt: Appveyor build status
 
 .. image:: https://readthedocs.org/projects/cmd2/badge/?version=latest
     :target: https://cmd2.readthedocs.io
 
-.. image:: https://img.shields.io/pypi/dm/cmd2.svg?style=plastic
-   :target: https://pypi.python.org/pypi/cmd2/
-   :alt: Downloads
-
-.. image:: https://img.shields.io/pypi/v/cmd2.svg?style=plastic
+.. image:: https://img.shields.io/pypi/v/cmd2.svg
    :target: https://pypi.python.org/pypi/cmd2/
    :alt: Latest Version
 
-.. image:: https://img.shields.io/github/license/python-cmd2/cmd2.svg?style=plastic
+.. image:: https://img.shields.io/pypi/l/cmd2.svg
     :target: https://pypi.python.org/pypi/cmd2/
     :alt: License
 

--- a/README.rst
+++ b/README.rst
@@ -148,13 +148,8 @@ example/exampleSession.txt::
 
     Documented commands (type help <topic>):
     ========================================
-    _load           ed    history  list   pause  run   set        show
-    _relative_load  edit  l        load   py     save  shell      speak
-    cmdenvironment  hi    li       orate  r      say   shortcuts
-
-    Undocumented commands:
-    ======================
-    EOF  eof  exit  help  q  quit
+    _relative_load  edit  help     list  orate  py    run   say  shell      show
+    cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
 
     (Cmd) help say
     Repeats what you tell me to.

--- a/cmd2.py
+++ b/cmd2.py
@@ -4,7 +4,7 @@
 To use, simply import cmd2.Cmd instead of cmd.Cmd; use precisely as though you
 were using the standard library's cmd, while enjoying the extra features.
 
-Searchable command history (commands: "hi", "li", "run")
+Searchable command history (commands: "history", "list", "run")
 Load commands from file, save to file, edit commands in file
 Multi-line commands
 Case-insensitive commands
@@ -548,6 +548,7 @@ class Cmd(cmd.Cmd):
                            })
 
     def do_help(self, arg):
+        '''List available commands with "help" or detailed help with "help cmd".'''
         if arg:
             funcname = self.func_named(arg)
             if funcname:
@@ -1056,10 +1057,12 @@ class Cmd(cmd.Cmd):
                     pass
             return stop
 
-    def do_EOF(self, arg):
+    def do_eof(self, arg):
+        """Automatically called at end of loading a script."""
         return self._STOP_SCRIPT_NO_EXIT  # End of script; should not exit app
 
     def do_quit(self, arg):
+        """Exits this application."""
         return self._STOP_AND_EXIT
 
     def select(self, options, prompt='Your choice? '):
@@ -1249,8 +1252,8 @@ class Cmd(cmd.Cmd):
         for hi in history:
             self.poutput(hi.pr())
 
-    def do_ed(self, arg):
-        """ed: edit most recent command in text editor
+    def do_edit(self, arg):
+        """edit: edit most recent command in text editor
         ed [N]: edit numbered command from history
         ed [filename]: edit specified file name
 
@@ -1275,7 +1278,7 @@ class Cmd(cmd.Cmd):
             f.close()
 
         os.system('%s %s' % (self.editor, filename))
-        self.do__load(filename)
+        self.do_load(filename)
 
     saveparser = (pyparsing.Optional(pyparsing.Word(pyparsing.nums) ^ '*')("idx") +
                   pyparsing.Optional(pyparsing.Word(legalChars + '/\\'))("fname") +
@@ -1337,7 +1340,7 @@ class Cmd(cmd.Cmd):
             arg = arg.split(None, 1)
             targetname, args = arg[0], (arg[1:] or [''])[0]
             targetname = os.path.join(self.current_script_dir or '', targetname)
-            self.do__load('%s %s' % (targetname, args))
+            self.do_load('%s %s' % (targetname, args))
 
     urlre = re.compile('(https?://[-\\w\\./]+)')
 
@@ -1407,17 +1410,6 @@ class Cmd(cmd.Cmd):
         else:
             if not self.run_commands_at_invocation(callargs):
                 self._cmdloop()
-
-    # Command Aliases
-    do_eof = do_EOF
-    do_exit = do_quit
-    do_q = do_quit
-    do_hi = do_history
-    do_l = do_list
-    do_li = do_list
-    do_edit = do_ed
-    do__load = do_load  # avoid an unfortunate legacy use of do_load from sqlpython
-    do_r = do_run
 
 
 class HistoryItem(str):

--- a/example/exampleSession.txt
+++ b/example/exampleSession.txt
@@ -2,13 +2,8 @@
 
 Documented commands (type help <topic>):
 ========================================
-_load           ed    history  list   pause  run   set        show
-_relative_load  edit  l        load   py     save  shell      speak
-cmdenvironment  hi    li       orate  r      say   shortcuts
-
-Undocumented commands:
-======================
-EOF  eof  exit  help  q  quit
+_relative_load  edit  help     list  orate  py    run   say  shell      show
+cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,8 @@ import cmd2
 # Help text for base cmd2.Cmd application
 BASE_HELP = """Documented commands (type help <topic>):
 ========================================
-_load           ed    history  list   py   save   shortcuts
-_relative_load  edit  l        load   r    set    show
-cmdenvironment  hi    li       pause  run  shell
-
-Undocumented commands:
-======================
-EOF  eof  exit  help  q  quit
+_relative_load  edit  help     list  pause  quit  save  shell      show
+cmdenvironment  eof   history  load  py     run   set   shortcuts
 """
 
 # Help text for the history command

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -346,7 +346,7 @@ def test_pipe_to_shell(base_app):
     out = run_cmd(base_app, 'help help | wc')
 
     if sys.platform == "win32":
-        expected = normalize("1      11      70")
+        expected = normalize("1      11      74")
     else:
         expected = normalize("1      11      66")
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -346,9 +346,9 @@ def test_pipe_to_shell(base_app):
     out = run_cmd(base_app, 'help help | wc')
 
     if sys.platform == "win32":
-        expected = normalize("1       5      24")
+        expected = normalize("1      11      70")
     else:
-        expected = normalize("1       5      20")
+        expected = normalize("1      11      66")
 
     assert out[0].strip() == expected[0].strip()
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -105,13 +105,8 @@ def test_base_with_transcript(_cmdline_app):
 
 Documented commands (type help <topic>):
 ========================================
-_load           ed    history  list   pause  run   set        show
-_relative_load  edit  l        load   py     save  shell      speak
-cmdenvironment  hi    li       orate  r      say   shortcuts
-
-Undocumented commands:
-======================
-EOF  eof  exit  help  q  quit
+_relative_load  edit  help     list  orate  py    run   say  shell      show
+cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/tests/transcript.txt
+++ b/tests/transcript.txt
@@ -2,13 +2,8 @@
 
 Documented commands (type help <topic>):
 ========================================
-_load           ed    history  list   pause  run   set        show
-_relative_load  edit  l        load   py     save  shell      speak
-cmdenvironment  hi    li       orate  r      say   shortcuts
-
-Undocumented commands:
-======================
-EOF  eof  exit  help  q  quit
+_relative_load  edit  help     list  orate  py    run   say  shell      show
+cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.


### PR DESCRIPTION
I documented previously undocumented commands and removed redundant command aliases.

This cleans up the out-of-the-box help menu significantly.  But short-form versions of commands are still available by default as long as self.abbrev is True (which is the default).

All of the unit tests have been updated to reflect these changes and the GitHub front-page documentation has been as well.

Unrelated, but put it in here anyways:  Updated AppVeyor badge to display build status for master branch instead of the latest one.