### PR TITLE
Improved the documentation regarding poutput

### DIFF
--- a/docs/transcript.rst
+++ b/docs/transcript.rst
@@ -29,7 +29,7 @@ This is by far the easiest way to generate a transcript.
 .. warning::
 
    Make sure you use the **poutput()** method in your ``cmd2`` application for generating command output.  This method
-   of the ``cmd2.Cmd`` class ensure that output is properly redirected when redirecting to a file, pipeing to a shell
+   of the ``cmd2.Cmd`` class ensure that output is properly redirected when redirecting to a file, piping to a shell
    command, and when generating a transcript.
 
 Manually

--- a/docs/transcript.rst
+++ b/docs/transcript.rst
@@ -26,6 +26,12 @@ A transcript can automatically generated based upon commands previously executed
 
 This is by far the easiest way to generate a transcript.
 
+.. warning::
+
+   Make sure you use the **poutput()** method in your ``cmd2`` application for generating command output.  This method
+   of the ``cmd2.Cmd`` class ensure that output is properly redirected when redirecting to a file, pipeing to a shell
+   command, and when generating a transcript.
+
 Manually
 --------
 Here's a transcript created from ``python examples/example.py``::

--- a/docs/unfreefeatures.rst
+++ b/docs/unfreefeatures.rst
@@ -155,8 +155,13 @@ but ``print`` decreases output flexibility).  ``cmd2`` applications can use
 ``self.poutput('output')``, ``self.pfeedback('message')``, and ``self.perror('errmsg')``
 instead.  These methods have these advantages:
 
+- Handle output redirection to file and/or pipe appropriately
 - More concise
     - ``.pfeedback()`` destination is controlled by :ref:`quiet` parameter.
+
+.. automethod:: cmd2.Cmd.poutput
+.. automethod:: cmd2.Cmd.perror
+.. automethod:: cmd2.Cmd.pfeedback
 
 
 color


### PR DESCRIPTION
Improved documentation related to **poutput** in general, but especially related to transcripts.

The documentation didn't make it very clear that the poutput() method should be used for generating output from cmd2 commands.  This PR attempts to fix that.

This closes #275