### PR TITLE
Fixed a few bugs and examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ News
 
 *Release date: TBD*
 
+* Bug Fixes
+    * `case_insensitive` is no longer a runtime-settable parameter, but it was still listed as such
+    * Fixed a recursive loop bug when abbreviated commands are enabled and it could get stuck in the editor forever
+        * Added additional command abbreviations to the "exclude from history" list
+    * Fixed argparse_example.py and pirate.py examples and transcript_regex.txt transcript
+* Enhancements
+- Organized all attributes used to configure the ParserManager into a single location
+- Set the default value of `abbrev` to `False` (which controls whether or not abbreviated commands are allowed)
+    - With good tab-completion of command names, using abbreviated commands isn't a particularly useful feature
+    - And it can create problems
+
 
 0.7.4
 -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -400,32 +400,29 @@ class Cmd(cmd.Cmd):
 
     Line-oriented command interpreters are often useful for test harnesses, internal tools, and rapid prototypes.
     """
-    # Attributes which are NOT dynamically settable at runtime
-    allow_cli_args = True       # Should arguments passed on the command-line be processed as commands?
-    allow_redirection = True    # Should output redirection and pipes be allowed
+    # Attributes used to configure the ParserManager (all are not dynamically settable at runtime)
     blankLinesAllowed = False
-    commentGrammars = pyparsing.Or(
-         [pyparsing.pythonStyleComment, pyparsing.cStyleComment]
-         )
+    case_insensitive = True  # Commands recognized regardless of case
+    commentGrammars = pyparsing.Or([pyparsing.pythonStyleComment, pyparsing.cStyleComment])
     commentInProgress = pyparsing.Literal('/*') + pyparsing.SkipTo(pyparsing.stringEnd ^ '*/')
-
-    default_to_shell = False    # Attempt to run unrecognized commands as shell commands
-    excludeFromHistory = '''run r list l history hi ed edit li eof'''.split()
-    exclude_from_help = ['do_eof']  # Commands to exclude from the help menu
-
-    # make sure your terminators are not in legalChars!
     legalChars = u'!#$%.:?@_-' + pyparsing.alphanums + pyparsing.alphas8bit
     multilineCommands = []  # NOTE: Multiline commands can never be abbreviated, even if abbrev is True
     prefixParser = pyparsing.Empty()
-    redirector = '>'            # for sending output to file
-    reserved_words = []
+    redirector = '>'        # for sending output to file
     shortcuts = {'?': 'help', '!': 'shell', '@': 'load', '@@': '_relative_load'}
-    terminators = [';']
+    terminators = [';']     # make sure your terminators are not in legalChars!
+
+    # Attributes which are NOT dynamically settable at runtime
+    allow_cli_args = True       # Should arguments passed on the command-line be processed as commands?
+    allow_redirection = True    # Should output redirection and pipes be allowed
+    default_to_shell = False    # Attempt to run unrecognized commands as shell commands
+    excludeFromHistory = '''run ru r history histor histo hist his hi h edit edi ed e eof eo'''.split()
+    exclude_from_help = ['do_eof']  # Commands to exclude from the help menu
+    reserved_words = []
 
     # Attributes which ARE dynamically settable at runtime
-    abbrev = True  # Abbreviated commands recognized
+    abbrev = False  # Abbreviated commands recognized
     autorun_on_edit = False  # Should files automatically run after editing (doesn't apply to commands)
-    case_insensitive = True  # Commands recognized regardless of case
     colors = (platform.system() != 'Windows')
     continuation_prompt = '> '
     debug = False
@@ -448,7 +445,6 @@ class Cmd(cmd.Cmd):
     # This starts out as a dictionary but gets converted to an OrderedDict sorted alphabetically by key
     settable = {'abbrev': 'Accept abbreviated commands',
                 'autorun_on_edit': 'Automatically run files after editing',
-                'case_insensitive': 'Upper- and lower-case both OK',
                 'colors': 'Colorized output (*nix only)',
                 'continuation_prompt': 'On 2nd+ line of input',
                 'debug': 'Show full error stack on error',

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -265,13 +265,13 @@ Abbreviated commands
 ====================
 
 ``cmd2`` apps will accept shortened command names
-so long as there is no ambiguity.  Thus, if
-``do_divide`` is defined, then ``divid``, ``div``,
+so long as there is no ambiguity if the ``abrev`` settable parameter is set to ``True``.
+Thus, if ``do_divide`` is defined, then ``divid``, ``div``,
 or even ``d`` will suffice, so long as there are
 no other commands defined beginning with *divid*,
 *div*, or *d*.
 
-This behavior can be turned off with ``app.abbrev`` (see :ref:`parameters`)
+This behavior is disabled by default, but can be turned on with ``app.abbrev`` (see :ref:`parameters`)
 
 .. warning::
 

--- a/docs/settingchanges.rst
+++ b/docs/settingchanges.rst
@@ -105,7 +105,6 @@ with::
     (Cmd) set --long
     abbrev: True                   # Accept abbreviated commands
     autorun_on_edit: False         # Automatically run files after editing
-    case_insensitive: True         # upper- and lower-case both OK
     colors: True                   # Colorized output (*nix only)
     continuation_prompt: >         # On 2nd+ line of input
     debug: False                   # Show full error stack on error

--- a/docs/settingchanges.rst
+++ b/docs/settingchanges.rst
@@ -103,7 +103,7 @@ comments, is viewable from within a running application
 with::
 
     (Cmd) set --long
-    abbrev: True                   # Accept abbreviated commands
+    abbrev: False                  # Accept abbreviated commands
     autorun_on_edit: False         # Automatically run files after editing
     colors: True                   # Colorized output (*nix only)
     continuation_prompt: >         # On 2nd+ line of input
@@ -118,5 +118,5 @@ with::
 
 Any of these user-settable parameters can be set while running your app with the ``set`` command like so::
 
-    set abbrev False
+    set abbrev True
 

--- a/examples/argparse_example.py
+++ b/examples/argparse_example.py
@@ -3,10 +3,10 @@
 """A sample application for cmd2 showing how to use Argparse to process command line arguments for your application.
 It doubles as an example of how you can still do transcript testing even if allow_cli_args is false.
 
