### PR TITLE
Fix for #244

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ cmd2.egg-info
 .cache
 *.pyc
 .coverage
+.tox
 htmlcov

--- a/cmd2.py
+++ b/cmd2.py
@@ -2398,7 +2398,22 @@ class Cmd2TestCase(unittest.TestCase):
             self.assertTrue(re.match(expected, result, re.MULTILINE | re.DOTALL), message)
 
     def _transform_transcript_expected(self, s):
-        """parse the string with slashed regexes into a valid regex"""
+        """parse the string with slashed regexes into a valid regex
+        
+        Given a string like:
+        
+            Match a 10 digit phone number: /\d{3}-\d{3}-\d{4}/
+        
+        Turn it into a valid regular expression which matches the literal text
+        of the string and the regular expression. We have to remove the slashes
+        because they differentiate between plain text and a regular expression.
+        Unless the slashes are escaped, in which case they are interpreted as
+        plain text, or there is only one slash, which is treated as plain text
+        also.
+        
+        Check the tests in tests/test_transcript.py to see all the edge
+        cases.
+        """
         regex = ''
         start = 0
 


### PR DESCRIPTION
In python 3.7, the behavior of re.escape() changed. Rework the test cases in test_transcript.py to ensure they run properly on both 3.4-3.6 as well as 3.7.
 
This closes #244 