### PR TITLE
Fixed transcript testing issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ debug: False
 default_file_name: command.txt
 echo: False
 editor: vim
-feedback_to_output: False
+feedback_to_output: True
 locals_in_py: True
 prompt: (Cmd)
 quiet: False
@@ -75,7 +75,7 @@ debug: False                   # Show full error stack on error
 default_file_name: command.txt # for ``save``, ``load``, etc.
 echo: False                    # Echo command issued into output
 editor: vim                    # Program used by ``edit``
-feedback_to_output: False      # include nonessentials in `|`, `>` results
+feedback_to_output: True       # include nonessentials in `|`, `>` results
 locals_in_py: True             # Allow access to your application in py via self
 prompt: (Cmd)                  # The prompt issued to solicit input
 quiet: False                   # Don't print nonessential feedback

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -266,16 +266,15 @@ _relative_load {}
     assert out == expected
 
 
-def test_base_save(base_app, capsys):
+def test_base_save(base_app):
     # TODO: Use a temporary directory for the file
     filename = 'deleteme.txt'
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'help save')
 
     # Test the * form of save which saves all commands from history
-    run_cmd(base_app, 'save * {}'.format(filename))
-    out, err = capsys.readouterr()
-    assert out == 'Saved to {}\n'.format(filename)
+    out = run_cmd(base_app, 'save * {}'.format(filename))
+    assert out == normalize('Saved to {}\n'.format(filename))
     expected = normalize("""
 help
 
@@ -288,18 +287,16 @@ save * deleteme.txt
     assert content == expected
 
     # Test the N form of save which saves a numbered command from history
-    run_cmd(base_app, 'save 1 {}'.format(filename))
-    out, err = capsys.readouterr()
-    assert out == 'Saved to {}\n'.format(filename)
+    out = run_cmd(base_app, 'save 1 {}'.format(filename))
+    assert out == normalize('Saved to {}\n'.format(filename))
     expected = normalize('help')
     with open(filename) as f:
         content = normalize(f.read())
     assert content == expected
 
     # Test the blank form of save which saves the most recent command from history
-    run_cmd(base_app, 'save {}'.format(filename))
-    out, err = capsys.readouterr()
-    assert out == 'Saved to {}\n'.format(filename)
+    out = run_cmd(base_app, 'save {}'.format(filename))
+    assert out == normalize('Saved to {}\n'.format(filename))
     expected = normalize('save 1 {}'.format(filename))
     with open(filename) as f:
         content = normalize(f.read())
@@ -397,6 +394,7 @@ def test_send_to_paste_buffer(base_app):
 
 
 def test_base_timing(base_app, capsys):
+    base_app.feedback_to_output = False
     out = run_cmd(base_app, 'set timing True')
     expected = normalize("""timing - was: False
 now: True

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -149,6 +149,7 @@ set maxrepeats 5
 -------------------------[6]
 say -ps --repeat=5 goodnight, Gracie
 (Cmd) run 4
+say -ps --repeat=5 goodnight, Gracie
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY

--- a/tests/transcript_regex.txt
+++ b/tests/transcript_regex.txt
@@ -10,7 +10,7 @@ debug: False
 default_file_name: command.txt
 echo: False
 editor: /([^\s]+)/
-feedback_to_output: False
+feedback_to_output: True
 locals_in_py: True
 maxrepeats: 3
 prompt: (Cmd)


### PR DESCRIPTION
Transcript testing no longer creates an unnecessary 2nd instance of the class derived from cmd2.Cmd.  This dramatically simplifies transcript testing for derived classes which have required parameters during construction.

As a side effect the, feedback_to_output attribute now defaults to false.  This had some minor ripple effects on various unit tests.

This closes #88 