### PR TITLE
Added use of @functools.wraps() in our decorators

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -30,6 +30,7 @@ import cmd
 import codecs
 import collections
 import datetime
+import functools
 import glob
 import io
 import optparse
@@ -271,6 +272,7 @@ def with_argument_list(func):
     method. Default passes a string of whatever the user typed.
     With this decorator, the decorated method will receive a list
     of arguments parsed from user input using shlex.split()."""
+    @functools.wraps(func)
     def cmd_wrapper(self, cmdline):
         lexed_arglist = parse_quoted_string(cmdline)
         func(self, lexed_arglist)
@@ -288,6 +290,7 @@ def with_argparser_and_unknown_args(argparser, subcommand_names=None):
     :return: function that gets passed parsed args and a list of unknown args
     """
     def arg_decorator(func):
+        @functools.wraps(func)
         def cmd_wrapper(instance, cmdline):
             lexed_arglist = parse_quoted_string(cmdline)
             args, unknown = argparser.parse_known_args(lexed_arglist)
@@ -324,6 +327,7 @@ def with_argparser(argparser, subcommand_names=None):
     :return: function that gets passed parsed args
     """
     def arg_decorator(func):
+        @functools.wraps(func)
         def cmd_wrapper(instance, cmdline):
             lexed_arglist = parse_quoted_string(cmdline)
             args = argparser.parse_args(lexed_arglist)
@@ -387,6 +391,7 @@ def options(option_list, arg_desc="arg"):
             option_parser.set_usage("%s %s" % (func.__name__[3:], arg_desc))
         option_parser._func = func
 
+        @functools.wraps(func)
         def new_func(instance, arg):
             """For @options commands this replaces the actual do_* methods in the instance __dict__.
 


### PR DESCRIPTION
This updates our decorator wrapper functions to look like the wrapped function.

This partially addresses Issue #271 where using multiple decorators can break help on subcommands, depending on the order in which the decorators are applied.

This PR doesn't actually fix anything in and of itself.  But it encourages the usage of @functools.wraps().  If other decorators use this, then there shouldn't be any problem.  Of course, we can't control how 3rd-party libraries implement decorators.  But we can at least be part of the solution instead of part of the problem.