### PR TITLE
Avoid conflict the `eg` tool from go-tools

### DIFF
--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -87,7 +87,7 @@ def test_shell_command_completion(cmd2_app):
         line = 'shell {}'.format(text)
         expected = ['calc.exe ']
     else:
-        text = 'eg'
+        text = 'egr'
         line = '!{}'.format(text)
         expected = ['egrep ']
 


### PR DESCRIPTION
With go-tools installed there is an `eg` command in system search path.
Let's add an additional character to avoid the test failure.