### PR TITLE
Provide method to run multiple commands w/o a cmdloop.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Once you have cmd2 cloned, before you start any cmd2 application, you first need
 
 ```bash
 # Install cmd2 prerequisites
-pip install -U six pyparsing
+pip install -U six pyparsing pyperclip
 
 # Install prerequisites for running cmd2 unit tests
 pip install -U pytest mock

--- a/tests/scripts/nested.txt
+++ b/tests/scripts/nested.txt
@@ -1,0 +1,4 @@
+_relative_load precmds.txt
+help
+shortcuts
+_relative_load postcmds.txt

--- a/tests/scripts/postcmds.txt
+++ b/tests/scripts/postcmds.txt
@@ -1,0 +1,2 @@
+set abbrev off
+set colors off

--- a/tests/scripts/precmds.txt
+++ b/tests/scripts/precmds.txt
@@ -1,0 +1,2 @@
+set abbrev on
+set colors on


### PR DESCRIPTION
runcmds_plus_hooks can accept multiple commands process the command queue to
 deal with subsequent commands loaded from scripts without requiring a command
 loop. This better supports a one-off batch processing scenario.

Also fixed the insertion order of commands placed in the command queue by load
and _relative_load so that script commands are run in the expected order.

Minor tweak to setup instructions in CONTRIBUTING.md to include pyperclip in
prerequisites.

closes #224 