### PR TITLE
Enabled Python 3.7 testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
         - os: linux
           python: 3.6
           env: TOXENV=py36
-#        - os: linux
-#          python: 3.7-dev
-#          env: TOXENV=py37
+        - os: linux
+          python: 3.7-dev
+          env: TOXENV=py37
 #        # Warning: Don't try to use code coverage analysis with pypy as it is insanely slow
 #        - os: linux
 #          python: pypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0 (TBD, 2018)
+* Bug Fixes
+    * Fixed unit tests on Python 3.7 due to changes in how re.escape() behaves in Python 3.7
+
 ## 0.7.9 (January 4, 2018)
 
 * Bug Fixes

--- a/cmd2.py
+++ b/cmd2.py
@@ -106,7 +106,7 @@ if six.PY2 and sys.platform.startswith('lin'):
     except ImportError:
         pass
 
-__version__ = '0.7.9'
+__version__ = '0.8.0a'
 
 # Pyparsing enablePackrat() can greatly speed up parsing, but problems have been seen in Python 3 in the past
 pyparsing.ParserElement.enablePackrat()
@@ -2399,18 +2399,18 @@ class Cmd2TestCase(unittest.TestCase):
 
     def _transform_transcript_expected(self, s):
         """parse the string with slashed regexes into a valid regex
-        
+
         Given a string like:
-        
+
             Match a 10 digit phone number: /\d{3}-\d{3}-\d{4}/
-        
+
         Turn it into a valid regular expression which matches the literal text
         of the string and the regular expression. We have to remove the slashes
         because they differentiate between plain text and a regular expression.
         Unless the slashes are escaped, in which case they are interpreted as
         plain text, or there is only one slash, which is treated as plain text
         also.
-        
+
         Check the tests in tests/test_transcript.py to see all the edge
         cases.
         """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Setuptools setup file, used to install or test 'cmd2'
 import sys
 from setuptools import setup
 
-VERSION = '0.7.9'
+VERSION = '0.8.0a'
 DESCRIPTION = "cmd2 - a tool for building interactive command line applications in Python"
 LONG_DESCRIPTION = """cmd2 is a tool for building interactive command line applications in Python. Its goal is to make 
 it quick and easy for developers to build feature-rich and user-friendly interactive command line applications.  It 
@@ -55,6 +55,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Software Development :: Libraries :: Python Modules

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -24,7 +24,7 @@ from conftest import run_cmd, normalize, BASE_HELP, HELP_HISTORY, SHORTCUTS_TXT,
 
 
 def test_ver():
-    assert cmd2.__version__ == '0.7.9'
+    assert cmd2.__version__ == '0.8.0a'
 
 
 def test_empty_statement(base_app):


### PR DESCRIPTION
Since the most recent PR fixed unit tests for the alpha version of Python 3.7, I have enabled Python 3.7 testing on Travis CI.

Also bumped version to 0.8.0a