### PR TITLE
Improved poutput() so that it can print falsy things

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -585,7 +585,7 @@ class Cmd(cmd.Cmd):
         :param msg: str - message to print to current stdout - anyting convertible to a str with '{}'.format() is OK
         :param end: str - string appended after the end of the message if not already present, default a newline
         """
-        if msg:
+        if msg is not None and msg != '':
             try:
                 msg_str = '{}'.format(msg)
                 self.stdout.write(msg_str)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1406,7 +1406,7 @@ def test_pseudo_raw_input_tty_rawinput_true():
             # for the 'set' command, and once for the 'quit' command,
             # that the rest of it worked
             assert m_input.call_count == 2
-    
+
 def test_pseudo_raw_input_tty_rawinput_false():
     # gin up some input like it's coming from a tty
     fakein = io.StringIO(u'{}'.format('set\n'))
@@ -1414,12 +1414,12 @@ def test_pseudo_raw_input_tty_rawinput_false():
     fakein.isatty = mtty
     mreadline = mock.MagicMock(name='readline', wraps=fakein.readline)
     fakein.readline = mreadline
-    
+
     # run the cmdloop, telling it where to get input from
     app = cmd2.Cmd(stdin=fakein)
     app.use_rawinput = False
     app._cmdloop()
-    
+
     # because we mocked the readline() call, we won't get the prompt
     # or the name of the command in the output, so we can't check
     # if its there. We assume that if readline() got called twice, once
@@ -1523,3 +1523,32 @@ def test_empty_stdin_input():
 
     line = app.pseudo_raw_input('(cmd2)')
     assert line == 'eof'
+
+
+def test_poutput_string(base_app):
+    msg = 'This is a test'
+    base_app.poutput(msg)
+    out = base_app.stdout.buffer
+    expected = msg + '\n'
+    assert out == expected
+
+def test_poutput_zero(base_app):
+    msg = 0
+    base_app.poutput(msg)
+    out = base_app.stdout.buffer
+    expected = str(msg) + '\n'
+    assert out == expected
+
+def test_poutput_empty_string(base_app):
+    msg = ''
+    base_app.poutput(msg)
+    out = base_app.stdout.buffer
+    expected = msg
+    assert out == expected
+
+def test_poutput_none(base_app):
+    msg = None
+    base_app.poutput(msg)
+    out = base_app.stdout.buffer
+    expected = ''
+    assert out == expected


### PR DESCRIPTION
Improved poutput() so that it can print falsy things such as integer zero.

The poutput() function has been ruggedized so that it has a better conditional check so that it will actually print
things which are "falsy" but are still convertible to a string.

A few unit tests have been added specifically for the poutput function.

This closes #222