### PR TITLE
Doctest gone

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -28,7 +28,6 @@ Git repository on GitHub at https://github.com/python-cmd2/cmd2
 import cmd
 import copy
 import datetime
-import doctest
 import glob
 import optparse
 import os
@@ -1816,29 +1815,6 @@ class Cmd2TestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
-
-    # NOTE: The doctest expected values work with Python 2.7, but are a bit off for Python 3.x.
-
-'''
-To make your application transcript-testable, replace
-
-::
-
-  app = MyApp()
-  app.cmdloop()
-
-with
-
-::
-
-  app = MyApp()
-  cmd2.run(app)
-
-Then run a session of your application and paste the entire screen contents
-into a file, ``transcript.test``, and invoke the test like::
-
-  python myapp.py --test transcript.test
-
-Wildcards can be used to test against multiple transcript files.
-'''
+    # If run as the main application, simply start a bare-bones cmd2 application with only built-in functionality.
+    app = Cmd()
+    app.cmdloop()

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,5 @@ deps =
   six
 commands=
   py.test -v --basetemp={envtmpdir} {posargs}
-  {envpython} cmd2.py
   {envpython} example/example.py --test example/exampleSession.txt
 


### PR DESCRIPTION
Since the doctests were removed and converted to pytest unit tests in a previous PR, there wasn't any point in having cmd2.py run the non-existent doctests when run as the main program.

So this PR changed cmd2.py to simply run cmd2.Cmd() as an app if run as the main program and removed the import of doctest.

The tox.ini was also updated accordingly to not try to run cmd2.py.