### PR TITLE
Parsing improvements for commands using the options decorator

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1055,11 +1055,8 @@ class Cmd(cmd.Cmd):
         off the received input, and dispatch to action methods, passing them
         the remainder of the line as argument.
         """
-
         # An almost perfect copy from Cmd; however, the pseudo_raw_input portion
         # has been split out so that it can be called separately
-
-        self.preloop()
         if self.use_rawinput and self.completekey:
             try:
                 import readline
@@ -1071,8 +1068,6 @@ class Cmd(cmd.Cmd):
         stop = None
         try:
             if intro is not None:
-                self.intro = intro
-            if self.intro:
                 self.stdout.write(str(self.intro) + "\n")
             while not stop:
                 if self.cmdqueue:
@@ -1082,7 +1077,6 @@ class Cmd(cmd.Cmd):
                 if self.echo and isinstance(self.stdin, file):
                     self.stdout.write(line + '\n')
                 stop = self.onecmd_plus_hooks(line)
-            self.postloop()
         finally:
             if self.use_rawinput and self.completekey:
                 try:
@@ -1414,7 +1408,7 @@ class Cmd(cmd.Cmd):
         self.use_rawinput = False
         self.prompt = self.continuation_prompt = ''
         self.current_script_dir = os.path.split(targetname)[0]
-        stop = self._cmdloop()
+        stop = self._cmdloop(None)
         self.stdin.close()
         keepstate.restore()
         self.lastcmd = ''
@@ -1460,7 +1454,9 @@ class Cmd(cmd.Cmd):
             self.runTranscriptTests(callargs)
         else:
             if not self.run_commands_at_invocation(callargs):
-                self._cmdloop()
+                self.preloop()
+                self._cmdloop(self.intro)
+                self.postloop()
 
 
 class HistoryItem(str):

--- a/cmd2.py
+++ b/cmd2.py
@@ -1134,7 +1134,7 @@ class Cmd(cmd.Cmd):
         '''Shows value of a parameter.'''
         # If arguments are being passed as a list instead of as a string
         if USE_ARG_LIST:
-            if arg and len(arg) > 0:
+            if arg:
                 arg = arg[0]
             else:
                 arg = ''
@@ -1255,7 +1255,7 @@ class Cmd(cmd.Cmd):
         """
         # If arguments are being passed as a list instead of as a string
         if USE_ARG_LIST:
-            if arg and len(arg) > 0:
+            if arg:
                 arg = arg[0]
             else:
                 arg = ''

--- a/cmd2.py
+++ b/cmd2.py
@@ -76,8 +76,10 @@ __version__ = '0.7.0'
 # Pyparsing enablePackrat() can greatly speed up parsing, but problems have been seen in Python 3 in the past
 pyparsing.ParserElement.enablePackrat()
 
-# TODO: Devise a way to make these next 3 parameters settable upon instantiating a cmd2.Cmd instance.
-# They all strongly effect how parsing occurs for commands using the @options decorator.
+
+# The next 3 variables and associated setter funtions effect how arguments are parsed for commands using @options.
+# The defaults are "sane" and maximize backward compatibility with cmd and previous versions of cmd2.
+# But depending on your particular application, you may wish to tweak them so you get the desired parsing behavior.
 
 # Use POSIX or Non-POSIX (Windows) rules for splititng a command-line string into a list of arguments via shlex.split()
 POSIX_SHLEX = False
@@ -87,6 +89,33 @@ STRIP_QUOTES_FOR_NON_POSIX = True
 
 # For option commandsm, pass a list of argument strings instead of a single argument string to the do_* methods
 USE_ARG_LIST = False
+
+
+def set_posix_shlex(val):
+    """ Allows user of cmd2 to choose between POSIX and non-POSIX splitting of args for @options commands.
+
+    :param val: bool - True => POSIX,  False => Non-POSIX
+    """
+    global POSIX_SHLEX
+    POSIX_SHLEX = val
+
+
+def set_strip_quotes(val):
+    """ Allows user of cmd2 to choose whether to automatically strip outer-quotes when POSIX_SHLEX is False.
+
+    :param val: bool - True => strip quotes on args and option args for @option commands if POSIX_SHLEX is False.
+    """
+    global STRIP_QUOTES_FOR_NON_POSIX
+    STRIP_QUOTES_FOR_NON_POSIX = val
+
+
+def set_use_arg_list(val):
+    """ Allows user of cmd2 to choose between passing @options commands an argument string or list or arg strings.
+
+    :param val: bool - True => arg is a list of strings,  False => arg is a string (for @options commands)
+    """
+    global USE_ARG_LIST
+    USE_ARG_LIST = val
 
 
 class OptionParser(optparse.OptionParser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ if sys.platform.startswith('win'):
     expect_colors = False
 # Output from the show command with default settings
 SHOW_TXT = """abbrev: True
+autorun_on_edit: True
 case_insensitive: True
 colors: {}
 continuation_prompt: >
@@ -64,6 +65,7 @@ if expect_colors:
 else:
     color_str = 'False'
 SHOW_LONG = """abbrev: True                   # Accept abbreviated commands
+autorun_on_edit: True          # Automatically run files after editing
 case_insensitive: True         # upper- and lower-case both OK
 colors: {}                  # Colorized output (*nix only)
 continuation_prompt: >         # On 2nd+ line of input

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -206,7 +206,7 @@ def test_base_cmdenvironment(base_app):
 
     # Settable parameters can be listed in any order, so need to validate carefully using unordered sets
     settable_params = {'continuation_prompt', 'default_file_name', 'prompt', 'abbrev', 'quiet', 'case_insensitive',
-                       'colors', 'echo', 'timing', 'editor', 'feedback_to_output', 'debug'}
+                       'colors', 'echo', 'timing', 'editor', 'feedback_to_output', 'debug', 'autorun_on_edit'}
     out_params = set(out[2].split("Settable parameters: ")[1].split())
     assert settable_params == out_params
 
@@ -346,9 +346,9 @@ def test_pipe_to_shell(base_app):
     out = run_cmd(base_app, 'help help | wc')
 
     if sys.platform == "win32":
-        expected = normalize("1      11      74")
+        expected = normalize("1      11      71")
     else:
-        expected = normalize("1      11      66")
+        expected = normalize("1      11      70")
 
     assert out[0].strip() == expected[0].strip()
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -204,7 +204,7 @@ Options:
 
 def test_comment_stripping(_cmdline_app):
     out = run_cmd(_cmdline_app, 'speak it was /* not */ delicious! # Yuck!')
-    expected = normalize("""it was  delicious!""")
+    expected = normalize("""it was delicious!""")
     assert out == expected
 
 


### PR DESCRIPTION
Improved how commands using the @options decorator are parsed to handle some difficult edge cases related to quotes and escape characters.

Added an "autorun_on_edit" settable parameter which defaults to True to preserve current behavior, but can be set to False to disable the automatic running of an edited file as a script when the editor closes.

Improved how piping works so it can deal with commands which output a large quantity of data.

Fixed where preloop() and postloop() get called so that do_load() for loading a script doesn't trigger them.