### PR TITLE
Refactored to remove a few things that felt out of place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,25 +28,25 @@ matrix:
 #          python: pypy3
 #          env: TOXENV=pypy3
         # Stock OSX Python
-        - os: osx
-          language: generic
-          env: TOXENV=py27
-        # Latest Python 3.x from Homebrew
-        - os: osx
-          language: generic
-          env:
-            - TOXENV=py36
-            - BREW_INSTALL=python3
+#        - os: osx
+#          language: generic
+#          env: TOXENV=py27
+#        # Latest Python 3.x from Homebrew
+#        - os: osx
+#          language: generic
+#          env:
+#            - TOXENV=py36
+#            - BREW_INSTALL=python3
 install:
-#  - pip install tox
-  - |
-    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-      if [[ -n "$BREW_INSTALL" ]]; then
-        brew update
-        brew install "$BREW_INSTALL"
-      fi
-    fi
-    pip install tox
+  - pip install tox
+#  - |
+#    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+#      if [[ -n "$BREW_INSTALL" ]]; then
+#        brew update
+#        brew install "$BREW_INSTALL"
+#      fi
+#    fi
+#    pip install tox
 
 script:
   - tox

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,15 @@ News
 
 * Bug fixes
     * Fixed a couple bugs in interacting with pastebuffer/clipboard on macOS and Linux
+    * Fixed a couple bugs in edit and save commands if called when history is empty
 * Enhancements
     * Ensure that path and shell command tab-completion results are alphabetically sorted
+    * Removed feature for load command to load scripts from URLS
+        * It didn't work, there were no unit tests, and it felt out of place
+    * Removed presence of a default file name and default file extension
+        * These also strongly felt out of place
+        * ``load`` and ``_relative_load`` now require a file path
+        * ``edit`` and ``save`` now use a temporary file if a file path isn't provided   
     
 0.7.3
 -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -1759,10 +1759,10 @@ Edited files are run on close if the ``autorun_on_edit`` settable parameter is T
             self.perror('Error saving {}'.format(fname))
             raise
 
-    def do__relative_load(self, arg=None):
+    def do__relative_load(self, file_path):
         """Runs commands in script file that is encoded as either ASCII or UTF-8 text.
 
-    Usage:  _relative_load [file_path]
+    Usage:  _relative_load <file_path>
 
     optional argument:
     file_path   a file path pointing to a script
@@ -1774,29 +1774,31 @@ relative to the already-running script's directory.
 
 NOTE: This command is intended to only be used within text file scripts.
         """
-        if arg:
-            arg = arg.split(None, 1)
-            targetname, args = arg[0], (arg[1:] or [''])[0]
-            targetname = os.path.join(self._current_script_dir or '', targetname)
-            self.do_load('%s %s' % (targetname, args))
+        # If arg is None or arg is an empty string this is an error
+        if not file_path:
+            self.perror('_relative_load command requires a file path:\n', traceback_war=False)
+            return
 
-    def do_load(self, file_path=None):
+        file_path = file_path.strip()
+        # NOTE: Relative path is an absolute path, it is just relative to the current script directory
+        relative_path = os.path.join(self._current_script_dir or '', file_path)
+        self.do_load(relative_path)
+
+    def do_load(self, file_path):
         """Runs commands in script file that is encoded as either ASCII or UTF-8 text.
 
-    Usage:  load [file_path]
+    Usage:  load <file_path>
 
     * file_path - a file path pointing to a script
 
 Script should contain one command per line, just like command would be typed in console.
         """
-        # If arg is None or arg is an empty string, use the default filename
+        # If arg is None or arg is an empty string this is an error
         if not file_path:
-            targetname = self.default_file_name
-        else:
-            file_path = file_path.split(None, 1)
-            targetname, args = file_path[0], (file_path[1:] or [''])[0].strip()
+            self.perror('load command requires a file path:\n', traceback_war=False)
+            return
 
