### PR TITLE
Check if name is in self.get_names() before removing

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1590,7 +1590,8 @@ class Cmd(cmd.Cmd):
 
         # Remove any command names which are explicitly excluded from the help menu
         for name in self.exclude_from_help:
-            names.remove(name)
+            if name in names:
+                names.remove(name)
 
         cmds_doc = []
         cmds_undoc = []


### PR DESCRIPTION
This is to avoid hitting `ERROR: Invalid syntax: list.remove(x): x not in list` if a command is added to exclude_from_help which does not exist in the instance.

I ran into this when trying to use 2 nested prompts each with different exclude_from_help lists. Once the second prompt was instantiated, the 'help' command is updated at the class level, so the command list may now be inaccurate for other instances.

Perhaps it should be considered to change exclude_from_help to an instance variable.