### PR TITLE
feedback_to_output now defaults to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Bug Fixes
     * Added workaround for bug which occurs in Python 2.7 on Linux when ``pygtk`` is installed
+    * ``pfeedback()`` now honors feedback_to_output setting and won't redirect when it is ``False``
+    * For ``edit`` command, both **editor** and **filename** can now have spaces in the name/path
+* Enhancements
+    * ``feedback_to_output`` now defaults to ``False`` so info like command timing won't redirect
     
 ## 0.7.6 (August 11, 2017)
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -470,7 +470,7 @@ class Cmd(cmd.Cmd):
             for editor in ['vim', 'vi', 'emacs', 'nano', 'pico', 'gedit', 'kate', 'subl', 'geany', 'atom']:
                 if _which(editor):
                     break
-    feedback_to_output = True  # Do include nonessentials in >, | output
+    feedback_to_output = False  # Do not include nonessentials in >, | output by default (things like timing)
     locals_in_py = True
     quiet = False  # Do not suppress nonessential output
     timing = False  # Prints elapsed time for each command

--- a/examples/transcript_regex.txt
+++ b/examples/transcript_regex.txt
@@ -1,6 +1,6 @@
 # Run this transcript with "python example.py -t transcript_regex.txt"
 # The regex for colors is because no color on Windows.
-# The regex for editor will match whatever program you use. 
+# The regex for editor will match whatever program you use.
 (Cmd) set
 abbrev: True
 autorun_on_edit: False
@@ -9,7 +9,7 @@ continuation_prompt: >
 debug: False
 echo: False
 editor: /.*/
-feedback_to_output: True
+feedback_to_output: False
 locals_in_py: True
 maxrepeats: 3
 prompt: (Cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ continuation_prompt: >
 debug: False
 echo: False
 editor: vim
-feedback_to_output: True
+feedback_to_output: False
 locals_in_py: True
 prompt: (Cmd)
 quiet: False
@@ -66,18 +66,18 @@ if expect_colors:
 else:
     color_str = 'False'
 SHOW_LONG = """
-abbrev: False            # Accept abbreviated commands
-autorun_on_edit: False   # Automatically run files after editing
-colors: {}            # Colorized output (*nix only)
-continuation_prompt: >   # On 2nd+ line of input
-debug: False             # Show full error stack on error
-echo: False              # Echo command issued into output
-editor: vim              # Program used by ``edit``
-feedback_to_output: True # Include nonessentials in `|`, `>` results
-locals_in_py: True       # Allow access to your application in py via self
-prompt: (Cmd)            # The prompt issued to solicit input
-quiet: False             # Don't print nonessential feedback
-timing: False            # Report execution times
+abbrev: False             # Accept abbreviated commands
+autorun_on_edit: False    # Automatically run files after editing
+colors: {}             # Colorized output (*nix only)
+continuation_prompt: >    # On 2nd+ line of input
+debug: False              # Show full error stack on error
+echo: False               # Echo command issued into output
+editor: vim               # Program used by ``edit``
+feedback_to_output: False # Include nonessentials in `|`, `>` results
+locals_in_py: True        # Allow access to your application in py via self
+prompt: (Cmd)             # The prompt issued to solicit input
+quiet: False              # Don't print nonessential feedback
+timing: False             # Report execution times
 """.format(color_str)
 
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -427,6 +427,7 @@ def test_relative_load_requires_an_argument(base_app, capsys):
 def test_base_save(base_app):
     # TODO: Use a temporary directory for the file
     filename = 'deleteme.txt'
+    base_app.feedback_to_output = True
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'help save')
 
@@ -472,6 +473,7 @@ def test_save_parse_error(base_app, capsys):
 
 def test_save_tempfile(base_app):
     # Just run help to make sure there is something in the history
+    base_app.feedback_to_output = True
     run_cmd(base_app, 'help')
     out = run_cmd(base_app, 'save *')
     output = out[0]
@@ -507,7 +509,7 @@ def test_save_invalid_path(base_app, capsys):
 def test_output_redirection(base_app):
     fd, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
     os.close(fd)
-    
+
     try:
         # Verify that writing to a file works
         run_cmd(base_app, 'help > {}'.format(filename))
@@ -533,7 +535,7 @@ def test_feedback_to_output_true(base_app):
     base_app.timing = True
     f, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
     os.close(f)
-    
+
     try:
         run_cmd(base_app, 'help > {}'.format(filename))
         with open(filename) as f:
@@ -550,7 +552,7 @@ def test_feedback_to_output_false(base_app, capsys):
     base_app.timing = True
     f, filename = tempfile.mkstemp(prefix='feedback_to_output', suffix='.txt')
     os.close(f)
-    
+
     try:
         run_cmd(base_app, 'help > {}'.format(filename))
         out, err = capsys.readouterr()
@@ -1253,12 +1255,14 @@ def test_clipboard_failure(capsys):
 
 def test_run_command_with_empty_arg(base_app):
     command = 'help'
+    base_app.feedback_to_output = True
     run_cmd(base_app, command)
     out = run_cmd(base_app, 'run')
     expected = normalize('{}\n\n'.format(command) + BASE_HELP)
     assert out == expected
 
 def test_run_command_with_empty_history(base_app):
+    base_app.feedback_to_output = True
     out = run_cmd(base_app, 'run')
     assert out == []
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -150,7 +150,6 @@ set maxrepeats 5
 -------------------------[6]
 say -ps --repeat=5 goodnight, Gracie
 (Cmd) run 4
-say -ps --repeat=5 goodnight, Gracie
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY
 OODNIGHT, GRACIEGAY
@@ -237,6 +236,7 @@ def test_commands_at_invocation():
 def test_transcript_from_cmdloop(request, capsys):
     # Create a cmd2.Cmd() instance and make sure basic settings are like we want for test
     app = CmdLineApp()
+    app.feedback_to_output = True
 
     # Get location of the transcript
     test_dir = os.path.dirname(request.module.__file__)

--- a/tests/transcript_regex.txt
+++ b/tests/transcript_regex.txt
@@ -9,7 +9,7 @@ continuation_prompt: >
 debug: False
 echo: False
 editor: /.*/
-feedback_to_output: True
+feedback_to_output: False
 locals_in_py: True
 maxrepeats: 3
 prompt: (Cmd)


### PR DESCRIPTION
This is so that non-essential info which isn't directly associated with command output, such as time elapsed while executing a command, won't redirect when command output is redirected using >, >>, or |.