### PR TITLE
submenu autocomplete

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -790,7 +790,9 @@ def _complete_from_cmd(cmd_obj, text, line, begidx, endidx):
     command_subcommand_params = line.split(None, 3)
 
     if len(command_subcommand_params) < (3 if text else 2):
-        return cmd_obj.completenames(text)
+        n = len(command_subcommand_params[0])
+        n += sum(1 for _ in takewhile(str.isspace, line[n:]))
+        return cmd_obj.completenames(text, line[n:], begidx - n, endidx - n)
 
     command, subcommand = command_subcommand_params[:2]
     n = len(command) + sum(1 for _ in takewhile(str.isspace, line))


### PR DESCRIPTION
For submenu commands autocompletion does not work correctly.

The problem is in calling `completenames` method, this method is overridden from `cmd.Cmd` class:

```python
# cmd
def completenames(self, text, *ignored):
    pass
```

```python
# cmd2
def completenames(self, text, line, begidx, endidx):
    pass
```
But in submenus it is called with only text argument (`cmd_obj.completenames(text)`) generating a `TypeError`.

I also added some completion tests for submenus.

Partially related to #268 