### PR TITLE
Fix pastebuffer/clipboard issues on macOS and Linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - python -m pip install pywin32 tox
+  - python -m pip install tox
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - python -m pip install tox
+  - python -m pip install pywin32 tox
 
 build: off
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -13,9 +13,6 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
 
-    # Don't complain about macOS-specific code until we have a CI platform that builds on macOS
-    if sys\.platform == 'darwin':
-
 # (integer): the number of digits after the decimal point to display for reported coverage percentages.
 precision = 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
 #            - BREW_INSTALL=python3
 install:
   - pip install tox
+  - apt-get install xclip
 #  - |
 #    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 #      if [[ -n "$BREW_INSTALL" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,26 @@ matrix:
 #        - os: linux
 #          python: pypy3
 #          env: TOXENV=pypy3
-#        # Stock OSX Python
-#        - os: osx
-#          language: generic
-#          env: TOXENV=py27
-#        # Latest Python 3.x from Homebrew
-#        - os: osx
-#          language: generic
-#          env:
-#            - TOXENV=py36
-#            - BREW_INSTALL=python3
+        # Stock OSX Python
+        - os: osx
+          language: generic
+          env: TOXENV=py27
+        # Latest Python 3.x from Homebrew
+        - os: osx
+          language: generic
+          env:
+            - TOXENV=py36
+            - BREW_INSTALL=python3
 install:
-  - pip install tox
-#  - |
-#    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-#      if [[ -n "$BREW_INSTALL" ]]; then
-#        brew update
-#        brew install "$BREW_INSTALL"
-#      fi
-#    fi
-#    pip install tox
+#  - pip install tox
+  - |
+    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      if [[ -n "$BREW_INSTALL" ]]; then
+        brew update
+        brew install "$BREW_INSTALL"
+      fi
+    fi
+    pip install tox
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: true  # false enables container-based build for fast boot times on Linux
+sudo: false  # false enables container-based build for fast boot times on Linux
 matrix:
     include:
         - os: linux
@@ -39,7 +39,6 @@ matrix:
 #            - BREW_INSTALL=python3
 install:
   - pip install tox
-  - sudo apt-get install xclip
 #  - |
 #    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 #      if [[ -n "$BREW_INSTALL" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false  # enable container-based build for fast boot times on Linux
+sudo: true  # false enables container-based build for fast boot times on Linux
 matrix:
     include:
         - os: linux
@@ -39,7 +39,7 @@ matrix:
 #            - BREW_INSTALL=python3
 install:
   - pip install tox
-  - apt-get install xclip
+  - sudo apt-get install xclip
 #  - |
 #    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 #      if [[ -n "$BREW_INSTALL" ]]; then

--- a/cmd2.py
+++ b/cmd2.py
@@ -415,7 +415,11 @@ else:
             """
             xclipproc = subprocess.Popen('xclip -o -sel clip', shell=True, stdout=subprocess.PIPE,
                                          stdin=subprocess.PIPE)
-            return xclipproc.stdout.read()
+            stdout, stderr = xclipproc.communicate()
+            if six.PY3:
+                return stdout.decode()
+            else:
+                return stdout
 
         def write_to_paste_buffer(txt):
             """Paste text to the clipboard for Linux OSes.
