### PR TITLE
Changed default value of USE_ARG_LIST and bumped version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,11 +7,16 @@ News
 *Release date: TBD*
 
 * Bug fixes
-    * Fixed a bug in display a span of history items when only an end index is supplied
+    * Fixed a bug in displaying a span of history items when only an end index is supplied
 * Enhancements
     * Added the ability to exclude commands from the help menu (**eof** included by default)
-    * Redundant list command removed and features merged into history command
-    * Added **pyscript** command which supports running Python scripts with arguments
+    * Redundant **list** command removed and features merged into **history** command
+    * Added **pyscript** command which supports tab-completion and running Python scripts with arguments
+    * Changed default value of USE_ARG_LIST to True - this affects the beavhior of all **@options** commands
+        * **WARNING**: This breaks backwards compatibility, to restore backwards compatibility, add this to the
+          **__init__()** method in your custom class derived from cmd2.Cmd:
+            * set_use_arg_list(False)
+        * This change improves argument parsing for all new applications
 
 0.7.2
 -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -87,7 +87,7 @@ try:
 except ImportError:
     pass
 
-__version__ = '0.7.3a'
+__version__ = '0.7.3'
 
 # Pyparsing enablePackrat() can greatly speed up parsing, but problems have been seen in Python 3 in the past
 pyparsing.ParserElement.enablePackrat()

--- a/cmd2.py
+++ b/cmd2.py
@@ -97,8 +97,8 @@ pyparsing.ParserElement.setDefaultWhitespaceChars(' \t')
 
 
 # The next 3 variables and associated setter functions effect how arguments are parsed for commands using @options.
-# The defaults are "sane" and maximize backward compatibility with cmd and previous versions of cmd2.
-# But depending on your particular application, you may wish to tweak them so you get the desired parsing behavior.
+# The defaults are "sane" and maximize ease of use for new applications based on cmd2.
+# To maximize backwards compatibility, we recommend setting USE_ARG_LIST to "False"
 
 # Use POSIX or Non-POSIX (Windows) rules for splitting a command-line string into a list of arguments via shlex.split()
 POSIX_SHLEX = False
@@ -107,7 +107,7 @@ POSIX_SHLEX = False
 STRIP_QUOTES_FOR_NON_POSIX = True
 
 # For option commands, pass a list of argument strings instead of a single argument string to the do_* methods
-USE_ARG_LIST = False
+USE_ARG_LIST = True
 
 
 def set_posix_shlex(val):

--- a/examples/example.py
+++ b/examples/example.py
@@ -9,7 +9,7 @@ Running `python example.py -t exampleSession.txt` will run all the commands in t
 verifying that the output produced matches the transcript.
 """
 
-from cmd2 import Cmd, make_option, options
+from cmd2 import Cmd, make_option, options, set_use_arg_list
 
 
 class CmdLineApp(Cmd):
@@ -25,6 +25,9 @@ class CmdLineApp(Cmd):
     def __init__(self):
         # Set use_ipython to True to enable the "ipy" command which embeds and interactive IPython shell
         Cmd.__init__(self, use_ipython=False)
+
+        # For option commands, pass a single argument string instead of a list of argument strings to the do_* methods
+        set_use_arg_list(False)
 
     @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
               make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),

--- a/examples/python_scripting.py
+++ b/examples/python_scripting.py
@@ -19,9 +19,6 @@ import os
 
 from cmd2 import Cmd, options, make_option, CmdResult, set_use_arg_list
 
-# For option commands, pass a list of argument strings instead of a single argument string to the do_* methods
-set_use_arg_list(True)
-
 
 class CmdLineApp(Cmd):
     """ Example cmd2 application to showcase conditional control flow in Python scripting within cmd2 aps. """
@@ -32,6 +29,9 @@ class CmdLineApp(Cmd):
         self._set_prompt()
         self.autorun_on_edit = False
         self.intro = 'Happy 𝛑 Day.  Note the full Unicode support:  😇  (Python 3 only)  💩'
+
+        # For option commands, pass a list of argument strings instead of a single argument string to the do_* methods
+        set_use_arg_list(True)
 
     def _set_prompt(self):
         """Set prompt so it displays the current working directory."""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Setuptools setup file, used to install or test 'cmd2'
 """
 from setuptools import setup
 
-VERSION = '0.7.3a'
+VERSION = '0.7.3'
 DESCRIPTION = "Extra features for standard library's cmd module"
 
 LONG_DESCRIPTION = """cmd2 is an enhancement to the standard library's cmd module for Python 2.7

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -22,7 +22,7 @@ from conftest import run_cmd, normalize, BASE_HELP, HELP_HISTORY, SHORTCUTS_TXT,
 
 
 def test_ver():
-    assert cmd2.__version__ == '0.7.3a'
+    assert cmd2.__version__ == '0.7.3'
 
 
 def test_base_help(base_app):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -227,11 +227,11 @@ def test_base_cmdenvironment(base_app):
         Command-line arguments allowed: True
         Output redirection and pipes allowed: True
         Parsing of @options commands:
-            Use POSIX-style argument parser (vs Windows): False
-            Strip Quotes when using Windows-style argument parser: True
-            Use a list of arguments instead of a single argument string: False
+            Use POSIX-style argument parser (vs Windows): {}
+            Strip Quotes when using Windows-style argument parser: {}
+            Use a list of arguments instead of a single argument string: {}
             
-""")
+""".format(cmd2.POSIX_SHLEX, cmd2.STRIP_QUOTES_FOR_NON_POSIX, cmd2.USE_ARG_LIST))
     assert out == expected
 
 def test_base_load(base_app, request):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -15,7 +15,7 @@ import six
 # Used for sm.input: raw_input() for Python 2 or input() for Python 3
 import six.moves as sm
 
-from cmd2 import Cmd, make_option, options, Cmd2TestCase
+from cmd2 import Cmd, make_option, options, Cmd2TestCase, set_use_arg_list
 from conftest import run_cmd, StdOut, normalize
 
 
@@ -28,6 +28,7 @@ class CmdLineApp(Cmd):
         # Need to use this older form of invoking super class constructor to support Python 2.x and Python 3.x
         Cmd.__init__(self, *args, **kwargs)
         self.settable.append('maxrepeats   Max number of `--repeat`s allowed')
+        set_use_arg_list(False)
 
     opts = [make_option('-p', '--piglatin', action="store_true", help="atinLay"),
             make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),


### PR DESCRIPTION
Now by default all **@options** commands get passed a list of argument strings instead of a single argument string.

This is a much easier and more robust behavior to deal with.  Additionally, command-line arguments are intelligently separated based on location of quotes to group things into a single argument.

**WARNING**:  This change breaks backward compatibility for older applicaitons based on cmd2.  To change the behavior to the way it used to be, add the following code to the __init__() method of our class derived from cmd2.Cmd:

```Python
    cmd2.set_use_arg_list(False)
```

This change really does make it easier for developers new to using cmd2 however.  It is to the point where I create all custom commands with @options, even if I use an empty list for the options because the argument parsing is just much better this way.

Also bumped version to 0.7.3 (from 0.7.3a) in preparation for a likely release within the next couple weeks