### PR TITLE
Ensure editor and the file to edit can have spaces in them

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1633,7 +1633,7 @@ Edited files are run on close if the ``autorun_on_edit`` settable parameter is T
             f.write(history_item or '')
             f.close()
 
-        os.system('%s %s' % (self.editor, filename))
+        os.system('"{}" "{}"'.format(self.editor, filename))
 
         if self.autorun_on_edit or history_item:
             self.do_load(filename)

--- a/examples/transcript_regex.txt
+++ b/examples/transcript_regex.txt
@@ -1,5 +1,6 @@
 # Run this transcript with "python example.py -t transcript_regex.txt"
-# The regex for editor matches any word until first space.  The one for colors is because no color on Windows.
+# The regex for colors is because no color on Windows.
+# The regex for editor will match whatever program you use. 
 (Cmd) set
 abbrev: True
 autorun_on_edit: False
@@ -7,7 +8,7 @@ colors: /(True|False)/
 continuation_prompt: >
 debug: False
 echo: False
-editor: /([^\s]+)/
+editor: /.*/
 feedback_to_output: True
 locals_in_py: True
 maxrepeats: 3

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -736,7 +736,23 @@ def test_edit_file(base_app, request, monkeypatch):
     run_cmd(base_app, 'edit {}'.format(filename))
 
     # We think we have an editor, so should expect a system call
-    m.assert_called_once_with('{} {}'.format(base_app.editor, filename))
+    m.assert_called_once_with('"{}" "{}"'.format(base_app.editor, filename))
+
+def test_edit_file_with_spaces(base_app, request, monkeypatch):
+    # Set a fake editor just to make sure we have one.  We aren't really going to call it due to the mock
+    base_app.editor = 'fooedit'
+
+    # Mock out the os.system call so we don't actually open an editor
+    m = mock.MagicMock(name='system')
+    monkeypatch.setattr("os.system", m)
+
+    test_dir = os.path.dirname(request.module.__file__)
+    filename = os.path.join(test_dir, 'my commands.txt')
+
+    run_cmd(base_app, 'edit {}'.format(filename))
+
+    # We think we have an editor, so should expect a system call
+    m.assert_called_once_with('"{}" "{}"'.format(base_app.editor, filename))
 
 def test_edit_number(base_app, monkeypatch):
     # Set a fake editor just to make sure we have one.  We aren't really going to call it due to the mock

--- a/tests/transcript_regex.txt
+++ b/tests/transcript_regex.txt
@@ -1,5 +1,6 @@
 # Run this transcript with "python example.py -t transcript_regex.txt"
-# The regex for editor matches any word until first space.  The one for colors is because no color on Windows.
+# The regex for colors is because no color on Windows.
+# The regex for editor will match whatever program you use.
 (Cmd) set
 abbrev: True
 autorun_on_edit: False
@@ -7,7 +8,7 @@ colors: /(True|False)/
 continuation_prompt: >
 debug: False
 echo: False
-editor: /([^\s]+)/
+editor: /.*/
 feedback_to_output: True
 locals_in_py: True
 maxrepeats: 3


### PR DESCRIPTION
The unit tests monkey patch the **os.system** call so its hard to verify this actually works.

I tested manually on macOS with python3.6 and spaces in both **editor** and the filename supplied to the **edit** command. Both work fine.