### PR TITLE
Added optional ipy command

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -76,7 +76,7 @@ except NameError:
 ipython_available = True
 try:
     from IPython import embed
-except ModuleNotFoundError:
+except ImportError:
     ipython_available = False
 
 __version__ = '0.7.0'

--- a/example/example.py
+++ b/example/example.py
@@ -22,6 +22,10 @@ class CmdLineApp(Cmd):
     # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
     # default_to_shell = True
 
+    def __init__(self):
+        # Set use_ipython to True to enable the "ipy" command which embeds and interactive IPython shell
+        Cmd.__init__(self, use_ipython=False)
+
     @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
               make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),
               make_option('-r', '--repeat', type="int", help="output [n] times")


### PR DESCRIPTION
If IPython is installed on the system AND the user passes a keyword argument "use_ipython" set to True to the cmd2.Cmd.__init() initializer, then a do_py() method and associated "ipy" command will be present (otherwise it will be absent).

The ipy command enters an embedded interactive IPython shell.  The shell has access to all of the local variables of the cmd2 application, most importantly self.  Since IPython has built-in tab-completion and help, it can be extremely useful for developers debugging thorny problems.  But the shell presented by the ipy command is not nearly as integrated with the cmd2 application as the shell presented by the py command - any changes made within it and/or variables created will not persist once the shell exits.  Moreover cmd2 commands cannot be run within the IPython shell and any arguments passed to ipy are simply ignored, so it cannot be used to run Python commands in a non-interactive fashion.

ipy is really present for two reasons:
1. Developer debugging during application development
2. End user interactive data analysis for data generated by the cmd2 application which you give them easy access to while in the IPython shell.

This PR addresses Issue #41.  The only thing left to be done for that issue is to update the Sphinx documentation with information on this feature.