### PR TITLE
Made a couple fixes to existing examples

### DIFF
--- a/examples/argparse_example.py
+++ b/examples/argparse_example.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 """A sample application for cmd2 showing how to use Argparse to process command line arguments for your application.
-It doubles as an example of how you can still do transcript testing even if allow_cli_args is false.
+It parses command line arguments looking for known arguments, but then still passes any unknown arguments onto cmd2
+to treat them as arguments at invocation.
 
 Thanks to cmd2's built-in transcript testing capability, it also serves as a test suite for argparse_example.py when
 used with the exampleSession.txt transcript.
@@ -10,6 +11,7 @@ Running `python argparse_example.py -t exampleSession.txt` will run all the comm
 argparse_example.py, verifying that the output produced matches the transcript.
 """
 import argparse
+import sys
 
 from cmd2 import Cmd, make_option, options
 
@@ -28,7 +30,7 @@ class CmdLineApp(Cmd):
         Cmd.__init__(self, use_ipython=False, transcript_files=transcript_files)
 
         # Disable cmd's usage of command-line arguments as commands to be run at invocation
-        self.allow_cli_args = False
+        # self.allow_cli_args = False
 
         # Example of args set from the command-line (but they aren't being used here)
         self._ip = ip_addr
@@ -68,8 +70,7 @@ if __name__ == '__main__':
     parser.add_argument('-i', '--ip', type=str, help='IPv4 address')
 
     # Add an argument which enables transcript testing
-    parser.add_argument('-t', '--test', type=str, help='Test against transcript in FILE (wildcards OK)')
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 
     port = None
     if args.port:
@@ -79,12 +80,11 @@ if __name__ == '__main__':
     if args.ip:
         ip_addr = args.ip
 
-    transcripts = None
-    if args.test:
-        transcripts = [args.test]
+    # Perform surgery on sys.argv to remove the arguments which have already been processed by argparse
+    sys.argv = sys.argv[:1] + unknown_args
 
     # Instantiate your cmd2 application
-    c = CmdLineApp(transcript_files=transcripts)
+    c = CmdLineApp()
 
     # And run your cmd2 application
     c.cmdloop()

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,9 +4,9 @@
 A sample application for cmd2.
 
 Thanks to cmd2's built-in transcript testing capability, it also serves as a
-test suite for example.py when used with the exampleSession.txt transcript.
+test suite for example.py when used with the transcript_regex.txt transcript.
 
-Running `python example.py -t exampleSession.txt` will run all the commands in
+Running `python example.py -t transcript_regex.txt` will run all the commands in
 the transcript against example.py, verifying that the output produced matches
 the transcript.
 """

--- a/examples/exampleSession.txt
+++ b/examples/exampleSession.txt
@@ -1,72 +1,18 @@
-# Run this transcript with "python example.py -t exampleSession.txt"
-(Cmd) help
-
-Documented commands (type help <topic>):
-========================================
-_relative_load  edit  history  orate  pyscript  run   say  shell      show
-cmdenvironment  help  load     py     quit      save  set  shortcuts  speak
-
-(Cmd) help say
-Repeats what you tell me to.
-Usage: speak [options] arg
-
-Options:
-  -h, --help            show this help message and exit
-  -p, --piglatin        atinLay
-  -s, --shout           N00B EMULATION MODE
-  -r REPEAT, --repeat=REPEAT
-                        output [n] times
-
-(Cmd) say goodnight, Gracie
-goodnight, Gracie
-(Cmd) say -ps --repeat=5 goodnight, Gracie
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-(Cmd) set maxrepeats 5
-maxrepeats - was: 3
-now: 5
-(Cmd) say -ps --repeat=5 goodnight, Gracie
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-(Cmd) hi
--------------------------[1]
-help
--------------------------[2]
-help say
--------------------------[3]
-say goodnight, Gracie
--------------------------[4]
-say -ps --repeat=5 goodnight, Gracie
--------------------------[5]
-set maxrepeats 5
--------------------------[6]
-say -ps --repeat=5 goodnight, Gracie
-(Cmd) run 4
-say -ps --repeat=5 goodnight, Gracie
-
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-OODNIGHT, GRACIEGAY
-(Cmd) orate Four score and
-> seven releases ago
-> our BDFL
-> blah blah blah
-Four score and
-seven releases ago
-our BDFL
-blah blah blah
-(Cmd) & look, a shortcut!
-look, a shortcut!
-(Cmd) show color
+# Run this transcript with "python argparse_example.py -t exampleSession.txt"
+# The regex for colors is because no color on Windows.
+# The regex for editor will match whatever program you use.
+# regexes on prompts just make the trailing space obvious
+(Cmd) set
+abbrev: False
+autorun_on_edit: False
 colors: /(True|False)/
-(Cmd) set prompt "---> "
-prompt - was: (Cmd)
-now: --->
----> say goodbye
-goodbye
+continuation_prompt: >/ /
+debug: False
+echo: False
+editor: /.*?/
+feedback_to_output: False
+locals_in_py: True
+maxrepeats: 3
+prompt: (Cmd)/ /
+quiet: False
+timing: False


### PR DESCRIPTION
Changes include:
- argparse_example.py modified to do pass all unknown args onto cmd2 and allow arguments at invocation
- example.py comments modified to indicate it is intended to be used with transcript_regext.txt
- exampleSession.txt fixed so it works properly with argparse_example.py