### PR TITLE
Added ability to exclude some commands from help menu

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1181,7 +1181,7 @@ class Cmd(cmd.Cmd):
 
     # noinspection PyUnusedLocal
     def do_shortcuts(self, args):
-        """Lists single-key shortcuts available."""
+        """Lists shortcuts (aliases) available."""
         result = "\n".join('%s: %s' % (sc[0], sc[1]) for sc in sorted(self.shortcuts))
         self.stdout.write("Single-key shortcuts for other commands:\n{}\n".format(result))
 
@@ -1509,7 +1509,7 @@ class Cmd(cmd.Cmd):
         py: Enters interactive Python mode.
         End with ``Ctrl-D`` (Unix) / ``Ctrl-Z`` (Windows), ``quit()``, '`exit()``.
         Non-python commands can be issued with ``cmd("your command")``.
-        Run python code from external files with ``run("filename.py")``
+        Run python code from external script files with ``run("filename.py")``
         """
         if self._in_py:
             self.perror("Recursively entering interactive Python consoles is not allowed.", traceback_war=False)
@@ -1802,7 +1802,7 @@ Edited files are run on close if the `autorun_on_edit` settable parameter is Tru
     def do__relative_load(self, arg=None):
         """Runs commands in script at file or URL.
 
-    Usage:  load [file_path]
+    Usage:  _relative_load [file_path]
 
     optional argument:
     file_path   a file path or URL pointing to a script
@@ -1812,6 +1812,8 @@ Script should contain one command per line, just like command would be typed in 
 
 If this is called from within an already-running script, the filename will be interpreted
 relative to the already-running script's directory.
+
+NOTE: This command is intended to only be used within text file scripts.
         """
         if arg:
             arg = arg.split(None, 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ import cmd2
 # Help text for base cmd2.Cmd application
 BASE_HELP = """Documented commands (type help <topic>):
 ========================================
-_relative_load  edit  help     list  pause  quit  save  shell      show
-cmdenvironment  eof   history  load  py     run   set   shortcuts
+_relative_load  edit  history  load   py    run   set    shortcuts
+cmdenvironment  help  list     pause  quit  save  shell  show
 """
 
 # Help text for the history command

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -106,8 +106,9 @@ def test_base_with_transcript(_cmdline_app):
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  edit  help     list  orate  py    run   say  shell      show
-cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
+_relative_load  help     load   py    save  shell      speak
+cmdenvironment  history  orate  quit  say   shortcuts
+edit            list     pause  run   set   show
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/tests/transcript.txt
+++ b/tests/transcript.txt
@@ -2,8 +2,9 @@
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  edit  help     list  orate  py    run   say  shell      show
-cmdenvironment  eof   history  load  pause  quit  save  set  shortcuts  speak
+_relative_load  help     load   py    save  shell      speak
+cmdenvironment  history  orate  quit  say   shortcuts
+edit            list     pause  run   set   show
 
 (Cmd) help say
 Repeats what you tell me to.


### PR DESCRIPTION
Added the **exclude_from_help** member variable to the cmd2.Cmd class.  This is a list of commands which should be excluded from the help menu.  By default, only the *do_eof* command is included in this list.

Updated unit tests to reflect the new default help menu with "eof" missing.

The reason behind this feature is that it can be confusing to end users to show them commands which they should never ever have a good reason to directly enter on the command line.  The **eof** "command" is one such obvious case.

I couldn't decide whether or not the **_relative_load** command should be included in that category or not.  It should only ever be included in script files and not entered at the command line, so I guess it should be.  But it is useful in scripts, so maybe it is good to know about via the help menu?

This closes #111 