### PR TITLE
Pipe improvement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ rerNews
     * Enhanced tab-completion of cmd2 command names to support case-insensitive completion
     * Added an example showing how to remove unused commands
     * Improved how transcript testing handles prompts with ANSI escape codes by stripping them
+    * Greatly improved implementation for how command output gets piped to a shell command
 
 0.7.5
 -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -776,11 +776,18 @@ class Cmd(cmd.Cmd):
             # Create a pipe with read and write sides
             read_fd, write_fd = os.pipe()
 
+            # Make sure that self.stdout.write() expects unicode strings in Python 3 and byte strings in Python 2
+            write_mode = 'w'
+            read_mode = 'r'
+            if six.PY2:
+                write_mode = 'wb'
+                read_mode = 'rb'
+
             # Open each side of the pipe and set stdout accordingly
             # noinspection PyTypeChecker
-            self.stdout = io.open(write_fd, 'w')
+            self.stdout = io.open(write_fd, write_mode)
             # noinspection PyTypeChecker
-            subproc_stdin = io.open(read_fd, 'r')
+            subproc_stdin = io.open(read_fd, read_mode)
 
             # If you don't set shell=True, subprocess failure will throw an exception
             try:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -124,3 +124,10 @@ If you wish to permanently uninstall ``cmd2``, this can also easily be done with
 
     pip uninstall cmd2
 
+Extra requirement for Python 2.7 only
+-------------------------------------
+If you want to be able to pipe the output of commands to a shell command on Python 2.7, then you will need one
+additional package installed:
+
+  * subprocess32
+

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -589,7 +589,10 @@ def test_pipe_to_shell_error(base_app, capsys):
 
     expected_error = 'FileNotFoundError'
     if six.PY2:
-        expected_error = 'OSError'
+        if sys.platform.startswith('win'):
+            expected_error = 'WindowsError'
+        else:
+            expected_error = 'OSError'
     assert err.startswith("EXCEPTION of type '{}' occurred with message:".format(expected_error))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
   pytest-cov
   pytest-xdist
   six
+  subprocess32
 commands =
   py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
   codecov


### PR DESCRIPTION
The previous implementation for piping command output to a shell command utilized a temporary file and only once the command was completely done did it "pipe" the command output to the shell command by using the temporary file as the commands input.  This approach had many disadvantages, including:

- No output would be seen from long running commands until the very end
- Many shell commands behave entirely differently when piped to versus have input redirected to them from a file (for example, **less** and **more** didn't work with this previous approach)

Now a real pipe is created to a subprocess.  This approach should "just work like intended" with all commands and has many advantages, including:

- Output from long running commands will be seen immediately
- Behavior in your cmd2 application should behave just like it would in a normal shell such as Bash

One downside is to work properly on Python 2.7, it requires the subprocess32 module which is the subprocess module from Python 3.2 backported to Python 2.7.  Another downside, is that unit testing the feature is now more difficult.

A more subtle downside is that users now need to be careful when designing multi-threaded cmd2 applications that do command processing in other threads where those threads can make calls to self.stdout.write.  If the end user does something to manually close the piped shell command before the cmd2 command is finished executing, then a BrokenPipe exception can occur.  This is easily fixed by putting a try/except to catch Broken Pipe errors in one strategic location in your code.  You just need to be aware of this.

This closes #197 