### PR TITLE
Linux clipboard interaction improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
+
 sudo: false  # false enables container-based build for fast boot times on Linux
+
+addons:
+  apt:
+    packages:
+      - xclip
+
 matrix:
     include:
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ matrix:
 #          env:
 #            - TOXENV=py36
 #            - BREW_INSTALL=python3
+
+# use xvfb (X Virtual Framebuffer) to imitate a display so that xclip should work
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
 install:
   - pip install tox
 #  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: python
 
 sudo: false  # false enables container-based build for fast boot times on Linux
 
-addons:
-  apt:
-    packages:
-      - xclip
-
 matrix:
     include:
         - os: linux
@@ -44,12 +39,6 @@ matrix:
 #          env:
 #            - TOXENV=py36
 #            - BREW_INSTALL=python3
-
-# use xvfb (X Virtual Framebuffer) to imitate a display so that xclip should work
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 install:
   - pip install tox

--- a/cmd2.py
+++ b/cmd2.py
@@ -398,18 +398,17 @@ else:
     # Running on Linux
     try:
         with open(os.devnull, 'w') as DEVNULL:
-            subprocess.check_call(['which', 'xclip'], stdout=DEVNULL, stderr=DEVNULL)
+            subprocess.check_call(['uptime', '|', 'xclip'], stdout=DEVNULL, stderr=DEVNULL)
         can_clip = True
     except (subprocess.CalledProcessError, OSError, IOError):
-        pass  # xclip is not present, so we cannot use it
+        pass  # something went wrong with xclip and we cannot use it
     if can_clip:
         def get_paste_buffer():
             """Get the contents of the clipboard for Linux OSes.
 
             :return: str - contents of the clipboard
             """
-            xclipproc = subprocess.Popen('xclip -o -sel clip', shell=True, stdout=subprocess.PIPE,
-                                         stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip', '-o', '-selection', 'clipboard'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             stdout, stderr = xclipproc.communicate()
             if six.PY3:
                 return stdout.decode()
@@ -421,7 +420,7 @@ else:
 
             :param txt: str - text to paste to the clipboard
             """
-            xclipproc = subprocess.Popen('xclip -sel clip', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip', '-selection', 'clipboard'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             if six.PY3:
                 xclipproc.stdin.write(txt.encode())
             else:
@@ -429,7 +428,7 @@ else:
             xclipproc.stdin.close()
 
             # but we want it in both the "primary" and "mouse" clipboards
-            xclipproc = subprocess.Popen('xclip', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             if six.PY3:
                 xclipproc.stdin.write(txt.encode())
             else:

--- a/cmd2.py
+++ b/cmd2.py
@@ -398,11 +398,10 @@ else:
     # Running on Linux
     try:
         with open(os.devnull, 'w') as DEVNULL:
-            subprocess.check_call('xclip -o -sel clip', shell=True, stdin=subprocess.PIPE, stdout=DEVNULL,
-                                  stderr=DEVNULL)
+            subprocess.check_call(['which', 'xclip'], stdout=DEVNULL, stderr=DEVNULL)
         can_clip = True
     except (subprocess.CalledProcessError, OSError, IOError):
-        pass  # something went wrong with xclip and we cannot use it
+        pass  # xclip is not present, so we cannot use it
     if can_clip:
         def get_paste_buffer():
             """Get the contents of the clipboard for Linux OSes.


### PR DESCRIPTION
Improved how the **xclip** command-line utility is tested for and used on Linux platforms.

This fix should more reliably determine if **xclip** can be used to read from and write to the X-Windows clipboard.

This is to support file redirection to the the clipboard (when no file is specified for file redirection) and associated unit tests.  Unfortunately the TravisCI Linux containers are headless and don't have a real X-Windows system running, so they have to skip these unit tests.

This closes #144 