### PR TITLE
Piped input now properly honors the echo setting

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -998,6 +998,8 @@ class Cmd(cmd.Cmd):
                 self.poutput(safe_prompt, end='')
                 self.stdout.flush()
                 line = self.stdin.readline()
+                if len(line) == 0:
+                    line = 'eof'
             else:
                 # we are reading from a pipe, read the line to see if there is
                 # anything there, if so, then decide whether to print the

--- a/cmd2.py
+++ b/cmd2.py
@@ -972,7 +972,7 @@ class Cmd(cmd.Cmd):
     def pseudo_raw_input(self, prompt):
         """
         began life as a copy of cmd's cmdloop; like raw_input but
-        
+
         - accounts for changed stdin, stdout
         - if input is a pipe (instead of a tty), look at self.echo
           to decide whether to print the prompt and the input
@@ -984,8 +984,7 @@ class Cmd(cmd.Cmd):
         if self.use_rawinput:
             try:
                 if sys.stdin.isatty():
-                    sys.stdout.write(safe_prompt)
-                    line = sm.input()
+                    line = sm.input(safe_prompt)
                 else:
                     line = sm.input()
                     if self.echo:

--- a/cmd2.py
+++ b/cmd2.py
@@ -717,8 +717,9 @@ class Cmd(cmd.Cmd):
         """
         if not sys.platform.startswith('win'):
             # Fix those annoying problems that occur with terminal programs like "less" when you pipe to them
-            proc = subprocess.Popen(shlex.split('stty sane'))
-            proc.communicate()
+            if self.stdin.isatty():
+                proc = subprocess.Popen(shlex.split('stty sane'))
+                proc.communicate()
         return stop
 
     def parseline(self, line):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1393,9 +1393,9 @@ def test_pseudo_raw_input_tty_rawinput_true():
     # use context managers so original functions get put back when we are done
     # we dont use decorators because we need m_input for the assertion
     with mock.patch('sys.stdin.isatty',
-                mock.MagicMock(name='isatty', return_value=True)):
+            mock.MagicMock(name='isatty', return_value=True)):
         with mock.patch('six.moves.input',
-                    mock.MagicMock(name='input', side_effect=['set', 'quit'])) as m_input:
+                mock.MagicMock(name='input', side_effect=['set', EOFError])) as m_input:
             # run the cmdloop, which should pull input from our mocks
             app = cmd2.Cmd()
             app.use_rawinput = True
@@ -1409,7 +1409,7 @@ def test_pseudo_raw_input_tty_rawinput_true():
     
 def test_pseudo_raw_input_tty_rawinput_false():
     # gin up some input like it's coming from a tty
-    fakein = io.StringIO(u'{}'.format('set\nquit\n'))
+    fakein = io.StringIO(u'{}'.format('set\n'))
     mtty = mock.MagicMock(name='isatty', return_value=True)
     fakein.isatty = mtty
     mreadline = mock.MagicMock(name='readline', wraps=fakein.readline)
@@ -1440,7 +1440,8 @@ def piped_rawinput_true(capsys, echo, command):
 
 # using the decorator puts the original function at six.moves.input
 # back when this method returns
-@mock.patch('six.moves.input', mock.MagicMock(name='input', side_effect=['set', 'quit']))
+@mock.patch('six.moves.input',
+        mock.MagicMock(name='input', side_effect=['set', EOFError]))
 def test_pseudo_raw_input_piped_rawinput_true_echo_true(capsys):
     command = 'set'
     app, out = piped_rawinput_true(capsys, True, command)
@@ -1450,7 +1451,8 @@ def test_pseudo_raw_input_piped_rawinput_true_echo_true(capsys):
 
 # using the decorator puts the original function at six.moves.input
 # back when this method returns
