### PR TITLE
.pfeedback() now honors feedback_to_output setting

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -627,7 +627,7 @@ class Cmd(cmd.Cmd):
             if self.feedback_to_output:
                 self.poutput(msg)
             else:
-                print(msg)
+                sys.stderr.write("{}\n".format(msg))
 
     def colorize(self, val, color):
         """Given a string (``val``), returns that string wrapped in UNIX-style

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -506,6 +506,7 @@ def test_save_invalid_path(base_app, capsys):
 
 def test_output_redirection(base_app):
     fd, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
+    os.close(fd)
     
     try:
         # Verify that writing to a file works
@@ -530,7 +531,8 @@ def test_output_redirection(base_app):
 def test_feedback_to_output_true(base_app):
     base_app.feedback_to_output = True
     base_app.timing = True
-    fd, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
+    f, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
+    os.close(f)
     
     try:
         run_cmd(base_app, 'help > {}'.format(filename))
@@ -546,7 +548,8 @@ def test_feedback_to_output_true(base_app):
 def test_feedback_to_output_false(base_app, capsys):
     base_app.feedback_to_output = False
     base_app.timing = True
-    fd, filename = tempfile.mkstemp(prefix='feedback_to_output', suffix='.txt')
+    f, filename = tempfile.mkstemp(prefix='feedback_to_output', suffix='.txt')
+    os.close(f)
     
     try:
         run_cmd(base_app, 'help > {}'.format(filename))


### PR DESCRIPTION
If feedback_to_output is false, .pfeedback() now sends messages to stderr instead of stdout.

Reluctantly had to modify an another existing test, test_cmd2.py::test_allow_redirection, as a result of this change.

Also fixes a TODO in test_cmd2.py::test_output_redirection to use tempfile.mkstemp to create a temporary file instead of using a hardcoded filename.

Tests pass on macOS running python3.6.

This closes #209 