-        expanded_path = os.path.expanduser(targetname)
+        expanded_path = os.path.abspath(os.path.expanduser(file_path.strip()))
         try:
             target = open(expanded_path)
         except IOError as e:

--- a/cmd2.py
+++ b/cmd2.py
@@ -1714,7 +1714,11 @@ Edited files are run on close if the ``autorun_on_edit`` settable parameter is T
                 filename = arg
                 buffer = ''
         else:
-            buffer = self.history[-1]
+            try:
+                buffer = self.history[-1]
+            except IndexError:
+                self.perror('edit must be called with argument if history is empty', traceback_war=False)
+                return
 
         if buffer:
             f = open(os.path.expanduser(filename), 'w')

--- a/cmd2.py
+++ b/cmd2.py
@@ -602,7 +602,7 @@ class Cmd(cmd.Cmd):
     colors = (platform.system() != 'Windows')
     continuation_prompt = '> '
     debug = False
-    default_file_name = 'command.txt'  # For ``save``, ``load``, etc.
+    default_file_name = 'command.txt'  # For ``edit`` when called with a history item number and ``save``
     echo = False
     editor = os.environ.get('EDITOR')
     if not editor:
@@ -622,14 +622,14 @@ class Cmd(cmd.Cmd):
     settable = stubborn_dict('''
         abbrev                Accept abbreviated commands
         autorun_on_edit       Automatically run files after editing
-        case_insensitive      upper- and lower-case both OK
+        case_insensitive      Upper- and lower-case both OK
         colors                Colorized output (*nix only)
         continuation_prompt   On 2nd+ line of input
         debug                 Show full error stack on error
-        default_file_name     for ``save``, ``load``, etc.
+        default_file_name     For ``edit`` and ``save``
         echo                  Echo command issued into output
         editor                Program used by ``edit``
-        feedback_to_output    include nonessentials in `|`, `>` results
+        feedback_to_output    Include nonessentials in `|`, `>` results
         locals_in_py          Allow access to your application in py via self
         prompt                The prompt issued to solicit input
         quiet                 Don't print nonessential feedback
@@ -1748,8 +1748,13 @@ Edited files are run on close if the ``autorun_on_edit`` settable parameter is T
         elif args.idx:
             saveme = self.history[int(args.idx) - 1]
         else:
-            # Since this save command has already been added to history, need to go one more back for previous
-            saveme = self.history[-2]
+            saveme = ''
+            # Wrap in try to deal with case of empty history
+            try:
+                # Since this save command has already been added to history, need to go one more back for previous
+                saveme = self.history[-2]
+            except IndexError:
+                pass
         try:
             f = open(os.path.expanduser(fname), 'w')
             f.write(saveme)

--- a/docs/settingchanges.rst
+++ b/docs/settingchanges.rst
@@ -104,12 +104,11 @@ with::
 
     (Cmd) set --long
     abbrev: True                   # Accept abbreviated commands
-    autorun_on_edit: True          # Automatically run files after editing
+    autorun_on_edit: False         # Automatically run files after editing
     case_insensitive: True         # upper- and lower-case both OK
     colors: True                   # Colorized output (*nix only)
     continuation_prompt: >         # On 2nd+ line of input
     debug: False                   # Show full error stack on error
-    default_file_name: command.txt # for ``save``, ``load``, etc.
     echo: False                    # Echo command issued into output
     editor: vim                    # Program used by ``edit``
     feedback_to_output: False      # include nonessentials in `|`, `>` results

--- a/examples/scripts/nested.txt
+++ b/examples/scripts/nested.txt
@@ -1,0 +1,3 @@
+!echo "Doing a relative load"
+_relative_load script.txt
+ 

--- a/examples/transcript_regex.txt
+++ b/examples/transcript_regex.txt
@@ -2,12 +2,11 @@
 # The regex for editor matches any word until first space.  The one for colors is because no color on Windows.
 (Cmd) set
 abbrev: True
-autorun_on_edit: True
+autorun_on_edit: False
 case_insensitive: True
 colors: /(True|False)/
 continuation_prompt: >
 debug: False
-default_file_name: command.txt
 echo: False
 editor: /([^\s]+)/
 feedback_to_output: False

--- a/save.hist
+++ b/save.hist
@@ -1,0 +1,7 @@
+save
+
+!cat command.txt
+
+help save
+
+save * save.hist

--- a/save.hist
+++ b/save.hist
@@ -1,7 +1,0 @@
-save
-
-!cat command.txt
-
-help save
-
-save * save.hist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,12 +48,11 @@ if sys.platform.startswith('win'):
     expect_colors = False
 # Output from the show command with default settings
 SHOW_TXT = """abbrev: True
-autorun_on_edit: True
+autorun_on_edit: False
 case_insensitive: True
 colors: {}
 continuation_prompt: >
 debug: False
-default_file_name: command.txt
 echo: False
 editor: vim
 feedback_to_output: True
@@ -67,20 +66,20 @@ if expect_colors:
     color_str = 'True '
 else:
     color_str = 'False'
-SHOW_LONG = """abbrev: True                   # Accept abbreviated commands
-autorun_on_edit: True          # Automatically run files after editing
-case_insensitive: True         # upper- and lower-case both OK
-colors: {}                  # Colorized output (*nix only)
-continuation_prompt: >         # On 2nd+ line of input
-debug: False                   # Show full error stack on error
-default_file_name: command.txt # for ``save``, ``load``, etc.
-echo: False                    # Echo command issued into output
-editor: vim                    # Program used by ``edit``
-feedback_to_output: True       # include nonessentials in `|`, `>` results
-locals_in_py: True             # Allow access to your application in py via self
-prompt: (Cmd)                  # The prompt issued to solicit input
-quiet: False                   # Don't print nonessential feedback
-timing: False                  # Report execution times
+SHOW_LONG = """
+abbrev: True             # Accept abbreviated commands
+autorun_on_edit: False   # Automatically run files after editing
+case_insensitive: True   # Upper- and lower-case both OK
+colors: {}            # Colorized output (*nix only)
+continuation_prompt: >   # On 2nd+ line of input
+debug: False             # Show full error stack on error
+echo: False              # Echo command issued into output
+editor: vim              # Program used by ``edit``
+feedback_to_output: True # Include nonessentials in `|`, `>` results
+locals_in_py: True       # Allow access to your application in py via self
+prompt: (Cmd)            # The prompt issued to solicit input
+quiet: False             # Don't print nonessential feedback
+timing: False            # Report execution times
 """.format(color_str)
 
 

--- a/tests/relative_multiple.txt
+++ b/tests/relative_multiple.txt
@@ -1,0 +1,1 @@
+_relative_load scripts/one_down.txt 

--- a/tests/script.txt
+++ b/tests/script.txt
@@ -1,2 +1,1 @@
-help
 help history

--- a/tests/scripts/one_down.txt
+++ b/tests/scripts/one_down.txt
@@ -1,0 +1,1 @@
+_relative_load ../script.txt

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -545,10 +545,7 @@ def test_edit_number(base_app):
     run_cmd(base_app, 'edit 1')
 
     # We have an editor, so should expect a system call
-    m.assert_called_once_with('{} {}'.format(base_app.editor, base_app.default_file_name))
-
-    # Editing history item causes a file of default name to get created, remove it so we have a clean slate
-    os.remove(base_app.default_file_name)
+    m.assert_called_once()
 
 
 def test_edit_blank(base_app):
@@ -565,10 +562,7 @@ def test_edit_blank(base_app):
     run_cmd(base_app, 'edit')
 
     # We have an editor, so should expect a system call
-    m.assert_called_once_with('{} {}'.format(base_app.editor, base_app.default_file_name))
-
-    # Editing history item causes a file of default name to get created, remove it so we have a clean slate
-    os.remove(base_app.default_file_name)
+    m.assert_called_once()
 
 
 def test_base_py_interactive(base_app):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -288,7 +288,7 @@ def test_base_load_with_empty_args(base_app, capsys):
     run_cmd(base_app, 'load')
     out, err = capsys.readouterr()
 
-    # The default file 'command.txt' doesn't exist, so we should get an error message
+    # The load command requires a file path argument, so we should get an error message
     expected = normalize("""ERROR: load command requires a file path:\n""")
     assert normalize(str(err)) == expected
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -283,18 +283,13 @@ load {}
     assert out == expected
 
 
-def test_base_load_default_file(base_app, capsys):
-    # TODO: Make sure to remove the 'command.txt' file in case it exists
-
+def test_base_load_with_empty_args(base_app, capsys):
     # The way the load command works, we can't directly capture its stdout or stderr
     run_cmd(base_app, 'load')
     out, err = capsys.readouterr()
 
     # The default file 'command.txt' doesn't exist, so we should get an error message
-    expected = normalize("""ERROR: Problem accessing script from command.txt:
-[Errno 2] No such file or directory: 'command.txt'
-To enable full traceback, run the following command:  'set debug true'
-""")
+    expected = normalize("""ERROR: load command requires a file path:\n""")
     assert normalize(str(err)) == expected
 
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -292,7 +292,7 @@ def test_base_load_default_file(base_app, capsys):
 
     # The default file 'command.txt' doesn't exist, so we should get an error message
     expected = normalize("""ERROR: Problem accessing script from command.txt:
-[Errno 2] No such file or directory: 'command.txt.txt'
+[Errno 2] No such file or directory: 'command.txt'
 To enable full traceback, run the following command:  'set debug true'
 """)
     assert normalize(str(err)) == expected

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -150,7 +150,7 @@ def test_path_completion_multiple(cmd2_app, request):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['script.py', 'script.txt']
+    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['script.py', 'script.txt', 'scripts/']
 
 def test_path_completion_nomatch(cmd2_app, request):
     test_dir = os.path.dirname(request.module.__file__)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -150,7 +150,7 @@ def test_path_completion_multiple(cmd2_app, request):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['script.py', 'script.txt', 'scripts/']
+    assert cmd2_app.path_complete(text, line, begidx, endidx) == ['script.py', 'script.txt', 'scripts' + os.path.sep]
 
 def test_path_completion_nomatch(cmd2_app, request):
     test_dir = os.path.dirname(request.module.__file__)

--- a/tests/transcript_regex.txt
+++ b/tests/transcript_regex.txt
@@ -2,12 +2,11 @@
 # The regex for editor matches any word until first space.  The one for colors is because no color on Windows.
 (Cmd) set
 abbrev: True
-autorun_on_edit: True
+autorun_on_edit: False
 case_insensitive: True
 colors: /(True|False)/
 continuation_prompt: >
 debug: False
-default_file_name: command.txt
 echo: False
 editor: /([^\s]+)/
 feedback_to_output: True


### PR DESCRIPTION
Changes include:

- On TravisCI, comment out mac OS builds for now since heavily backlogged
- The ``load`` command now only loads files, it no longer attempts to load a script from a URL
    - As far as I can tell, this feature didn't work and there were no unit tests.  It also felt out of place
    - If any end user was actually using this feature and can explain to me how it was supposed to work so that I can fix it and add a unit test, I'd be happy to entertain the concept of putting it back in
- The ``defaultExtension`` member variable no longer exists
    - It was only used by load and felt really kludgey and unecessary
- ``autorun_on_edit`` defaults to False
    - This feels like a safer and more expected default
- The ``default_file_name`` member variable no longer exits
    - ``load`` and ``_relative_load`` now require  a file path
    - ``edit`` and ``save`` use a temporary file if a file path isn't provided
- The implementation of ``load`` and ``_relative_load`` has been significantly simplified
- A couple bugs related to calling ``edit`` or ``save`` in a certain way when the history list is empty have been fixed

This closes #142 