### PR TITLE
Fixed removed_unused.py example and help for edit command

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -2176,7 +2176,7 @@ a..b, a:b, a:, ..b  items by indices (inclusive)
 
     @with_argument_list
     def do_edit(self, arglist):
-        """Edit a file or command in a text editor.
+        """Edit a file in a text editor.
 
 Usage:  edit [file_path]
     Where:

--- a/examples/remove_unused.py
+++ b/examples/remove_unused.py
@@ -19,10 +19,10 @@ class RemoveUnusedBuiltinCommands(cmd2.Cmd):
         cmd2.Cmd.__init__(self)
 
         # To hide commands from displaying in the help menu, add their function name to the exclude_from_help list
-        self.exclude_from_help.append('do__relative_load')
+        self.exclude_from_help.append('do_py')
 
         # To remove built-in commands entirely, delete their "do_*" function from the cmd2.Cmd class
-        del cmd2.Cmd.do_cmdenvironment
+        del cmd2.Cmd.do_edit
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The remove_unused.py example had become outdated since the cmdenvironment command no longer exists.

The help text for the edit command was outdated since the functionality for editing previous commands got moved from the edit command to the history command.

This closes #276.
This closes #282.