### PR TITLE
Fix/add completion for shell commands when default_to_shell is True

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1357,12 +1357,14 @@ class Cmd(cmd.Cmd):
                 if command == '':
                     compfunc = self.completedefault
                 else:
-
                     # Get the completion function for this command
                     try:
                         compfunc = getattr(self, 'complete_' + command)
                     except AttributeError:
-                        compfunc = self.completedefault
+                        if self.default_to_shell and command in self._get_exes_in_path(command, False):
+                            compfunc = functools.partial(path_complete)
+                        else:
+                            compfunc = self.completedefault
 
                     # If there are subcommands, then try completing those if the cursor is in
                     # index 1 of the command tokens


### PR DESCRIPTION
Currently, path completion works for shell commands when they are run in either the `shell <name>` form or in the `!<name>` form, but not in the plain `<name>` form when `default_to_shell` is set to `True`

This change would allow for path completion for a command if `default_to_shell` is `True` and the currently-typed command is in the users's path (as determined by the _get_exes_in_path method)

One thing I was wondering was if there was an effective difference between:
`compfunc = functools.partial(path_complete)` and `compfunc = path_complete`

I saw the former in other parts of the source, so I stuck to that choice for this change, but I was curious if there was a reason for this.