### PR TITLE
Speedup tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,4 +4,4 @@ install:
 build: off
 
 test_script:
-  - python -m tox -e py27,py34,py35,py36
+  - python -m tox -e py27,py35,py36

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,4 +4,4 @@ install:
 build: off
 
 test_script:
-  - python -m tox -e py27,py35,py36
+  - python -m tox -e py27,py35,py36-win

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
         - os: linux
           python: 3.6
           env: TOXENV=py36
-        - os: linux
-          python: 3.7-dev
-          env: TOXENV=py37
+#        - os: linux
+#          python: 3.7-dev
+#          env: TOXENV=py37
 #        # Warning: Don't try to use code coverage analysis with pypy as it is insanely slow
 #        - os: linux
 #          python: pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,py37,pypy
+envlist = py27,py33,py34,py35,py36,py36-winpy37,pypy
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
@@ -59,6 +59,16 @@ deps =
 commands =
   py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
+
+[testenv:py36-win]
+deps =
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-xdist
+  six
+commands = py.test -v -n2
 
 [testenv:py37]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
 
 [testenv:py27]
 commands =
-  codecov erase
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 
@@ -30,7 +29,6 @@ commands = py.test -v -n2
 
 [testenv:py36]
 commands =
-  codecov erase
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,jython,pypy
+envlist = py27,py33,py34,py35,py36,py37,pypy
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
@@ -10,9 +10,30 @@ deps =
   pyperclip
   pytest
   pytest-cov
+  pytest-xdist
   six
-commands=
-  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
-  {envpython} examples/example.py --test examples/exampleSession.txt
+
+[testenv:py27]
+commands =
+  codecov erase
+  py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
+
+[testenv:py33]
+commands = py.test -v -n2
+
+[testenv:py34]
+commands = py.test -v -n2
+
+[testenv:py35]
+commands = py.test -v -n2
+
+[testenv:py36]
+commands =
+  codecov erase
+  py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
+  codecov
+
+[testenv:py37]
+commands = py.test -v -n2
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,9 @@ deps =
   pyperclip
   pytest
   pytest-cov
-  pytest-xdist
   six
 commands =
-  py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
-  {envpython} examples/example.py --test examples/exampleSession.txt
+  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 
 [testenv:py33]
@@ -57,11 +55,9 @@ deps =
   pyperclip
   pytest
   pytest-cov
-  pytest-xdist
   six
 commands =
-  py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
-  {envpython} examples/example.py --test examples/exampleSession.txt
+  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 
 [testenv:py37]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py27,py33,py34,py35,py36,py37,pypy
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
+
+[testenv:py27]
 deps =
   codecov
   mock
@@ -12,26 +14,61 @@ deps =
   pytest-cov
   pytest-xdist
   six
-
-[testenv:py27]
 commands =
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 
 [testenv:py33]
+deps =
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-xdist
+  six
 commands = py.test -v -n2
 
 [testenv:py34]
+deps =
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-xdist
+  six
 commands = py.test -v -n2
 
 [testenv:py35]
+deps =
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-xdist
+  six
 commands = py.test -v -n2
 
 [testenv:py36]
+deps =
+  codecov
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-cov
+  pytest-xdist
+  six
 commands =
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
   codecov
 
 [testenv:py37]
+deps =
+  mock
+  pyparsing
+  pyperclip
+  pytest
+  pytest-xdist
+  six
 commands = py.test -v -n2
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
   six
 commands =
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
+  {envpython} examples/example.py --test examples/exampleSession.txt
   codecov
 
 [testenv:py33]
@@ -60,6 +61,7 @@ deps =
   six
 commands =
   py.test -v -n2 --cov=cmd2 --basetemp={envtmpdir} {posargs}
+  {envpython} examples/example.py --test examples/exampleSession.txt
   codecov
 
 [testenv:py37]


### PR DESCRIPTION
Now that we have a lot of unit tests and are running code coverage analysis,
our unit tests take a long time to run.

Changes include ...

tox:
- Install pytest-xdist to parallelize unit tests
- Only run code coverage analysis on Python 2.7 and 3.6
- Don't run examples/example.py anymore, just run the unit tests

TravisCI:
- Stop building on Python 3.7-dev since that won't be released for some time

AppVeyor:
- Stop building on Python 3.4 since that isn't as important and is covered by Travis