### PR TITLE
Fix a couple clipboard related bugs on Linux

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -319,7 +319,8 @@ def get_paste_buffer():
     """
     pb_str = pyperclip.paste()
 
-    if six.PY2:
+    # If value returned from the clipboard is unicode and this is Python 2, convert to a "normal" Python 2 string first
+    if six.PY2 and not isinstance(pb_str, str):
         import unicodedata
         pb_str = unicodedata.normalize('NFKD', pb_str).encode('ascii', 'ignore')
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -300,7 +300,12 @@ def options(option_list, arg_desc="arg"):
 
 # Can we access the clipboard?  Should always be true on Windows and Mac, but only sometimes on Linux
 try:
-    _ = pyperclip.paste()
+    if six.PY3 and sys.platform.startswith('linux'):
+        # Avoid extraneous output to stderr from xclip when clipboard is empty at cost of overwriting clipboard contents
+        pyperclip.copy('')
+    else:
+        # Try getting the contents of the clipboard
+        _ = pyperclip.paste()
 except pyperclip.exceptions.PyperclipException:
     can_clip = False
 else:


### PR DESCRIPTION
Fixed a couple bugs related to using pyperclip to interact with the clipboard on Linux.

Bugs fixed:
- Empty clipboard bug when using Python 3 and pyperclip with xclip when pasting at startup
- Unicode bug when using Python 2 and pyperclip with gtk

This closes #186 