### PR TITLE
edit command now uses options decorator

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1589,13 +1589,11 @@ Paths or arguments that contain spaces must be enclosed in quotes
         except IndexError:
             return None
 
-    def do_edit(self, arg):
-        """Edit a file or command in a text editor.
-
-    Usage:  edit [N]|[file_path]
-
+    @options([], arg_desc="""[N]|[file_path]
     * N         - Number of command (from history), or `*` for all commands in history (default: last command)
-    * file_path - path to a file to open in editor
+    * file_path - path to a file to open in editor""")
+    def do_edit(self, arg, opts=None):
+        """Edit a file or command in a text editor.
 
 The editor used is determined by the ``editor`` settable parameter.
 "set editor (program-name)" to change or set the EDITOR environment variable.
@@ -1605,15 +1603,16 @@ If neither is supplied, the most recent command in the history is edited.
 
 Edited commands are always run after the editor is closed.
 
-Edited files are run on close if the ``autorun_on_edit`` settable parameter is True."""
+Edited files are run on close if the ``autorun_on_edit`` settable parameter is True.
+"""
         if not self.editor:
             raise EnvironmentError("Please use 'set editor' to specify your text editing program of choice.")
         filename = None
-        if arg:
+        if arg and arg[0]:
             try:
-                history_item = self._last_matching(int(arg))
+                history_item = self._last_matching(int(arg[0]))
             except ValueError:
-                filename = arg
+                filename = arg[0]
                 history_item = ''
         else:
             try:

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -751,7 +751,7 @@ def test_edit_file_with_spaces(base_app, request, monkeypatch):
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'my commands.txt')
 
-    run_cmd(base_app, 'edit {}'.format(filename))
+    run_cmd(base_app, 'edit {!r}'.format(filename))
 
     # We think we have an editor, so should expect a system call
     m.assert_called_once_with('"{}" "{}"'.format(base_app.editor, filename))

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -751,7 +751,7 @@ def test_edit_file_with_spaces(base_app, request, monkeypatch):
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'my commands.txt')
 
-    run_cmd(base_app, 'edit {!r}'.format(filename))
+    run_cmd(base_app, 'edit "{}"'.format(filename))
 
     # We think we have an editor, so should expect a system call
     m.assert_called_once_with('"{}" "{}"'.format(base_app.editor, filename))
@@ -911,7 +911,10 @@ def test_default_to_shell_unknown(shell_app):
 def test_default_to_shell_good(capsys):
     app = cmd2.Cmd()
     app.default_to_shell = True
-    line = 'ls'
+    if sys.platform.startswith('win'):
+        line = 'dir'
+    else:
+        line = 'ls'
     statement = app.parser_manager.parsed(line)
     retval = app.default(statement)
     assert not retval


### PR DESCRIPTION
Converted **edit** command to an **@options** command for the better argument parsing related to spaces and quotes

The recent change of edit to allow spaces means that it can benefit from the better argument parsing cmd2 has for commands implemented using the **@options** decorator.