### PR TITLE
Multiline abbreviations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ News
 * Added CmdResult namedtumple for returning and storing results
 * Added local file system path completion for ``edit``, ``load``, ``save``, and ``shell`` commands
 * Add shell command completion for ``shell`` command or ``!`` shortcut
+* Abbreviated multiline commands are no longer allowed (they never worked correctly anyways)
 
 0.7.0
 -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -600,7 +600,7 @@ class Cmd(cmd.Cmd):
     excludeFromHistory = '''run r list l history hi ed edit li eof'''.split()
     # make sure your terminators are not in legalChars!
     legalChars = u'!#$%.:?@_-' + pyparsing.alphanums + pyparsing.alphas8bit
-    multilineCommands = []
+    multilineCommands = []  # NOTE: Multiline commands can never be abbreviated, even if abbrev is True
     noSpecialParse = 'set ed edit exit'.split()
     prefixParser = pyparsing.Empty()
     redirector = '>'  # for sending output to file
@@ -1089,7 +1089,7 @@ class Cmd(cmd.Cmd):
             result = target
         else:
             if self.abbrev:  # accept shortened versions of commands
-                funcs = [fname for fname in self.keywords if fname.startswith(arg)]
+                funcs = [func for func in self.keywords if func.startswith(arg) and func not in self.multilineCommands]
                 if len(funcs) == 1:
                     result = 'do_' + funcs[0]
         return result

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -243,6 +243,11 @@ no other commands defined beginning with *divid*,
 
 This behavior can be turned off with ``app.abbrev`` (see :ref:`parameters`)
 
+.. warning::
+
+    Due to the way the parsing logic works for multiline commands, abbreviations
+    will not be accepted for multiline commands.
+
 Misc. pre-defined commands
 ==========================
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,7 +2,7 @@
 """
 Unit/functional testing for helper functions/classes in the cmd2.py module.
 
-These are primarily tests related to parsing.  Moreover, they are mostly a port of the old doctest tests which were 
+These are primarily tests related to parsing.  Moreover, they are mostly a port of the old doctest tests which were
 problematic because they worked properly for some versions of pyparsing but not for others.
 
 Copyright 2017 Todd Leonhardt <todd.leonhardt@gmail.com>
@@ -246,6 +246,12 @@ def test_parse_multiline_ignores_terminators_in_comments(parser):
     assert len(results.terminator) == 2
     assert results.terminator[0] == '\n'
     assert results.terminator[1] == '\n'
+
+def test_parse_abbreviated_multiline_not_allowed(parser):
+    line = 'multilin command\n'
+    results = parser.parseString(line)
+    assert results.command == 'multilin'
+    assert results.multilineCommand == ''
 
 # Unicode support is only present in cmd2 for Python 3
 @pytest.mark.skipif(sys.version_info < (3,0), reason="cmd2 unicode support requires python3")


### PR DESCRIPTION
Addressed this issue as best I could.

The way the pyparsing logic works, it would have been extremely difficult to actually support abbreviated versions of multiline commands.

So abbreviated commands are now explicitly disallowed.  The documentation has been updated and a unit test was added.

This closes #103 