### PR TITLE
Add option to cancel the current line on keyboard interrupt.

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1016,6 +1016,7 @@ class Cmd(cmd.Cmd):
     allow_cli_args = True       # Should arguments passed on the command-line be processed as commands?
     allow_redirection = True    # Should output redirection and pipes be allowed
     default_to_shell = False    # Attempt to run unrecognized commands as shell commands
+    quit_on_sigint = True       # Quit the loop on interrupt instead of just resetting prompt
     reserved_words = []
 
     # Attributes which ARE dynamically settable at runtime
@@ -1889,7 +1890,14 @@ class Cmd(cmd.Cmd):
                         self.poutput('{}{}'.format(self.prompt, line))
                 else:
                     # Otherwise, read a command from stdin
-                    line = self.pseudo_raw_input(self.prompt)
+                    if not self.quit_on_sigint:
+                        try:
+                            line = self.pseudo_raw_input(self.prompt)
+                        except KeyboardInterrupt:
+                            self.poutput('^C')
+                            line = ''
+                    else:
+                        line = self.pseudo_raw_input(self.prompt)
 
                 # Run the command along with all associated pre and post hooks
                 stop = self.onecmd_plus_hooks(line)


### PR DESCRIPTION
When receiving the INT signal (e.g. from Ctrl+C), the behavior of most shells is to cancel the current line of input and provide a fresh prompt. This change would provide an option to specify this behavior by setting a flag (attribute). The default behavior would of course respect backwards compatibility.

As someone new to the code base, I was wondering a few things while exploring.
1. Is the attribute defined in a good spot and is this attribute the best way to add the option of this functionality.
2. Is there another entry point besides _cmdloop where a change might be necessary?
3. Is there a cleaner way to test without the little SayApp that I made?

Also whether or not to print out the "^C" would be a matter of preference. It seems like Bash does this, but Zsh doesn't, for example (with my configurations, at least).