### PR TITLE
Added unicode parsing tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ cmd2 provides the following features, in addition to those already existing in c
 - Bare ``>``, ``>>`` with no filename send output to paste buffer
 - Pipe output to shell commands with ``|``
 - Simple transcript-based application testing
+- Unicode character support (*Python 3 only*)
 
 Instructions for implementing each feature follow.
 


### PR DESCRIPTION
Added a few unit tests which verify appropriate parsing of unicode characters in the command line for Python 3. 

These tests are skipped for Python 2 since cmd2 only attempts to provide unicode support when running with Python 3.