### PR TITLE
Fixes a bug which caused transcript failures to display twice

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1895,8 +1895,7 @@ Script should contain one command per line, just like command would be typed in 
         sys.argv = [sys.argv[0]]  # the --test argument upsets unittest.main()
         testcase = TestMyAppCase()
         runner = unittest.TextTestRunner()
-        result = runner.run(testcase)
-        result.printErrors()
+        runner.run(testcase)
 
     def _run_commands_at_invocation(self, callargs):
         """Runs commands provided as arguments on the command line when the application is started.

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -270,7 +270,7 @@ def test_transcript_from_cmdloop(request, capsys):
 
     # Check for the unittest "OK" condition for the 1 test which ran
     expected_start = ".\n----------------------------------------------------------------------\nRan 1 test in"
-    expected_end = "s\n\nOK\n\n"
+    expected_end = "s\n\nOK\n"
     out, err = capsys.readouterr()
     if six.PY3:
         assert err.startswith(expected_start)
@@ -296,7 +296,7 @@ def test_multiline_command_transcript_with_comments_at_beginning(request, capsys
 
     # Check for the unittest "OK" condition for the 1 test which ran
     expected_start = ".\n----------------------------------------------------------------------\nRan 1 test in"
-    expected_end = "s\n\nOK\n\n"
+    expected_end = "s\n\nOK\n"
     out, err = capsys.readouterr()
     if six.PY3:
         assert err.startswith(expected_start)
@@ -329,7 +329,7 @@ def test_regex_transcript(request, capsys):
 
     # Check for the unittest "OK" condition for the 1 test which ran
     expected_start = ".\n----------------------------------------------------------------------\nRan 1 test in"
-    expected_end = "s\n\nOK\n\n"
+    expected_end = "s\n\nOK\n"
     out, err = capsys.readouterr()
     if six.PY3:
         assert err.startswith(expected_start)


### PR DESCRIPTION
Previously, all transcript failures were being displayed to the user twice.

This PR fixes that issue.

This closes #120 