### PR TITLE
Use pytest-forked module for Linux CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.1 (TBD, 2018)
+## 0.8.1 (March TBD, 2018)
 
 * Bug Fixes
     * Fixed a bug if a non-existent **do_*** method was added to the ``exclude_from_help`` list
@@ -16,7 +16,7 @@
     * ``exclude_from_help`` and ``excludeFromHistory`` are now instance instead of class attributes
     * Added flag and index based tab completion helper functions
         * See [tab_completion.py](https://github.com/python-cmd2/cmd2/blob/master/examples/tab_completion.py)
-* Attributes Removed
+* Attributes Removed (**can cause breaking changes**)
     * ``abbrev`` - Removed support for abbreviated commands
         * Good tab completion makes this unnecessary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ The tables below list all prerequisites along with the minimum required version 
 ### Optional prerequisites for enhanced unit test features
 | Prerequisite                                | Minimum Version |
 | ------------------------------------------- | --------------- |
+| [pytest-forked](https://pypi.python.org/pypi/pytest-forked)| `0.2` |
 | [pytest-xdist](https://pypi.python.org/pypi/pytest-xdist)| `1.15` |
 | [pytest-cov](https://pypi.python.org/pypi/pytest-cov) | `1.8` |
 
@@ -201,7 +202,7 @@ pip install -U pytest mock
 pip install -U sphinx sphinx-rtd-theme
 
 # Install optional prerequisites for running unit tests in parallel and doing code coverage analysis
-pip install -U pytest-xdist pytest-cov
+pip install -U pytest-xdist pytest-cov pytest-forked
 ```
 
 For doing cmd2 development, you actually do NOT want to have cmd2 installed as a Python package.  
@@ -268,6 +269,13 @@ dramatically speed up test execution by running tests in parallel on multiple co
 py.test -n4
 ```
 where `4` should be replaced by the number of parallel threads you wish to run for testing.
+
+If you have the `pytest-forked` pytest plugin for running tests in isolated formed processes, you
+can speed things up even further:
+
+```shell
+py.test -nauto --forked
+```
 
 #### Measuring code coverage
 
@@ -390,11 +398,11 @@ how to do it.
 
 6.  Indicate what local testing you have done (e.g. what OS and version(s) of Python did you run the
     unit test suite with)
-    
+
 7.  Creating the PR causes our continuous integration (CI) systems to automatically run all of the
     unit tests on all supported OSes and all supported versions of Python.  You should watch your PR
     to make sure that all unit tests pass on Both TravisCI (Linux) and AppVeyor (Windows).  
-    
+
 8.  If any unit tests fail, you should look at the details and fix the failures.  You can then push
     the fix to the same branch in your fork and the PR will automatically get updated and the CI system
     will automatically run all of the unit tests again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,8 +270,8 @@ py.test -n4
 ```
 where `4` should be replaced by the number of parallel threads you wish to run for testing.
 
-If you have the `pytest-forked` pytest plugin for running tests in isolated formed processes, you
-can speed things up even further:
+If you have the `pytest-forked` pytest plugin (not avilable on Windows) for running tests in isolated formed processes, 
+you can speed things up even further:
 
 ```shell
 py.test -nauto --forked

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if sys.version_info < (3, 0):
     INSTALL_REQUIRES += ['subprocess32']
 
 # unittest.mock was added in Python 3.3.  mock is a backport of unittest.mock to all versions of Python
-TESTS_REQUIRE = ['mock', 'pytest', 'pexpect']
+TESTS_REQUIRE = ['mock', 'pytest', 'pytest-xdist', 'pytest-forked']
 DOCS_REQUIRE = ['sphinx', 'sphinx_rtd_theme', 'pyparsing', 'pyperclip', 'six']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if sys.version_info < (3, 0):
     INSTALL_REQUIRES += ['subprocess32']
 
 # unittest.mock was added in Python 3.3.  mock is a backport of unittest.mock to all versions of Python
-TESTS_REQUIRE = ['mock', 'pytest', 'pytest-xdist', 'pytest-forked']
+TESTS_REQUIRE = ['mock', 'pytest', 'pytest-xdist']
 DOCS_REQUIRE = ['sphinx', 'sphinx_rtd_theme', 'pyparsing', 'pyperclip', 'six']
 
 setup(

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -11,7 +11,6 @@ import io
 import tempfile
 
 import mock
-import pexpect
 import pytest
 import six
 
@@ -1502,37 +1501,3 @@ def test_poutput_none(base_app):
     out = base_app.stdout.buffer
     expected = ''
     assert out == expected
-
-
-@pytest.mark.skipif(sys.platform == 'win32' or sys.platform.startswith('lin'),
-                    reason="pexpect doesn't have a spawn() function on Windows and readline doesn't work on TravisCI")
-def test_persistent_history(request):
-    """Will run on macOS to verify expected persistent history behavior."""
-    test_dir = os.path.dirname(request.module.__file__)
-    persistent_app = os.path.join(test_dir, '..', 'examples', 'persistent_history.py')
-
-    python = 'python3'
-    if six.PY2:
-        python = 'python2'
-
-    command = '{} {}'.format(python, persistent_app)
-
-    # Start an instance of the persistent history example and send it a few commands
-    child = pexpect.spawn(command)
-    prompt = 'ph> '
-    child.expect(prompt)
-    child.sendline('help')
-    child.expect(prompt)
-    child.sendline('help history')
-    child.expect(prompt)
-    child.sendline('quit')
-    child.close()
-
-    # Start a 2nd instance of the persistent history example and send it an up arrow to verify persistent history
-    up_arrow = '\x1b[A'
-    child2 = pexpect.spawn(command)
-    child2.expect(prompt)
-    child2.send(up_arrow)
-    child2.expect('quit')
-    assert child2.after == b'quit'
-    child2.close()

--- a/tox.ini
+++ b/tox.ini
@@ -34,12 +34,11 @@ deps =
   pyreadline
   pytest
   pytest-cov
-  pytest-forked
   pytest-xdist
   six
   subprocess32
 commands =
-  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing --forked
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
   codecov
 
 [testenv:py34]
@@ -71,10 +70,9 @@ deps =
   pyperclip
   pyreadline
   pytest
-  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2 --forked
+commands = py.test -v -n2
 
 [testenv:py36]
 deps =
@@ -98,10 +96,9 @@ deps =
   pyperclip
   pyreadline
   pytest
-  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2 --forked
+commands = py.test -v -n2
 
 [testenv:py37]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -13,104 +13,104 @@ setenv =
 deps =
   codecov
   mock
-  pexpect
   pyparsing
   pyperclip
   pytest
   pytest-cov
+  pytest-forked
   pytest-xdist
   six
   subprocess32
 commands =
-  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing --forked
   codecov
 
 [testenv:py27-win]
 deps =
   codecov
   mock
-  pexpect
   pyparsing
   pyperclip
   pyreadline
   pytest
   pytest-cov
+  pytest-forked
   pytest-xdist
   six
   subprocess32
 commands =
-  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing --forked
   codecov
 
 [testenv:py34]
 deps =
   mock
-  pexpect
   pyparsing
   pyperclip
   pytest
+  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -n2 --forked
 
 [testenv:py35]
 deps =
   mock
-  pexpect
   pyparsing
   pyperclip
   pytest
+  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -n2 --forked
 
 [testenv:py35-win]
 deps =
   mock
-  pexpect
   pyparsing
   pyperclip
   pyreadline
   pytest
+  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -n2 --forked
 
 [testenv:py36]
 deps =
   codecov
   mock
-  pexpect
   pyparsing
   pyperclip
   pytest
   pytest-cov
+  pytest-forked
   pytest-xdist
   six
 commands =
-  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing
+  py.test {posargs: -n 2} --cov=cmd2 --cov-report=term-missing --forked
   codecov
 
 [testenv:py36-win]
 deps =
   mock
-  pexpect
   pyparsing
   pyperclip
   pyreadline
   pytest
+  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -n2 --forked
 
 [testenv:py37]
 deps =
   mock
-  pexpect
   pyparsing
   pyperclip
   pytest
+  pytest-forked
   pytest-xdist
   six
-commands = py.test -v -n2
+commands = py.test -v -n2 --forked
 


### PR DESCRIPTION
Now the Travis CI Linux builds make use of the ``pytest-forked`` module to speed up unit tests.  

The reason this helps is due to an apparent bug in ``pyparsing``.  See Issue #287 for more information.

Also:
- Removed use of ``pexpect`` in unit test along with the single unit test which used it and was skipped on all current CI platforms because it didn't work there.

This closes #293 