### PR TITLE
Add path completion unit tests

### DIFF
--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -111,6 +111,18 @@ def test_base_run_python_script(base_app, capsys, request):
     assert out == expected
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="Unit test doesn't work on win32, but feature does")
+def test_base_run_pyscript(base_app, capsys, request):
+    test_dir = os.path.dirname(request.module.__file__)
+    python_script = os.path.join(test_dir, 'script.py')
+    expected = 'This is a python script running ...\n'
+
+    run_cmd(base_app, "pyscript {}".format(python_script))
+    out, err = capsys.readouterr()
+    assert out == expected
+
+
 def test_base_error(base_app):
     out = run_cmd(base_app, 'meow')
     assert out == ["*** Unknown syntax: meow"]

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -138,7 +138,7 @@ def test_path_completion_single_mid(cmd2_app, request):
     begidx = line.find(text)
     endidx = begidx + len(text)
 
-    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['tests/']
+    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['tests' + os.path.sep]
 
 def test_path_completion_multiple(cmd2_app, request):
     test_dir = os.path.dirname(request.module.__file__)
@@ -163,3 +163,31 @@ def test_path_completion_nomatch(cmd2_app, request):
     begidx = endidx - len(text)
 
     assert cmd2_app.path_complete(text, line, begidx, endidx) == []
+
+def test_parseline_command_and_args(cmd2_app):
+    line = 'help history'
+    command, args, out_line = cmd2_app.parseline(line)
+    assert command == 'help'
+    assert args == 'history'
+    assert line == out_line
+
+def test_parseline_emptyline(cmd2_app):
+    line = ''
+    command, args, out_line = cmd2_app.parseline(line)
+    assert command == None
+    assert args == None
+    assert line == out_line
+
+def test_parseline_strips_line(cmd2_app):
+    line = '  help history  '
+    command, args, out_line = cmd2_app.parseline(line)
+    assert command == 'help'
+    assert args == 'history'
+    assert line.strip() == out_line
+
+def test_parseline_expands_shortcuts(cmd2_app):
+    line = '!cat foobar.txt'
+    command, args, out_line = cmd2_app.parseline(line)
+    assert command == 'shell'
+    assert args == 'cat foobar.txt'
+    assert line.replace('!', 'shell ') == out_line


### PR DESCRIPTION
Added unit tests for the most common cases of path completion.

This addresses the bulk of happy-day cases for #109 

But there are still a number of unit tests which need to be written for various corner cases and other unusual cases.