### PR TITLE
Added default sigint handler

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -1501,7 +1501,7 @@ class Cmd(cmd.Cmd):
     def preloop(self):
         """Hook method executed once when the cmdloop() method is called."""
         # Register a default SIGINT signal handler for Ctrl+C
-        signal.signal(signalnum=signal.SIGINT, handler=self.sigint_handler)
+        signal.signal(signal.SIGINT, self.sigint_handler)
 
     def precmd(self, statement):
         """Hook method executed just before the command is processed by ``onecmd()`` and after adding it to the history.

--- a/cmd2.py
+++ b/cmd2.py
@@ -1496,7 +1496,7 @@ class Cmd(cmd.Cmd):
             pipe_proc.terminate()
 
         # Re-raise a KeyboardInterrupt so other parts of the code can catch it
-        raise KeyboardInterrupt("Got a keyboard interrupt within a Python script")
+        raise KeyboardInterrupt("Got a keyboard interrupt")
 
     def preloop(self):
         """Hook method executed once when the cmdloop() method is called."""

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -63,11 +63,11 @@ class SubcommandsExample(cmd2.Cmd):
     @with_argparser(base_parser)
     def do_base(self, args):
         """Base command help"""
-        try:
+        if args.func is not None:
             # Call whatever subcommand function was selected
             args.func(self, args)
-        except AttributeError:
-            # No subcommand was provided, so as called
+        else:
+            # No subcommand was provided, so call help
             self.do_help('base')
 
     # functools.partialmethod was added in Python 3.4

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -915,6 +915,8 @@ def say_app():
     return app
 
 def test_interrupt_quit(say_app):
+    say_app.quit_on_sigint = True
+
     # Mock out the input call so we don't actually wait for a user's response on stdin
     m = mock.MagicMock(name='input')
     m.side_effect = ['say hello', KeyboardInterrupt(), 'say goodbye', 'eof']


### PR DESCRIPTION
This is an attempt to improve the out-of-the-box way in which Ctrl-C is handled.

Added a default signal handler for SIGINT that does the following:
- Terminates a pipe process if one exists
- Raises a KeyboardInterrupt for other parts of the code to catch

Also:
- Changed the default value for quit_on_sigint to False
- Modified the way the subcommand functions are called in subcommand.py (unrelated to rest of PR)