### PR TITLE
Removed pause command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,8 @@ example/exampleSession.txt:
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  help     orate  pyscript  save  shell      speak
-cmdenvironment  history  pause  quit      say   shortcuts
-edit            load     py     run       set   show
+_relative_load  edit  history  orate  pyscript  run   say  shell      show
+cmdenvironment  help  load     py     quit      save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/cmd2.py
+++ b/cmd2.py
@@ -1128,13 +1128,6 @@ class Cmd(cmd.Cmd):
         except (ValueError, AttributeError):
             self.do_show(arg)
 
-    # noinspection PyMethodMayBeStatic
-    def do_pause(self, text):
-        """Displays the specified text then waits for the user to press <Enter>.
-
-    Usage:  pause [text]"""
-        sm.input(text + '\n')
-
     def do_shell(self, command):
         """Execute a command as if at the OS prompt.
 
@@ -2276,7 +2269,37 @@ class CmdResult(namedtuple_with_two_defaults('CmdResult', ['out', 'err', 'war'])
 
 if __name__ == '__main__':
     # If run as the main application, simply start a bare-bones cmd2 application with only built-in functionality.
-    # But enable the ipy command if IPython is installed, which supports advanced interactive debugging of your app,
-    # via introspection on self.
-    app = Cmd(use_ipython=True)
+
+    # Set this to True to include the ipy command if IPython is installed, which supports advanced interactive debugging
+    # of your application via introspection on self.
+    # include_ipy = False
+    #
+    # app = Cmd(use_ipython=include_ipy)
+    # app.cmdloop()
+
+
+    class HelpApp(Cmd):
+        """Class for testing custom help_* methods which override docstring help."""
+
+        def __init__(self, *args, **kwargs):
+            # Need to use this older form of invoking super class constructor to support Python 2.x and Python 3.x
+            Cmd.__init__(self, *args, **kwargs)
+
+        def do_squat(self, arg):
+            """This docstring help will never be shown because the help_squat method overrides it."""
+            pass
+
+        def help_squat(self):
+            self.stdout.write('This command does diddly squat...\n')
+
+        def do_edit(self, arg):
+            """This overrides the edit command and does nothing."""
+            pass
+
+        # This command will be in the "undocumented" section of the help menu
+        def do_undoc(self, arg):
+            pass
+
+
+    app = HelpApp()
     app.cmdloop()

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -286,8 +286,6 @@ with automatically included ``do_`` methods.
 
 .. automethod:: cmd2.Cmd.do_quit
 
-.. automethod:: cmd2.Cmd.do_pause
-
 .. automethod:: cmd2.Cmd.do_shell
 
 ( ``!`` is a shortcut for ``shell``; thus ``!ls``

--- a/examples/exampleSession.txt
+++ b/examples/exampleSession.txt
@@ -3,9 +3,8 @@
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  help     orate  pyscript  save  shell      speak
-cmdenvironment  history  pause  quit      say   shortcuts
-edit            load     py     run       set   show
+_relative_load  edit  history  orate  pyscript  run   say  shell      show
+cmdenvironment  help  load     py     quit      save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ import cmd2
 # Help text for base cmd2.Cmd application
 BASE_HELP = """Documented commands (type help <topic>):
 ========================================
-_relative_load  edit  history  pause  pyscript  run   set    shortcuts
-cmdenvironment  help  load     py     quit      save  shell  show
+_relative_load  edit  history  py        quit  save  shell      show
+cmdenvironment  help  load     pyscript  run   set   shortcuts
 """
 
 # Help text for the history command

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -182,14 +182,6 @@ def test_base_error(base_app):
     assert out == ["*** Unknown syntax: meow"]
 
 
-def test_base_pause(base_app):
-    # Mock out the input call so we don't actually wait for a user's response on stdin
-    m = mock.MagicMock(name='input', return_value='\n')
-    sm.input = m
-
-    run_cmd(base_app, 'pause')
-    m.assert_called_once()
-
 def test_base_history(base_app):
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
@@ -556,9 +548,9 @@ def test_pipe_to_shell(base_app):
         # Windows
         # Get help menu and pipe it's output to the sort shell command
         out = run_cmd(base_app, 'help | sort')
-        expected = ['', '', '_relative_load  edit  history  pause  pyscript  run   set    shortcuts',
+        expected = ['', '', '_relative_load  edit  history  py        quit  save  shell      show',
                     '========================================',
-                    'cmdenvironment  help  load     py     quit      save  shell  show',
+                    'cmdenvironment  help  load     pyscript  run   set   shortcuts',
                     'Documented commands (type help <topic>):']
         assert out == expected
     else:
@@ -870,8 +862,8 @@ class HelpApp(cmd2.Cmd):
     def help_squat(self):
         self.stdout.write('This command does diddly squat...\n')
 
-    def do_pause(self, arg):
-        """This overrides the pause command and does nothing."""
+    def do_edit(self, arg):
+        """This overrides the edit command and does nothing."""
         pass
 
     # This command will be in the "undocumented" section of the help menu
@@ -894,8 +886,8 @@ def test_custom_help_menu(help_app):
     expected = normalize("""
 Documented commands (type help <topic>):
 ========================================
-_relative_load  edit  history  pause  pyscript  run   set    shortcuts  squat
-cmdenvironment  help  load     py     quit      save  shell  show
+_relative_load  edit  history  py        quit  save  shell      show
+cmdenvironment  help  load     pyscript  run   set   shortcuts  squat
 
 Undocumented commands:
 ======================
@@ -909,8 +901,8 @@ def test_help_undocumented(help_app):
     assert out == expected
 
 def test_help_overridden_method(help_app):
-    out = run_cmd(help_app, 'help pause')
-    expected = normalize('This overrides the pause command and does nothing.')
+    out = run_cmd(help_app, 'help edit')
+    expected = normalize('This overrides the edit command and does nothing.')
     assert out == expected
 
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -106,9 +106,8 @@ def test_base_with_transcript(_cmdline_app):
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  help     orate  pyscript  save  shell      speak
-cmdenvironment  history  pause  quit      say   shortcuts
-edit            load     py     run       set   show
+_relative_load  edit  history  orate  pyscript  run   say  shell      show
+cmdenvironment  help  load     py     quit      save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.

--- a/tests/transcript.txt
+++ b/tests/transcript.txt
@@ -2,9 +2,8 @@
 
 Documented commands (type help <topic>):
 ========================================
-_relative_load  help     orate  pyscript  save  shell      speak
-cmdenvironment  history  pause  quit      say   shortcuts
-edit            load     py     run       set   show
+_relative_load  edit  history  orate  pyscript  run   say  shell      show
+cmdenvironment  help  load     py     quit      save  set  shortcuts  speak
 
 (Cmd) help say
 Repeats what you tell me to.


### PR DESCRIPTION
It was pretty useless, it just printed a message and sat there and waited for the user to hit enter.

It didn't feel like it belonged built in within a top-level framework.  

If a particular application wants this functionality, it is a 2 line change for them to add it back.