### PR TITLE
Added workaround for bug in Python 2 on Linux when pygtk is installed

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -46,9 +46,11 @@ from optparse import make_option
 import pyparsing
 import pyperclip
 
-# Workaround for gtk interfering when printing from background thread while main
-# thread is blocking in raw_input() in Python 2 on Linux when gtk is installed
+# On some systems, pyperclip will import gtk for its clipboard functionality.
+# The following code is a workaround for gtk interfering with printing from a background
+# thread while the CLI thread is blocking in raw_input() in Python 2 on Linux.
 try:
+    # noinspection PyUnresolvedReferences
     import gtk
     gtk.set_interactive(0)
 except ImportError:

--- a/cmd2.py
+++ b/cmd2.py
@@ -46,6 +46,14 @@ from optparse import make_option
 import pyparsing
 import pyperclip
 
+# Workaround for gtk interfering when printing from background thread while main
+# thread is blocking in raw_input() in Python 2 on Linux when gtk is installed
+try:
+    import gtk
+    gtk.set_interactive(0)
+except ImportError:
+    pass
+
 # next(it) gets next item of iterator it. This is a replacement for calling it.next() in Python 2 and next(it) in Py3
 from six import next
 


### PR DESCRIPTION
This bug is exposed by cmd2's dependency on pyperclip and pyperclip's optional dependency on pygtk.

This bug will prevent all output to stdout from background threads in an application which imports pyperclip and calls raw_input() to get input from stdin.

This closes #205 