-Thanks to cmd2's built-in transcript testing capability, it also serves as a test suite for argparse_example.py when 
+Thanks to cmd2's built-in transcript testing capability, it also serves as a test suite for argparse_example.py when
 used with the exampleSession.txt transcript.
 
-Running `python argparse_example.py -t exampleSession.txt` will run all the commands in the transcript against 
+Running `python argparse_example.py -t exampleSession.txt` will run all the commands in the transcript against
 argparse_example.py, verifying that the output produced matches the transcript.
 """
 import argparse
@@ -16,15 +16,14 @@ from cmd2 import Cmd, make_option, options
 
 class CmdLineApp(Cmd):
     """ Example cmd2 application. """
-    multilineCommands = ['orate']
-    Cmd.shortcuts.update({'&': 'speak'})
-    maxrepeats = 3
-    Cmd.settable.append('maxrepeats')
-
-    # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
-    # default_to_shell = True
-
     def __init__(self, ip_addr=None, port=None, transcript_files=None):
+        self.multilineCommands = ['orate']
+        self.shortcuts.update({'&': 'speak'})
+        self.maxrepeats = 3
+
+        # Add stuff to settable and/or shortcuts before calling base class initializer
+        self.settable['maxrepeats'] = 'Max number of `--repeat`s allowed'
+
         # Set use_ipython to True to enable the "ipy" command which embeds and interactive IPython shell
         Cmd.__init__(self, use_ipython=False, transcript_files=transcript_files)
 
@@ -34,6 +33,9 @@ class CmdLineApp(Cmd):
         # Example of args set from the command-line (but they aren't being used here)
         self._ip = ip_addr
         self._port = port
+
+        # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
+        # self.default_to_shell = True
 
     @options([make_option('-p', '--piglatin', action="store_true", help="atinLay"),
               make_option('-s', '--shout', action="store_true", help="N00B EMULATION MODE"),

--- a/examples/example.py
+++ b/examples/example.py
@@ -19,6 +19,7 @@ class CmdLineApp(Cmd):
     # default_to_shell = True
 
     def __init__(self):
+        self.abbrev = True
         self.multilineCommands = ['orate']
         self.maxrepeats = 3
 

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -11,14 +11,16 @@ from cmd2 import Cmd, options, make_option
 
 class Pirate(Cmd):
     """A piratical example cmd2 application involving looting and drinking."""
-    default_to_shell = True
-    multilineCommands = ['sing']
-    terminators = Cmd.terminators + ['...']
-    songcolor = 'blue'
-    settable = Cmd.settable + 'songcolor Color to ``sing`` in (red/blue/green/cyan/magenta, bold, underline)'
-    Cmd.shortcuts.update({'~': 'sing'})
-
     def __init__(self):
+        self.default_to_shell = True
+        self.multilineCommands = ['sing']
+        self.terminators = Cmd.terminators + ['...']
+        self.songcolor = 'blue'
+
+        # Add stuff to settable and/or shortcuts before calling base class initializer
+        self.settable['songcolor'] = 'Color to ``sing`` in (red/blue/green/cyan/magenta, bold, underline)'
+        self.shortcuts.update({'~': 'sing'})
+
         """Initialize the base class as well as this one"""
         Cmd.__init__(self)
         # prompts and defaults

--- a/examples/transcript_regex.txt
+++ b/examples/transcript_regex.txt
@@ -3,13 +3,12 @@
 (Cmd) set
 abbrev: True
 autorun_on_edit: False
-case_insensitive: True
 colors: /(True|False)/
 continuation_prompt: >
 debug: False
 echo: False
 editor: /([^\s]+)/
-feedback_to_output: False
+feedback_to_output: True
 locals_in_py: True
 maxrepeats: 3
 prompt: (Cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,9 +47,8 @@ expect_colors = True
 if sys.platform.startswith('win'):
     expect_colors = False
 # Output from the show command with default settings
-SHOW_TXT = """abbrev: True
+SHOW_TXT = """abbrev: False
 autorun_on_edit: False
-case_insensitive: True
 colors: {}
 continuation_prompt: >
 debug: False
@@ -67,9 +66,8 @@ if expect_colors:
 else:
     color_str = 'False'
 SHOW_LONG = """
