### PR TITLE
Fixed a hard-coded path separator

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -87,7 +87,7 @@ try:
 except ImportError:
     pass
 
-__version__ = '0.7.1a'
+__version__ = '0.7.1'
 
 # Pyparsing enablePackrat() can greatly speed up parsing, but problems have been seen in Python 3 in the past
 pyparsing.ParserElement.enablePackrat()
@@ -1461,7 +1461,7 @@ class Cmd(cmd.Cmd):
                 return []
 
         # Get a list of every directory in the PATH environment variable and ignore symbolic links
-        paths = [p for p in os.getenv('PATH').split(':') if not os.path.islink(p)]
+        paths = [p for p in os.getenv('PATH').split(os.path.pathsep) if not os.path.islink(p)]
 
         # Find every executable file in the PATH that matches the pattern
         exes = []

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Setuptools setup file, used to install or test 'cmd2'
 """
 from setuptools import setup
 
-VERSION = '0.7.1a'
+VERSION = '0.7.1'
 DESCRIPTION = "Extra features for standard library's cmd module"
 
 LONG_DESCRIPTION = """cmd2 is an enhancement to the standard library's cmd module for Python 2.7

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -22,7 +22,7 @@ from conftest import run_cmd, normalize, BASE_HELP, HELP_HISTORY, SHORTCUTS_TXT,
 
 
 def test_ver():
-    assert cmd2.__version__ == '0.7.1a'
+    assert cmd2.__version__ == '0.7.1'
 
 
 def test_base_help(base_app):


### PR DESCRIPTION
Fixed a bug where a path separator was hard-coded as ":" and replaced it with os.path.pathsep

Also changed version from 0.7.1a to 0.7.1 in preparation for upcoming release.

This closes #100 