### PR TITLE
Improved how new argparse-based decorators provide help

### DIFF
--- a/docs/argument_processing.rst
+++ b/docs/argument_processing.rst
@@ -58,24 +58,25 @@ Help Messages
 
 By default, cmd2 uses the docstring of the command method when a user asks
 for help on the command. When you use the ``@with_argument_parser``
-decorator, the formatted help from the ``argparse.ArgumentParser`` is
-appended to the docstring for the method of that command. With this code::
+decorator, the docstring for the ``do_*`` method is used to set the description for the ``argparse.ArgumentParser`` is
+With this code::
 
    argparser = argparse.ArgumentParser()
-   argparser.add_argument('tag', nargs=1, help='tag')
+   argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argument_parser(argparser)
    def do_tag(self, args):
       """create a html tag"""
-      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag[0], ' '.join(args.content)))
+      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
       self.stdout.write('\n')
 
 The ``help tag`` command displays:
 
 .. code-block:: none
 
-   create a html tag
    usage: tag [-h] tag content [content ...]
+
+   create a html tag
 
    positional arguments:
      tag         tag
@@ -85,14 +86,15 @@ The ``help tag`` command displays:
      -h, --help  show this help message and exit
 
 
-If you would prefer the short description of your command to come after the usage message, leave the docstring on your method empty, but supply a ``description`` variable to the argument parser::
+If you would prefer you can set the ``description`` while instantiating the ``argparse.ArgumentParser`` and leave the
+docstring on your method empty::
 
    argparser = argparse.ArgumentParser(description='create an html tag')
-   argparser.add_argument('tag', nargs=1, help='tag')
+   argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argument_parser(argparser)
    def do_tag(self, args):
-      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag[0], ' '.join(args.content)))
+      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
       self.stdout.write('\n')
 
 Now when the user enters ``help tag`` they see:
@@ -117,11 +119,11 @@ To add additional text to the end of the generated help message, use the ``epilo
       description='create an html tag',
       epilog='This command can not generate tags with no content, like <br/>.'
    )
-   argparser.add_argument('tag', nargs=1, help='tag')
+   argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argument_parser(argparser)
    def do_tag(self, args):
-      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag[0], ' '.join(args.content)))
+      self.stdout.write('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
       self.stdout.write('\n')
 
 Which yields:

--- a/examples/argparse_example.py
+++ b/examples/argparse_example.py
@@ -64,7 +64,7 @@ class CmdLineApp(Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    tag_parser = argparse.ArgumentParser(description='create a html tag')
+    tag_parser = argparse.ArgumentParser()
     tag_parser.add_argument('tag', nargs=1, help='tag')
     tag_parser.add_argument('content', nargs='+', help='content to surround with tag')
 

--- a/examples/argparse_example.py
+++ b/examples/argparse_example.py
@@ -65,13 +65,13 @@ class CmdLineApp(Cmd):
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
     tag_parser = argparse.ArgumentParser()
-    tag_parser.add_argument('tag', nargs=1, help='tag')
+    tag_parser.add_argument('tag', help='tag')
     tag_parser.add_argument('content', nargs='+', help='content to surround with tag')
 
     @with_argument_parser(tag_parser)
     def do_tag(self, args):
         """create a html tag"""
-        self.poutput('<{0}>{1}</{0}>'.format(args.tag[0], ' '.join(args.content)))
+        self.poutput('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
 
 
     @with_argument_list

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -76,7 +76,7 @@ class Pirate(Cmd):
     yo_parser = argparse.ArgumentParser()
     yo_parser.add_argument('--ho', type=int, default=2, help="How often to chant 'ho'")
     yo_parser.add_argument('-c', '--commas', action='store_true', help='Intersperse commas')
-    yo_parser.add_argument('beverage', nargs=1, help='beverage to drink with the chant')
+    yo_parser.add_argument('beverage', help='beverage to drink with the chant')
 
     @with_argument_parser(yo_parser)
     def do_yo(self, args):
@@ -84,7 +84,7 @@ class Pirate(Cmd):
         chant = ['yo'] + ['ho'] * args.ho
         separator = ', ' if args.commas else ' '
         chant = separator.join(chant)
-        print('{0} and a bottle of {1}'.format(chant, args.beverage[0]))
+        print('{0} and a bottle of {1}'.format(chant, args.beverage))
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ edit  help  history  load  py  pyscript  quit  set  shell  shortcuts
 # Help text for the history command
 HELP_HISTORY = """usage: history [-h] [-r | -e | -o FILE] [-s] [arg]
 
-run, edit, and save previously entered commands
+View, run, edit, and save previously entered commands.
 
 positional arguments:
   arg                   empty               all history items

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -37,12 +37,12 @@ class ArgparseApp(cmd2.Cmd):
             self.stdout.write('\n')
 
     tag_parser = argparse.ArgumentParser(description='create a html tag')
-    tag_parser.add_argument('tag', nargs=1, help='tag')
+    tag_parser.add_argument('tag', help='tag')
     tag_parser.add_argument('content', nargs='+', help='content to surround with tag')
 
     @cmd2.with_argument_parser(tag_parser)
     def do_tag(self, args):
-        self.stdout.write('<{0}>{1}</{0}>'.format(args.tag[0], ' '.join(args.content)))
+        self.stdout.write('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
         self.stdout.write('\n')
 
     @cmd2.with_argument_list

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -140,10 +140,14 @@ def test_argparse_quoted_arguments_posix_multiple(argparse_app):
 
 def test_argparse_help_docstring(argparse_app):
     out = run_cmd(argparse_app, 'help say')
-    assert out[0] == 'Repeat what you tell me to.'
+    assert out[0].startswith('usage: say')
+    assert out[1] == ''
+    assert out[2] == 'Repeat what you tell me to.'
 
 def test_argparse_help_description(argparse_app):
     out = run_cmd(argparse_app, 'help tag')
+    assert out[0].startswith('usage: tag')
+    assert out[1] == ''
     assert out[2] == 'create a html tag'
 
 def test_argparse_prog(argparse_app):


### PR DESCRIPTION
Now "help command" and "command -h" provide exactly the same help text.

The function docstring for the "do_*" command sets and overrides the ArgumentParser "description" if the docstring is not empty.