### PR TITLE
Improved how subprocess module is used

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -357,7 +357,7 @@ elif sys.platform == 'darwin':
         # Python 3.3+ supports subprocess.DEVNULL, but that isn't defined for Python 2.7
         with open(os.devnull, 'w') as DEVNULL:
             # test for pbcopy - AFAIK, should always be installed on MacOS
-            subprocess.check_call('pbcopy -help', shell=True, stdin=subprocess.PIPE, stdout=DEVNULL, stderr=DEVNULL)
+            subprocess.check_call(['pbcopy', '-help'], stdin=subprocess.PIPE, stdout=DEVNULL, stderr=DEVNULL)
         can_clip = True
     except (subprocess.CalledProcessError, OSError, IOError):
         pass
@@ -367,7 +367,7 @@ elif sys.platform == 'darwin':
 
             :return: str - contents of the clipboard
             """
-            pbcopyproc = subprocess.Popen('pbpaste', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+            pbcopyproc = subprocess.Popen('pbpaste', stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)
             stdout, stderr = pbcopyproc.communicate()
             if six.PY3:
@@ -380,7 +380,7 @@ elif sys.platform == 'darwin':
 
             :param txt: str - text to paste to the clipboard
             """
-            pbcopyproc = subprocess.Popen('pbcopy', shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+            pbcopyproc = subprocess.Popen('pbcopy', stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)
             if six.PY3:
                 pbcopyproc.communicate(txt.encode())
@@ -398,7 +398,7 @@ else:
     # Running on Linux
     try:
         with open(os.devnull, 'w') as DEVNULL:
-            subprocess.check_call(['uptime', '|', 'xclip'], stdout=DEVNULL, stderr=DEVNULL)
+            subprocess.check_call(['uptime', '|', 'xclip'], stdin=subprocess.PIPE, stdout=DEVNULL, stderr=DEVNULL)
         can_clip = True
     except (subprocess.CalledProcessError, OSError, IOError):
         pass  # something went wrong with xclip and we cannot use it
@@ -408,7 +408,8 @@ else:
 
             :return: str - contents of the clipboard
             """
-            xclipproc = subprocess.Popen(['xclip', '-o', '-selection', 'clipboard'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip', '-o', '-selection', 'clipboard'], stdin=subprocess.PIPE,
+                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = xclipproc.communicate()
             if six.PY3:
                 return stdout.decode()
@@ -420,7 +421,8 @@ else:
 
             :param txt: str - text to paste to the clipboard
             """
-            xclipproc = subprocess.Popen(['xclip', '-selection', 'clipboard'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip', '-selection', 'clipboard'], stdin=subprocess.PIPE,
+                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if six.PY3:
                 xclipproc.stdin.write(txt.encode())
             else:
@@ -428,7 +430,8 @@ else:
             xclipproc.stdin.close()
 
             # but we want it in both the "primary" and "mouse" clipboards
-            xclipproc = subprocess.Popen(['xclip'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            xclipproc = subprocess.Popen(['xclip'], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
             if six.PY3:
                 xclipproc.stdin.write(txt.encode())
             else:

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -627,12 +627,3 @@ def test_cmdloop_without_rawinput():
         app.cmdloop()
     out = app.stdout.buffer
     assert out == expected
-
-
-@pytest.mark.skipif(not cmd2.can_clip,
-                    reason="CLI utility for interacting with PasteBuffer/ClipBoard is not available")
-def test_pastebuffer_read_and_write():
-    text_to_pb = 'This is a test ...'
-    cmd2.write_to_paste_buffer(text_to_pb)
-    text_from_pb = cmd2.get_paste_buffer()
-    assert text_from_pb == text_to_pb

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -416,27 +416,20 @@ def test_pipe_to_shell(base_app):
 def test_send_to_paste_buffer(base_app):
     from cmd2 import can_clip
 
+    # Test writing to the PasteBuffer/Clipboard
     run_cmd(base_app, 'help >')
     expected = normalize(BASE_HELP)
 
     # If the tools for interacting with the clipboard/pastebuffer are available
     if cmd2.can_clip:
         # Read from the clipboard
-        try:
-            # Python2
-            import Tkinter as tk
-        except ImportError:
-            # Python3
-            import tkinter as tk
+        assert normalize(cmd2.get_paste_buffer()) == expected
 
-        root = tk.Tk()
-        # keep the window from showing
-        root.withdraw()
-
-        # read the clipboard
-        c = root.clipboard_get()
-
-        assert normalize(c) == expected
+    # Test appending to the PasteBuffer/Clipboard
+    run_cmd(base_app, 'help history >>')
+    expected = normalize(BASE_HELP + '\n' + HELP_HISTORY)
+    if cmd2.can_clip:
+        assert normalize(cmd2.get_paste_buffer()) == expected
 
 
 def test_base_timing(base_app, capsys):


### PR DESCRIPTION
Improved how subprocess.check_call() and subprocess.Popen() are used to interact with command-line utilities for reading/writing the PasteBuffer/Clipboard on macOS and Linux.

Also improved a unit test and then removed another unit test which was made redundant.