### PR TITLE
Readline improvements

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -64,9 +64,12 @@ from six.moves.urllib.request import urlopen
 
 # Prefer statically linked gnureadline if available (for Mac OS X compatibility due to issues with libedit)
 try:
-    import gnureadline
+    import gnureadline as readline
 except ImportError:
-    import readline
+    try:
+        import readline
+    except ImportError:
+        pass
 
 # Python 3 compatibility hack due to no built-in file keyword in Python 3
 # Due to one occurrence of isinstance(<foo>, file) checking to see if something is of file type
@@ -1132,9 +1135,12 @@ class Cmd(cmd.Cmd):
         # An almost perfect copy from Cmd; however, the pseudo_raw_input portion
         # has been split out so that it can be called separately
         if self.use_rawinput and self.completekey:
-            self.old_completer = readline.get_completer()
-            readline.set_completer(self.complete)
-            readline.parse_and_bind(self.completekey + ": complete")
+            try:
+                self.old_completer = readline.get_completer()
+                readline.set_completer(self.complete)
+                readline.parse_and_bind(self.completekey + ": complete")
+            except NameError:
+                pass
         stop = None
         try:
             while not stop:
@@ -1148,7 +1154,10 @@ class Cmd(cmd.Cmd):
                 stop = self.onecmd_plus_hooks(line)
         finally:
             if self.use_rawinput and self.completekey:
-                readline.set_completer(self.old_completer)
+                try:
+                    readline.set_completer(self.old_completer)
+                except NameError:
+                    pass
             return stop
 
     # noinspection PyUnusedLocal

--- a/cmd2.py
+++ b/cmd2.py
@@ -62,6 +62,12 @@ from six.moves import zip
 # noinspection PyUnresolvedReferences
 from six.moves.urllib.request import urlopen
 
+# Prefer statically linked gnureadline if available (for Mac OS X compatibility due to issues with libedit)
+try:
+    import gnureadline
+except ImportError:
+    import readline
+
 # Python 3 compatibility hack due to no built-in file keyword in Python 3
 # Due to one occurrence of isinstance(<foo>, file) checking to see if something is of file type
 try:
@@ -1111,9 +1117,8 @@ class Cmd(cmd.Cmd):
             if not len(line):
                 line = 'EOF'
             else:
-                if line[-1] == '\n':  # this was always true in Cmd
-                    line = line[:-1]
-        return line
+                line = line.rstrip('\r\n')
+        return line.strip()
 
     def _cmdloop(self):
         """Repeatedly issue a prompt, accept input, parse an initial prefix
@@ -1127,14 +1132,9 @@ class Cmd(cmd.Cmd):
         # An almost perfect copy from Cmd; however, the pseudo_raw_input portion
         # has been split out so that it can be called separately
         if self.use_rawinput and self.completekey:
-            try:
-                # noinspection PyUnresolvedReferences
-                import readline
-                self.old_completer = readline.get_completer()
-                readline.set_completer(self.complete)
-                readline.parse_and_bind(self.completekey + ": complete")
-            except ImportError:
-                pass
+            self.old_completer = readline.get_completer()
+            readline.set_completer(self.complete)
+            readline.parse_and_bind(self.completekey + ": complete")
         stop = None
         try:
             while not stop:
@@ -1148,12 +1148,7 @@ class Cmd(cmd.Cmd):
                 stop = self.onecmd_plus_hooks(line)
         finally:
             if self.use_rawinput and self.completekey:
-                try:
-                    # noinspection PyUnresolvedReferences
-                    import readline
-                    readline.set_completer(self.old_completer)
-                except ImportError:
-                    pass
+                readline.set_completer(self.old_completer)
             return stop
 
     # noinspection PyUnusedLocal


### PR DESCRIPTION
Made it easier to use cmd2 on Mac OS X by trying to import gnureadline as readline first and then trying to import readline if that fails.

This closes #90 