### PR TITLE
Refactored to replace custom StubbornDict with collections.OrderedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,22 @@ Example cmd2 application (**examples/example.py**):
 ```python
 '''A sample application for cmd2.'''
 
-from cmd2 import Cmd, make_option, options
+from cmd2 import Cmd, make_option, options, set_use_arg_list
 
 class CmdLineApp(Cmd):
-    multilineCommands = ['orate']
-    Cmd.shortcuts.update({'&': 'speak'})
-    maxrepeats = 3
-    Cmd.settable.append('maxrepeats')
+    def __init__(self):
+        self.multilineCommands = ['orate']
+        self.maxrepeats = 3
 
-    # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
-    # default_to_shell = True
+        # Add stuff to settable and shortcutgs before calling base class initializer
+        self.settable['maxrepeats'] = 'max repetitions for speak command'
+        self.shortcuts.update({'&': 'speak'})
+
+        # Set use_ipython to True to enable the "ipy" command which embeds and interactive IPython shell
+        Cmd.__init__(self, use_ipython=False)
+
+        # For option commands, pass a single argument string instead of a list of argument strings to the do_* methods
+        set_use_arg_list(False)
 
     @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
               make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),

--- a/examples/example.py
+++ b/examples/example.py
@@ -14,15 +14,18 @@ from cmd2 import Cmd, make_option, options, set_use_arg_list
 
 class CmdLineApp(Cmd):
     """ Example cmd2 application. """
-    multilineCommands = ['orate']
-    Cmd.shortcuts.update({'&': 'speak'})
-    maxrepeats = 3
-    Cmd.settable.append('maxrepeats')
 
     # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
     # default_to_shell = True
 
     def __init__(self):
+        self.multilineCommands = ['orate']
+        self.maxrepeats = 3
+
+        # Add stuff to settable and shortcutgs before calling base class initializer
+        self.settable['maxrepeats'] = 'max repetitions for speak command'
+        self.shortcuts.update({'&': 'speak'})
+
         # Set use_ipython to True to enable the "ipy" command which embeds and interactive IPython shell
         Cmd.__init__(self, use_ipython=False)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -43,27 +43,6 @@ def test_remaining_args():
     assert cmd2.remaining_args('-f bar   bar   cow', ['bar', 'cow']) == 'bar   cow'
 
 
-def test_stubborn_dict_class():
-    d = cmd2.StubbornDict(large='gross', small='klein')
-    assert sorted(d.items()) == [('large', 'gross'), ('small', 'klein')]
-
-    d.append(['plain', '  plaid'])
-    assert sorted(d.items()) == [('large', 'gross'), ('plaid', ''), ('plain', ''), ('small', 'klein')]
-
-    d += '   girl Frauelein, Maedchen\n\n shoe schuh'
-    assert sorted(d.items()) == [('girl', 'Frauelein, Maedchen'), ('large', 'gross'), ('plaid', ''), ('plain', ''),
-                                 ('shoe', 'schuh'), ('small', 'klein')]
-
-def test_stubborn_dict_factory():
-    assert sorted(cmd2.stubborn_dict('cow a bovine\nhorse an equine').items()) == [('cow', 'a bovine'),
-                                                                                   ('horse', 'an equine')]
-    assert sorted(cmd2.stubborn_dict(['badger', 'porcupine a poky creature']).items()) == [('badger', ''),
-                                                                                           ('porcupine',
-                                                                                           'a poky creature')]
-    assert sorted(cmd2.stubborn_dict(turtle='has shell', frog='jumpy').items()) == [('frog', 'jumpy'),
-                                                                                    ('turtle', 'has shell')]
-
-
 def test_history_span(hist):
     h = hist
     assert h.span('-2..') == ['third', 'fourth']

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -20,14 +20,16 @@ from conftest import run_cmd, StdOut, normalize
 
 
 class CmdLineApp(Cmd):
-    multilineCommands = ['orate']
-    maxrepeats = 3
-    redirector = '->'
-
     def __init__(self, *args, **kwargs):
+        self.multilineCommands = ['orate']
+        self.maxrepeats = 3
+        self.redirector = '->'
+
+        # Add stuff to settable and/or shortcuts before calling base class initializer
+        self.settable['maxrepeats'] = 'Max number of `--repeat`s allowed'
+
         # Need to use this older form of invoking super class constructor to support Python 2.x and Python 3.x
         Cmd.__init__(self, *args, **kwargs)
-        self.settable.append('maxrepeats   Max number of `--repeat`s allowed')
 
         # Configure how arguments are parsed for @options commands
         set_posix_shlex(False)


### PR DESCRIPTION
The self.settable object is now an OrderedDict instead of a custom StubbornDict.

This allowed removal of the custom StubbornDict class.

This closes #147 