### PR TITLE
Added ability to specify a startup_script in cmd2.Cmd.__init__()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
     * Added [quit_on_sigint](http://cmd2.readthedocs.io/en/latest/settingchanges.html#quit-on-sigint) attribute to enable canceling current line instead of quitting when Ctrl+C is typed
     * Added possibility of having readline history preservation in a SubMenu
     * Added [table_display.py](https://github.com/python-cmd2/cmd2/blob/master/examples/table_display.py) example to demonstrate how to display tabular data
-    * Added command aliasing with ``alias`` command
+    * Added command aliasing with ``alias`` and ``unalias`` commands
+    * Added the ability to load an initialization script at startup
+        * See [alias_startup.py](https://github.com/python-cmd2/cmd2/blob/master/examples/alias_startup.py) for an example
     
 ## 0.8.1 (March 9, 2018)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Main Features
 - Option to display long output using a pager with ``cmd2.Cmd.ppaged()``
 - Multi-line commands
 - Special-character command shortcuts (beyond cmd's `@` and `!`)
-- Command aliasing and loading a commands at startup from an initialization script
+- Command aliasing similar to bash `alias` command
+- Ability to load commands at startup from an initialization script
 - Settable environment parameters
 - Parsing commands with arguments using `argparse`, including support for sub-commands
 - Sub-menu support via the ``AddSubmenu`` decorator

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Main Features
 - Option to display long output using a pager with ``cmd2.Cmd.ppaged()``
 - Multi-line commands
 - Special-character command shortcuts (beyond cmd's `@` and `!`)
-- Command aliasing
+- Command aliasing and loading a commands at startup from an initialization script
 - Settable environment parameters
 - Parsing commands with arguments using `argparse`, including support for sub-commands
 - Sub-menu support via the ``AddSubmenu`` decorator

--- a/cmd2.py
+++ b/cmd2.py
@@ -1088,7 +1088,7 @@ class Cmd(cmd.Cmd):
                 'timing': 'Report execution times'}
 
     def __init__(self, completekey='tab', stdin=None, stdout=None, persistent_history_file='',
-                 persistent_history_length=1000, use_ipython=False, transcript_files=None):
+                 persistent_history_length=1000, startup_script=None, use_ipython=False, transcript_files=None):
         """An easy but powerful framework for writing line-oriented command interpreters, extends Python's cmd package.
 
         :param completekey: str - (optional) readline name of a completion key, default to Tab
@@ -1096,6 +1096,7 @@ class Cmd(cmd.Cmd):
         :param stdout: (optional) alternate output file object, if not specified, sys.stdout is used
         :param persistent_history_file: str - (optional) file path to load a persistent readline history from
         :param persistent_history_length: int - (optional) max number of lines which will be written to the history file
+        :param startup_script: str - (optional) file path to a a script to load and execute at startup
         :param use_ipython: (optional) should the "ipy" command be included for an embedded IPython shell
         :param transcript_files: str - (optional) allows running transcript tests when allow_cli_args is False
         """
@@ -1179,6 +1180,10 @@ class Cmd(cmd.Cmd):
 
         # If this string is non-empty, then this warning message will print if a broken pipe error occurs while printing
         self.broken_pipe_warning = ''
+
+        # If a startup script is provided, then add it in the queue to load
+        if startup_script is not None:
+            self.cmdqueue.append('load {}'.format(startup_script))
 
     # -----  Methods related to presenting output to the user -----
 

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -52,6 +52,19 @@ be pointless within an interactive session.
 .. _pyparsing: http://pyparsing.wikispaces.com/
 .. _arg_print: https://github.com/python-cmd2/cmd2/blob/master/examples/arg_print.py
 
+Startup Initialization Script
+=============================
+You can load and execute commands from a startup initialization script by passing a file path to the ``startup_script``
+argument to the ``cmd.Cmd.__init__()`` method like so::
+
+    class AliasAndStartup(cmd2.Cmd):
+    def __init__(self):
+        cmd2.Cmd.__init__(self, startup_script='.cmd2rc')
+
+See the AliasStartup_ example for a demonstration.
+
+.. _AliasStartup: https://github.com/python-cmd2/cmd2/blob/master/examples/alias_startup.py
+
 Commands at invocation
 ======================
 

--- a/docs/settingchanges.rst
+++ b/docs/settingchanges.rst
@@ -10,7 +10,7 @@ its name is included in the dictionary ``app.settable``.
 
 
 Shortcuts
-===========================
+=========
 
 Command shortcuts for long command names and common commands can make life more convenient for your users.
 Shortcuts are used without a space separating them from their arguments, like ``!ls``.  By default, the
@@ -48,7 +48,7 @@ To define more shortcuts, update the dict ``App.shortcuts`` with the
 
 
 Aliases
-================
+=======
 
 In addition to shortcuts, ``cmd2`` provides a full alias feature via the ``alias`` command which is similar to the
 ``alias`` command in Bash.

--- a/examples/.cmd2rc
+++ b/examples/.cmd2rc
@@ -1,0 +1,2 @@
+alias ls !ls -hal
+alias pwd !pwd

--- a/examples/alias_startup.py
+++ b/examples/alias_startup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""A simple example demonstrating the following:
+    1) How to add custom command aliases using the alias command
+    2) How to load an initialization script at startup
+"""
+import argparse
+
+import cmd2
+import pyparsing
+
+from cmd2 import with_argument_list, with_argparser, with_argparser_and_unknown_args
+
+
+class AliasAndStartup(cmd2.Cmd):
+    """ Example cmd2 application where we create commands that just print the arguments they are called with."""
+
+    def __init__(self):
+        cmd2.Cmd.__init__(self, startup_script='.cmd2rc')
+
+
+if __name__ == '__main__':
+    app = AliasAndStartup()
+    app.cmdloop()


### PR DESCRIPTION
This fixes #317.

This is intended primarily to make using the new **alias** command more powerful, but has a much broader use case in that it allows individual users to customize their initialization of a ``cmd2`` application and to always run a set of commands at startup. 