### PR TITLE
Packaging fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
 include LICENSE
 include README.md
 include CHANGELOG.md
+include CODEOWNERS
+include CONTRIBUTING.md
+include tox.ini
+recursive-include docs *
+recursive-include examples *
+recursive-include tests *

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -375,11 +375,6 @@ def test_path_completion_user_expansion(cmd2_app):
     # Verify that the results are the same in both cases
     assert completions_tilde == completions_home
 
-    # This next assert fails on AppVeyor Windows containers, but works fine on my Windows 10 VM
-    if not sys.platform.startswith('win'):
-        # Verify that there is something there
-        assert completions_tilde
-
 def test_path_completion_directories_only(cmd2_app, request):
     test_dir = os.path.dirname(request.module.__file__)
 


### PR DESCRIPTION
Fixes for #279.

After reviewing `test_path_completion_user_expansion()`, I believe that if the user running the tests has an empty home directory, the assertions are not really exercising the functionality. An empty home directory could happen in automated build environments like Travis CI or OS packaging environments as was discovered in the linked issue.

@tleonhardt do you think we need to come up with some more robust assertions in this test? Like see if there is a way we can monkey with the $HOME environment variable so we can set it to a temporary directory created and populated by the test?