### PR TITLE
Add codecov integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,10 +13,10 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
 
-    # Don't complain about OS-specific code for other OSes (excludes Windows and Mac, includes Linux)
-    if sys\.platform
+    # Don't complain about macOS-specific code until we have a CI platform that builds on macOS
+    if sys\.platform == 'darwin':
 
-# (integer): the number of digits after the decimal point to display for reported coverage percentages. 
+# (integer): the number of digits after the decimal point to display for reported coverage percentages.
 precision = 1
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ matrix:
         - os: linux
           python: 3.7-dev
           env: TOXENV=py37
-        - os: linux
-          python: pypy
-          env: TOXENV=pypy
-        - os: linux
-          python: pypy3
-          env: TOXENV=pypy3
+#        # Warning: Don't try to use code coverage analysis with pypy as it is insanely slow
+#        - os: linux
+#          python: pypy
+#          env: TOXENV=pypy
+#        - os: linux
+#          python: pypy3
+#          env: TOXENV=pypy3
 #        # Stock OSX Python
 #        - os: osx
 #          language: generic

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py34,py35,py36,jython,pypy
 
 [testenv]
-passenv = CI TRAVIS TRAVIS_*
+passenv = CI TRAVIS TRAVIS_* APPVEYOR*
 deps =
   codecov
   mock
@@ -11,7 +11,7 @@ deps =
   pytest-cov
   six
 commands=
-  py.test -v --cov=./ --basetemp={envtmpdir} {posargs}
+  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
   {envpython} examples/example.py --test examples/exampleSession.txt
   codecov
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,16 @@
 envlist = py27,py34,py35,py36,jython,pypy
 
 [testenv]
+passenv = CI TRAVIS TRAVIS_*
 deps =
+  codecov
   mock
   pyparsing
   pytest
+  pytest-cov
   six
 commands=
-  py.test -v --basetemp={envtmpdir} {posargs}
+  py.test -v --cov=./ --basetemp={envtmpdir} {posargs}
   {envpython} examples/example.py --test examples/exampleSession.txt
+  codecov
 


### PR DESCRIPTION
Added integration with codecov.io for calculating unit test code coverage.

NOTES: 

- Doing code coverage analysis when using pypy takes forever, so I disabled running unit tests on pypy and pypy3
- For now excluding code which runs only on macOS until we have a regular macOS build working on either TravisCI or CircleCI
- AppVeyor seems to be working with codecov for Python 2 builds, but not Python 3 builds