@@ -423,11 +427,18 @@ else:
             :param txt: str - text to paste to the clipboard
             """
             xclipproc = subprocess.Popen('xclip -sel clip', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-            xclipproc.stdin.write(txt.encode())
+            if six.PY3:
+                xclipproc.stdin.write(txt.encode())
+            else:
+                xclipproc.stdin.write(txt)
             xclipproc.stdin.close()
+            
             # but we want it in both the "primary" and "mouse" clipboards
             xclipproc = subprocess.Popen('xclip', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-            xclipproc.stdin.write(txt.encode())
+            if six.PY3:
+                xclipproc.stdin.write(txt.encode())
+            else:
+                xclipproc.stdin.write(txt)
             xclipproc.stdin.close()
     else:
         # noinspection PyUnusedLocal

--- a/cmd2.py
+++ b/cmd2.py
@@ -432,7 +432,7 @@ else:
             else:
                 xclipproc.stdin.write(txt)
             xclipproc.stdin.close()
-            
+
             # but we want it in both the "primary" and "mouse" clipboards
             xclipproc = subprocess.Popen('xclip', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             if six.PY3:
@@ -1412,7 +1412,8 @@ class Cmd(cmd.Cmd):
             elif os.path.isdir(path_completions[0]) and add_sep_after_tilde:
                 completions[0] = os.path.sep + completions[0]
 
-        return completions
+        # If there are multiple completions, then sort them alphabetically
+        return sorted(completions)
 
     # Enable tab completion of paths for relevant commands
     complete_edit = path_complete
@@ -1453,7 +1454,8 @@ class Cmd(cmd.Cmd):
         if len(exes) == 1 and endidx == len(line):
             exes[0] += ' '
 
-        return exes
+        # If there are multiple completions, then sort them alphabetically
+        return sorted(exes)
 
     # noinspection PyUnusedLocal
     def complete_shell(self, text, line, begidx, endidx):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -418,30 +418,30 @@ def test_pipe_to_shell(base_app):
     assert out[0].strip() == expected[0].strip()
 
 
+@pytest.mark.skipif(not cmd2.can_clip,
+                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not installed")
 def test_send_to_paste_buffer(base_app):
     from cmd2 import can_clip
 
     run_cmd(base_app, 'help >')
     expected = normalize(BASE_HELP)
 
-    # If an appropriate tool is installed for reading the contents of the clipboard, then do so
-    if can_clip:
-        # Read from the clipboard
-        try:
-            # Python2
-            import Tkinter as tk
-        except ImportError:
-            # Python3
-            import tkinter as tk
+    # Read from the clipboard
+    try:
+        # Python2
+        import Tkinter as tk
+    except ImportError:
+        # Python3
+        import tkinter as tk
 
-        root = tk.Tk()
-        # keep the window from showing
-        root.withdraw()
+    root = tk.Tk()
+    # keep the window from showing
+    root.withdraw()
 
-        # read the clipboard
-        c = root.clipboard_get()
+    # read the clipboard
+    c = root.clipboard_get()
 
-        assert normalize(c) == expected
+    assert normalize(c) == expected
 
 
 def test_base_timing(base_app, capsys):
@@ -647,6 +647,8 @@ def test_cmdloop_without_rawinput():
     assert out == expected
 
 
+@pytest.mark.skipif(not cmd2.can_clip,
+                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not installed")
 def test_pastebuffer_read_and_write():
     text_to_pb = 'This is a test ...'
     cmd2.write_to_paste_buffer(text_to_pb)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -418,30 +418,30 @@ def test_pipe_to_shell(base_app):
     assert out[0].strip() == expected[0].strip()
 
 
-@pytest.mark.skipif(not cmd2.can_clip,
-                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not installed")
 def test_send_to_paste_buffer(base_app):
     from cmd2 import can_clip
 
     run_cmd(base_app, 'help >')
     expected = normalize(BASE_HELP)
 
-    # Read from the clipboard
-    try:
-        # Python2
-        import Tkinter as tk
-    except ImportError:
-        # Python3
-        import tkinter as tk
+    # If the tools for interacting with the clipboard/pastebuffer are available
+    if cmd2.can_clip:
+        # Read from the clipboard
+        try:
+            # Python2
+            import Tkinter as tk
+        except ImportError:
+            # Python3
+            import tkinter as tk
 
-    root = tk.Tk()
-    # keep the window from showing
-    root.withdraw()
+        root = tk.Tk()
+        # keep the window from showing
+        root.withdraw()
 
-    # read the clipboard
-    c = root.clipboard_get()
+        # read the clipboard
+        c = root.clipboard_get()
 
-    assert normalize(c) == expected
+        assert normalize(c) == expected
 
 
 def test_base_timing(base_app, capsys):
@@ -647,10 +647,11 @@ def test_cmdloop_without_rawinput():
     assert out == expected
 
 
-@pytest.mark.skipif(not cmd2.can_clip,
-                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not installed")
 def test_pastebuffer_read_and_write():
     text_to_pb = 'This is a test ...'
     cmd2.write_to_paste_buffer(text_to_pb)
     text_from_pb = cmd2.get_paste_buffer()
-    assert text_from_pb == text_to_pb
+
+    # If the tools for interacting with the clipboard/pastebuffer are available
+    if cmd2.can_clip:
+        assert text_from_pb == text_to_pb

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -36,6 +36,21 @@ def test_base_help_history(base_app):
     expected = normalize(HELP_HISTORY)
     assert out == expected
 
+def test_base_options_help(base_app, capsys):
+    run_cmd(base_app, 'show -h')
+    out, err = capsys.readouterr()
+    expected = run_cmd(base_app, 'help show')
+    # 'show -h' is the same as 'help show', other than whitespace differences of an extra newline present in 'help show'
+    assert normalize(str(out)) == expected
+
+def test_base_invalid_option(base_app, capsys):
+    run_cmd(base_app, 'show -z')
+    out, err = capsys.readouterr()
+    show_help = run_cmd(base_app, 'help show')
+    expected = ['no such option: -z']
+    expected.extend(show_help)
+    # 'show -h' is the same as 'help show', other than whitespace differences of an extra newline present in 'help show'
+    assert normalize(str(out)) == expected
 
 def test_base_shortcuts(base_app):
     out = run_cmd(base_app, 'shortcuts')
@@ -632,4 +647,8 @@ def test_cmdloop_without_rawinput():
     assert out == expected
 
 
-
+def test_pastebuffer_read_and_write():
+    text_to_pb = 'This is a test ...'
+    cmd2.write_to_paste_buffer(text_to_pb)
+    text_from_pb = cmd2.get_paste_buffer()
+    assert text_from_pb == text_to_pb

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -647,11 +647,10 @@ def test_cmdloop_without_rawinput():
     assert out == expected
 
 
+@pytest.mark.skipif(not cmd2.can_clip,
+                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not available")
 def test_pastebuffer_read_and_write():
     text_to_pb = 'This is a test ...'
     cmd2.write_to_paste_buffer(text_to_pb)
     text_from_pb = cmd2.get_paste_buffer()
-
-    # If the tools for interacting with the clipboard/pastebuffer are available
-    if cmd2.can_clip:
-        assert text_from_pb == text_to_pb
+    assert text_from_pb == text_to_pb

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -15,7 +15,7 @@ import six
 # Used for sm.input: raw_input() for Python 2 or input() for Python 3
 import six.moves as sm
 
-from cmd2 import Cmd, make_option, options, Cmd2TestCase, set_use_arg_list
+from cmd2 import Cmd, make_option, options, Cmd2TestCase, set_use_arg_list, set_posix_shlex, set_strip_quotes
 from conftest import run_cmd, StdOut, normalize
 
 
@@ -28,6 +28,10 @@ class CmdLineApp(Cmd):
         # Need to use this older form of invoking super class constructor to support Python 2.x and Python 3.x
         Cmd.__init__(self, *args, **kwargs)
         self.settable.append('maxrepeats   Max number of `--repeat`s allowed')
+
+        # Configure how arguments are parsed for @options commands
+        set_posix_shlex(False)
+        set_strip_quotes(True)
         set_use_arg_list(False)
 
     opts = [make_option('-p', '--piglatin', action="store_true", help="atinLay"),
@@ -54,8 +58,7 @@ class CmdLineApp(Cmd):
 
 
 class DemoApp(Cmd):
-    @options([make_option('-n', '--name', action="store", help="your name"),
-              ])
+    @options(make_option('-n', '--name', action="store", help="your name"))
     def do_hello(self, arg, opts):
         """Says hello."""
         if opts.name:


### PR DESCRIPTION
Various changes include:

- Enable macOS build for Python 2.7 and 3.6 on TravisCI
- Removed some unused code from cmd2.py
- Fixed a couple bugs with pastebuffer/clipboard interaction on macOS and Linux
- Ensure path and shell command completions are sorted alphabetically
- Added a number of unit tests

This closes #141 