### PR TITLE
Fix for extra output at startup when using Python 2.7 on Linux

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -308,7 +308,7 @@ def options(option_list, arg_desc="arg"):
 # Can we access the clipboard?  Should always be true on Windows and Mac, but only sometimes on Linux
 # noinspection PyUnresolvedReferences
 try:
-    if six.PY3 and sys.platform.startswith('linux'):
+    if sys.platform.startswith('linux'):
         # Avoid extraneous output to stderr from xclip when clipboard is empty at cost of overwriting clipboard contents
         pyperclip.copy('')
     else:


### PR DESCRIPTION
Fix a bug where an extra line of output was printing at startup when using Python 2.7 on Linux where Pyperclip was using xclip under the hood and the clipboard was empty.

The fix involves using a different way of testing to make sure pyperclip's cut/paste functionality is working.  So on Linux, cmd2 applications will now copy and empty string to the clipboard at startup just to make sure they can.

Hopefully this won't inconvenience users.  It seems better than printing a line at application startup which won't make any sense to end users.