-@mock.patch('six.moves.input', mock.MagicMock(name='input', side_effect=['set', 'quit']))
+@mock.patch('six.moves.input',
+        mock.MagicMock(name='input', side_effect=['set', EOFError]))
 def test_pseudo_raw_input_piped_rawinput_true_echo_false(capsys):
     command = 'set'
     app, out = piped_rawinput_true(capsys, False, command)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -7,6 +7,7 @@ Released under MIT license, see LICENSE file
 """
 import os
 import sys
+import io
 import tempfile
 
 import mock
@@ -849,6 +850,7 @@ def test_cmdloop_without_rawinput():
     # Create a cmd2.Cmd() instance and make sure basic settings are like we want for test
     app = cmd2.Cmd()
     app.use_rawinput = False
+    app.echo = False
     app.intro = 'Hello World, this is an intro ...'
     app.stdout = StdOut()
 
@@ -858,7 +860,7 @@ def test_cmdloop_without_rawinput():
 
     # Need to patch sys.argv so cmd2 doesn't think it was called with arguments equal to the py.test args
     testargs = ["prog"]
-    expected = app.intro + '\n{}'.format(app.prompt)
+    expected = app.intro + '\n'
     with mock.patch.object(sys, 'argv', testargs):
         # Run the command loop
         app.cmdloop()
@@ -1388,7 +1390,54 @@ def test_echo(capsys):
     assert app._current_script_dir is None
     assert out.startswith('{}{}\n'.format(app.prompt, command) + 'history [arg]: lists past commands issued')
 
+#@pytest.mark.parametrize('rawinput', [True, False])
+def test_piped_input_echo_false(capsys):
+    command = 'set'
 
+    # hack up stdin
+    fakein = io.StringIO(command)
+    #realin = sys.stdin
+    #sys.stdin = fakein
+
+    # run the cmdloop, which should pull input from stdin
+    app = cmd2.Cmd(stdin=fakein)
+    app.use_rawinput = False
+    app.echo = False
+    app.abbrev = False
+    app._cmdloop()
+    out, err = capsys.readouterr()
+
+    # put stdin back
+    #sys.stdin = realin
+
+    firstline = out.splitlines()[0]
+    assert firstline == 'abbrev: False'
+    assert not '{}{}'.format(app.prompt, command) in out
+
+#@pytest.mark.parametrize('rawinput', [True, False])
+def test_piped_input_echo_true(capsys):
+    command = 'set'
+
+    # hack up stdin
+    fakein = io.StringIO(command)
+    # realin = sys.stdin
+    # sys.stdin = fakein
+
+    # run the cmdloop, which should pull input from stdin
+    app = cmd2.Cmd(stdin=fakein)
+    app.use_rawinput = False
+    app.echo = True
+    app.abbrev = False
+    app._cmdloop()
+    out, err = capsys.readouterr()
+
+    # put stdin back
+    # sys.stdin = realin
+
+    out = out.splitlines()
+    assert out[0] == '{}{}'.format(app.prompt, command)
+    assert out[1] == 'abbrev: False'
+        
 def test_raw_input(base_app):
     base_app.use_raw_input = True
     fake_input = 'quit'

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1428,7 +1428,7 @@ def test_piped_input_rawinput_true_echo_false(capsys):
 # as stdin
 def piped_input_rawinput_false(capsys, echo, command):
     # mock up the input
-    fakein = io.StringIO(command)
+    fakein = io.StringIO(u'{}'.format(command))
 
     # run the cmdloop, which should pull input from stdin
     app = cmd2.Cmd(stdin=fakein)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1389,7 +1389,7 @@ def test_echo(capsys):
     assert app._current_script_dir is None
     assert out.startswith('{}{}\n'.format(app.prompt, command) + 'history [arg]: lists past commands issued')
 
-def test_pseudo_raw_input_tty_rawinput_true(capsys):
+def test_pseudo_raw_input_tty_rawinput_true():
     minput = mock.MagicMock(name='input', side_effect=['set', 'quit'])
     sm.input = minput
     mtty = mock.MagicMock(name='isatty', return_value=True)
@@ -1398,9 +1398,7 @@ def test_pseudo_raw_input_tty_rawinput_true(capsys):
     # run the cmdloop, which should pull input from the mocked input
     app = cmd2.Cmd()
     app.use_rawinput = True
-    app.abbrev = False
     app._cmdloop()
-    out, err = capsys.readouterr()
     
     # because we mocked the input() call, we won't see the prompt
     # or the name of the command in the output, so we can't check
@@ -1409,7 +1407,7 @@ def test_pseudo_raw_input_tty_rawinput_true(capsys):
     # that the rest of it worked
     assert minput.call_count == 2
 
-def test_pseudo_raw_input_tty_rawinput_false(capsys):
+def test_pseudo_raw_input_tty_rawinput_false():
     # mock up the input
     fakein = io.StringIO(u'{}'.format('set\nquit\n'))
     mtty = mock.MagicMock(name='isatty', return_value=True)
@@ -1420,9 +1418,7 @@ def test_pseudo_raw_input_tty_rawinput_false(capsys):
     # run the cmdloop, telling it where to get input from
     app = cmd2.Cmd(stdin=fakein)
     app.use_rawinput = False
-    app.abbrev = False
     app._cmdloop()
-    out, err = capsys.readouterr()
     
     # because we mocked the readline() call, we won't see the prompt
     # or the name of the command in the output, so we can't check

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1390,14 +1390,11 @@ def test_echo(capsys):
     assert app._current_script_dir is None
     assert out.startswith('{}{}\n'.format(app.prompt, command) + 'history [arg]: lists past commands issued')
 
-#@pytest.mark.parametrize('rawinput', [True, False])
-def test_piped_input_echo_false(capsys):
+def test_piped_input_echo_false_rawinput_false(capsys):
     command = 'set'
 
-    # hack up stdin
+    # mock up the input
     fakein = io.StringIO(command)
-    #realin = sys.stdin
-    #sys.stdin = fakein
 
     # run the cmdloop, which should pull input from stdin
     app = cmd2.Cmd(stdin=fakein)
@@ -1407,21 +1404,50 @@ def test_piped_input_echo_false(capsys):
     app._cmdloop()
     out, err = capsys.readouterr()
 
-    # put stdin back
-    #sys.stdin = realin
-
     firstline = out.splitlines()[0]
     assert firstline == 'abbrev: False'
     assert not '{}{}'.format(app.prompt, command) in out
 
-#@pytest.mark.parametrize('rawinput', [True, False])
-def test_piped_input_echo_true(capsys):
+#
+# WARNING:
+# 
+# this test passes, and validates the proper behavior of
+# cmd2.pseudo_raw_input() when use_rawinput = True
+#
+# However, there is only one way to patch/mock/hack input()
+# or raw_input() for testing: that is to change the
+# sys.stdin file descriptor. This results in unpredictable
+# failures when 'pytest -n8' parallelizes tests.
+#
+# @pytest.mark.parametrize('rawinput', [True, False])
+# def test_piped_input_echo_false_stdin_hack(capsys, rawinput):
+#     command = 'set'
+#
+#     # hack up stdin
+#     fakein = io.StringIO(command)
+#     realin = sys.stdin
+#     sys.stdin = fakein
+#
+#     # run the cmdloop, which should pull input from stdin
+#     app = cmd2.Cmd(stdin=fakein)
+#     app.use_rawinput = rawinput
+#     app.echo = False
+#     app.abbrev = False
+#     app._cmdloop()
+#     out, err = capsys.readouterr()
+#
+#     # put stdin back
+#     sys.stdin = realin
+#
+#     firstline = out.splitlines()[0]
+#     assert firstline == 'abbrev: False'
+#     assert not '{}{}'.format(app.prompt, command) in out
+
+def test_piped_input_echo_true_rawinput_false(capsys):
     command = 'set'
 
-    # hack up stdin
+    # mock up the input
     fakein = io.StringIO(command)
-    # realin = sys.stdin
-    # sys.stdin = fakein
 
     # run the cmdloop, which should pull input from stdin
     app = cmd2.Cmd(stdin=fakein)
@@ -1431,13 +1457,45 @@ def test_piped_input_echo_true(capsys):
     app._cmdloop()
     out, err = capsys.readouterr()
 
-    # put stdin back
-    # sys.stdin = realin
-
     out = out.splitlines()
     assert out[0] == '{}{}'.format(app.prompt, command)
     assert out[1] == 'abbrev: False'
-        
+
+#
+# WARNING:
+# 
+# this test passes, and validates the proper behavior of
+# cmd2.pseudo_raw_input() when use_rawinput = True
+#
+# However, there is only one way to patch/mock/hack input()
+# or raw_input() for testing: that is to change the
+# sys.stdin file descriptor. This results in unpredictable
+# failures when 'pytest -n8' parallelizes tests.
+#
+# @pytest.mark.parametrize('rawinput', [True, False])
+# def test_piped_input_echo_true_stdin_hack(capsys, rawinput):
+#     command = 'set'
+#
+#     # hack up stdin
+#     fakein = io.StringIO(command)
+#     realin = sys.stdin
+#     sys.stdin = fakein
+#
+#     # run the cmdloop, which should pull input from stdin
+#     app = cmd2.Cmd()
+#     app.use_rawinput = rawinput
+#     app.echo = True
+#     app.abbrev = False
+#     app._cmdloop()
+#     out, err = capsys.readouterr()
+#
+#     # put stdin back
+#     sys.stdin = realin
+#
+#     out = out.splitlines()
+#     assert out[0] == '{}{}'.format(app.prompt, command)
+#     assert out[1] == 'abbrev: False'
+
 def test_raw_input(base_app):
     base_app.use_raw_input = True
     fake_input = 'quit'

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1436,11 +1436,11 @@ def test_pseudo_raw_input_tty_rawinput_false(capsys):
 #
 # the only way to make this testable is to mock the builtin input()
 # function
-def piped_input_rawinput_true(capsys, echo, command):
+def piped_rawinput_true(capsys, echo, command):
     m = mock.Mock(name='input', side_effect=[command, 'quit'])
     sm.input = m
 
-    # run the cmdloop, which should pull input from our mocked input_list
+    # run the cmdloop, which should pull input from our mocked input
     app = cmd2.Cmd()
     app.use_rawinput = True
     app.echo = echo
@@ -1449,16 +1449,16 @@ def piped_input_rawinput_true(capsys, echo, command):
     out, err = capsys.readouterr()
     return (app, out)
 
-def test_piped_input_rawinput_true_echo_true(capsys):
+def test_pseudo_raw_input_piped_rawinput_true_echo_true(capsys):
     command = 'set'
-    app, out = piped_input_rawinput_true(capsys, True, command)
+    app, out = piped_rawinput_true(capsys, True, command)
     out = out.splitlines()
     assert out[0] == '{}{}'.format(app.prompt, command)
     assert out[1] == 'abbrev: False'
 
-def test_piped_input_rawinput_true_echo_false(capsys):
+def test_pseudo_raw_input_piped_rawinput_true_echo_false(capsys):
     command = 'set'
-    app, out = piped_input_rawinput_true(capsys, False, command)
+    app, out = piped_rawinput_true(capsys, False, command)
     firstline = out.splitlines()[0]
     assert firstline == 'abbrev: False'
     assert not '{}{}'.format(app.prompt, command) in out
@@ -1468,11 +1468,11 @@ def test_piped_input_rawinput_true_echo_false(capsys):
 #
 # the only way to make this testable is to pass a file handle
 # as stdin
-def piped_input_rawinput_false(capsys, echo, command):
+def piped_rawinput_false(capsys, echo, command):
     # mock up the input
     fakein = io.StringIO(u'{}'.format(command))
 
-    # run the cmdloop, which should pull input from stdin
+    # run the cmdloop, telling it where to get input from
     app = cmd2.Cmd(stdin=fakein)
     app.use_rawinput = False
     app.echo = echo
@@ -1481,16 +1481,16 @@ def piped_input_rawinput_false(capsys, echo, command):
     out, err = capsys.readouterr()
     return (app, out)
 
-def test_piped_input_rawinput_false_echo_true(capsys):
+def test_pseudo_raw_input_piped_rawinput_false_echo_true(capsys):
     command = 'set'
-    app, out = piped_input_rawinput_false(capsys, True, command)
+    app, out = piped_rawinput_false(capsys, True, command)
     out = out.splitlines()
     assert out[0] == '{}{}'.format(app.prompt, command)
     assert out[1] == 'abbrev: False'
 
-def test_piped_input_rawinput_false_echo_false(capsys):
+def test_pseudo_raw_input_piped_rawinput_false_echo_false(capsys):
     command = 'set'
-    app, out = piped_input_rawinput_false(capsys, False, command)
+    app, out = piped_rawinput_false(capsys, False, command)
     firstline = out.splitlines()[0]
     assert firstline == 'abbrev: False'
     assert not '{}{}'.format(app.prompt, command) in out


### PR DESCRIPTION
When input is piped into **cmd2** from something that isn't a tty, we now honor the **echo* setting to determine whether we should print the prompt and the command to the output stream.

Also fixed a bug where we tried to execute **stty** on the input stream, even when it wasn't a tty.

This closes #218 