### PR TITLE
cmd2 now protects against GNU Readline bug when ANSI escapes in prompt

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -34,7 +34,6 @@ import optparse
 import os
 import platform
 import re
-import readline
 import shlex
 import six
 import subprocess
@@ -79,6 +78,13 @@ try:
     from IPython import embed
 except ImportError:
     ipython_available = False
+
+# Try to import readline, but allow failure for convenience in Windows unit testing
+# Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
+try:
+    import readline
+except ImportError:
+    pass
 
 __version__ = '0.7.1a'
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -34,6 +34,7 @@ import optparse
 import os
 import platform
 import re
+import readline
 import shlex
 import six
 import subprocess
@@ -1096,12 +1097,37 @@ class Cmd(cmd.Cmd):
 
         return False
 
+    @staticmethod
+    def _surround_ansi_escapes(prompt, start="\x01", end="\x02"):
+        """Overcome bug in GNU Readline in relation to calculation of prompt length in presence of ASNI escape codes.
+
+        :param prompt: str - original prompt
+        :param start: str - start code to tell GNU Readline about beginning of invisible characters
+        :param end: str - end code to tell GNU Readline about end of invisible characters
+        :return: str - prompt safe to pass to GNU Readline
+        """
+        escaped = False
+        result = ""
+
+        for c in prompt:
+            if c == "\x1b" and not escaped:
+                result += start + c
+                escaped = True
+            elif c.isalpha() and escaped:
+                result += c + end
+                escaped = False
+            else:
+                result += c
+
+        return result
+
     def pseudo_raw_input(self, prompt):
         """copied from cmd's cmdloop; like raw_input, but accounts for changed stdin, stdout"""
 
         if self.use_rawinput:
+            safe_prompt = self._surround_ansi_escapes(prompt)
             try:
-                line = sm.input(prompt)
+                line = sm.input(safe_prompt)
             except EOFError:
                 line = 'EOF'
         else:

--- a/cmd2.py
+++ b/cmd2.py
@@ -1106,6 +1106,10 @@ class Cmd(cmd.Cmd):
         :param end: str - end code to tell GNU Readline about end of invisible characters
         :return: str - prompt safe to pass to GNU Readline
         """
+        # Windows terminals don't use ANSI escape codes and Windows readline isn't based on GNU Readline
+        if sys.platform == "win32":
+            return prompt
+
         escaped = False
         result = ""
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -62,15 +62,6 @@ from six.moves import zip
 # noinspection PyUnresolvedReferences
 from six.moves.urllib.request import urlopen
 
-# Prefer statically linked gnureadline if available (for Mac OS X compatibility due to issues with libedit)
-try:
-    import gnureadline as readline
-except ImportError:
-    try:
-        import readline
-    except ImportError:
-        pass
-
 # Python 3 compatibility hack due to no built-in file keyword in Python 3
 # Due to one occurrence of isinstance(<foo>, file) checking to see if something is of file type
 try:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ The basic use of ``cmd2`` is identical to that of cmd_.
 
    The tab-completion feature provided by cmd_ relies on underlying capability provided by GNU readline or an
    equivalent library.  Linux distros will almost always come with the required library installed.
-   For Mac OS X, we recommend installing the `gnureadline <https://pypi.python.org/pypi/gnureadline>`_ Python module.
+   For Mac OS X, we recommend using the `Homebrew <https://brew.sh>`_ package manager to install the ``readline`` package.
    For Windows, we recommend installing the `pyreadline <https://pypi.python.org/pypi/pyreadline>`_ Python module.
 
 Resources


### PR DESCRIPTION
The Python 3 input() or Python 2 raw_input() functions use the Python readline module under the hood, which in turn relies on OS-specific readline libraries.

On Linux and (sometimes) on Mac this underlying library is GNU Readline.  GNU Readline has a bug in how the prompt length is calculated if there are "invisible" non-printable characters such as ANSI color escape codes.  GNU Readline knows it has this bug and provides a way of escaping these invisible escape characters.

So as a convenience to end users who may want to use color in their prompts, cmd2 now automatically protects any ANSI escape characters in the prompt with GNU Readline escapes on non-Windows OSes.

This closes #92 