-abbrev: True             # Accept abbreviated commands
+abbrev: False            # Accept abbreviated commands
 autorun_on_edit: False   # Automatically run files after editing
-case_insensitive: True   # Upper- and lower-case both OK
 colors: {}            # Colorized output (*nix only)
 continuation_prompt: >   # On 2nd+ line of input
 debug: False             # Show full error stack on error

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -99,7 +99,7 @@ To enable full traceback, run the following command:  'set debug true'
 """)
     assert normalize(str(err)) == expected
 
-def test_set_abbreviated(base_app):
+def test_set_quiet(base_app):
     out = run_cmd(base_app, 'set quie True')
     expected = normalize("""
 quiet - was: False
@@ -649,7 +649,7 @@ def test_edit_no_editor(base_app, capsys):
     base_app.editor = None
 
     # Make sure we get an exception, but cmd2 handles it
-    run_cmd(base_app, 'ed')
+    run_cmd(base_app, 'edit')
     out, err = capsys.readouterr()
 
     expected = _expected_no_editor_error()

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -21,6 +21,7 @@ from conftest import run_cmd, StdOut, normalize
 
 class CmdLineApp(Cmd):
     def __init__(self, *args, **kwargs):
+        self.abbrev = True
         self.multilineCommands = ['orate']
         self.maxrepeats = 3
         self.redirector = '->'

--- a/tests/transcript_regex.txt
+++ b/tests/transcript_regex.txt
@@ -3,7 +3,6 @@
 (Cmd) set
 abbrev: True
 autorun_on_edit: False
-case_insensitive: True
 colors: /(True|False)/
 continuation_prompt: >
 debug: False


### PR DESCRIPTION
Bug fixes:
- case_insensitive is no longer a runtime-settable parameter, but it was still listed as such
- Fixed a recursive loop bug when abbreviated commands are enabled and it could get stuck in the editor forever
    - Added additional command abbreviations to the "exclude from history" list
- Fixed argparse_example.py and pirate.py examples

Other changes:
- Organized all attributes used to configure the ParserManager into a single location
- Set the default value of "abbrev" to False (which controls whether or not abbreviated commands are allowed)
    - With good tab-completion of command names, using abbreviated commands isn't a particularly useful feature
    - And it can create problems