### PR TITLE
pytest-cov and pytest-xdist now play nicely together

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
+# Source
+source = cmd.py,tests
 # (boolean, default False): whether to measure branch coverage in addition to statement coverage.
 branch = False
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
 # Source
-source = cmd.py,tests
+source = cmd2.py
 # (boolean, default False): whether to measure branch coverage in addition to statement coverage.
 branch = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ testpaths = tests
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
+setenv =
+    PYTHONPATH={toxinidir}
 
 [testenv:py27]
 deps =
@@ -18,7 +20,7 @@ deps =
   pytest-xdist
   six
 commands =
-  py.test -v --cov=cmd2 -nauto --cov-report=term-missing tests
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
   codecov
 
 [testenv:py33]
@@ -29,7 +31,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -nauto
+commands = py.test -v -n2
 
 [testenv:py34]
 deps =
@@ -39,7 +41,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -nauto
+commands = py.test -v -n2
 
 [testenv:py35]
 deps =
@@ -49,7 +51,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -nauto
+commands = py.test -v -n2
 
 [testenv:py36]
 deps =
@@ -62,7 +64,7 @@ deps =
   pytest-xdist
   six
 commands =
-  py.test -v --cov=cmd2 -nauto --cov-report=term-missing tests
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
   codecov
 
 [testenv:py36-win]
@@ -73,7 +75,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -nauto
+commands = py.test -v -n2
 
 [testenv:py37]
 deps =
@@ -83,5 +85,5 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -nauto
+commands = py.test -v -n2
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py27,py33,py34,py35,py36,py36-winpy37,pypy
 
+[pytest]
+testpaths = tests
+
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
 
@@ -12,9 +15,10 @@ deps =
   pyperclip
   pytest
   pytest-cov
+  pytest-xdist
   six
 commands =
-  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
+  py.test -v --cov=cmd2 -nauto --cov-report=term-missing tests
   codecov
 
 [testenv:py33]
@@ -25,7 +29,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -nauto
 
 [testenv:py34]
 deps =
@@ -35,7 +39,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -nauto
 
 [testenv:py35]
 deps =
@@ -45,7 +49,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -nauto
 
 [testenv:py36]
 deps =
@@ -55,9 +59,10 @@ deps =
   pyperclip
   pytest
   pytest-cov
+  pytest-xdist
   six
 commands =
-  py.test -v --cov=cmd2 --basetemp={envtmpdir} {posargs}
+  py.test -v --cov=cmd2 -nauto --cov-report=term-missing tests
   codecov
 
 [testenv:py36-win]
@@ -68,7 +73,7 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -nauto
 
 [testenv:py37]
 deps =
@@ -78,5 +83,5 @@ deps =
   pytest
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -nauto
 


### PR DESCRIPTION
Honestly I'm not sure wtf the magic sauce was that fixed it.  I referenced this pytest-cov Issue:
https://github.com/pytest-dev/pytest-cov/issues/129

And in particular this example where one user showed how he got it to work:
https://github.com/rouge8/xdist-cov/pull/1

Regardless, the build is now way, way faster and code coverage calculation is accurate ;-)
