### PR TITLE
Made a few code ruggedizations

### DIFF
--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -856,7 +856,7 @@ def test_default_to_shell_good(capsys):
     app.default_to_shell = True
     line = 'ls'
     statement = app.parser_manager.parsed(line)
-    retval = app._default(statement)
+    retval = app.default(statement)
     assert not retval
     out, err = capsys.readouterr()
     assert out == ''
@@ -866,7 +866,7 @@ def test_default_to_shell_failure(capsys):
     app.default_to_shell = True
     line = 'ls does_not_exist.xyz'
     statement = app.parser_manager.parsed(line)
-    retval = app._default(statement)
+    retval = app.default(statement)
     assert not retval
     out, err = capsys.readouterr()
     assert out == "*** Unknown syntax: {}\n".format(line)


### PR DESCRIPTION
- poutput() can now take any argument convertible to a str via '{}'.format() instead of only str
- postparsing_postcmd() automatically runs a 'stty sane' on POSIX OSes to handle those cases of your terminal getting in a messed up state if you do something like pipe to a terminal command like "less" and then improperly quit out of it with a Ctrl-C instead of properly using "q"
- In _restore_output(), immeditelly restore stdout state in a finally block after closing the temporary one used for redirection/piping