### PR TITLE
pyscript now expands the script path before calling do_py

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1611,7 +1611,7 @@ Paths or arguments that contain spaces must be enclosed in quotes
         sys.argv.extend(arg[1:])
 
         # Run the script
-        self.do_py("run('{}')".format(arg[0]))
+        self.do_py("run('{}')".format(script_path))
 
         # Restore command line arguments to original state
         sys.argv = orig_args


### PR DESCRIPTION
Fixes a bug when calling pyscript with a path that includes a tilde.

This closes #126 