### PR TITLE
Added preference for gnureadline Python module when available

### DIFF
--- a/cmd2.py
+++ b/cmd2.py
@@ -88,13 +88,17 @@ try:
 except ImportError:
     ipython_available = False
 
-# Try to import readline, but allow failure for convenience in Windows unit testing
-# Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
+# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
 try:
-    # noinspection PyUnresolvedReferences
-    import readline
+    import gnureadline as readline
 except ImportError:
-    pass
+    # Try to import readline, but allow failure for convenience in Windows unit testing
+    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
+    try:
+        # noinspection PyUnresolvedReferences
+        import readline
+    except ImportError:
+        pass
 
 # BrokenPipeError and FileNotFoundError exist only in Python 3. Use IOError for Python 2.
 if six.PY3:

--- a/cmd2.py
+++ b/cmd2.py
@@ -1381,7 +1381,6 @@ class Cmd(cmd.Cmd):
         :param state: int - non-negative integer
         """
         if state == 0:
-            import readline
             origline = readline.get_line_buffer()
             line = origline.lstrip()
             stripped = len(origline) - len(line)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,10 @@ The basic use of ``cmd2`` is identical to that of cmd_.
 
    The tab-completion feature provided by cmd_ relies on underlying capability provided by GNU readline or an
    equivalent library.  Linux distros will almost always come with the required library installed.
-   For macOS, we recommend using the `Homebrew <https://brew.sh>`_ package manager to install the ``readline`` package;
-   alternatively for macOS the ``conda`` package manager that comes with the Anaconda Python distro can be used to
-   install ``readline`` (preferably from conda-forge).
+   For macOS, we recommend using the `gnureadline <https://pypi.python.org/pypi/gnureadline>`_ Python module which includes
+   a statically linked version of GNU readline.  Alternatively on macOS the ``conda`` package manager that comes
+   with the Anaconda Python distro can be used to install ``readline`` (preferably from conda-forge) or the
+   `Homebrew <https://brew.sh>`_ package manager can be used to to install the ``readline`` package.
    For Windows, we recommend installing the `pyreadline <https://pypi.python.org/pypi/pyreadline>`_ Python module.
 
 Resources

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,5 +1,4 @@
 
-=========================
 Installation Instructions
 =========================
 
@@ -138,5 +137,33 @@ Extra requirement for Python 2.7 only
 If you want to be able to pipe the output of commands to a shell command on Python 2.7, then you will need one
 additional package installed:
 
-  * subprocess32
+  * subprocess32gNU
 
+Extra requirement for macOS
+===========================
+macOS comes with the `libedit <http://thrysoee.dk/editline/>`_ library which is similar, but not identical, to GNU Readline.
+Tab-completion for ``cmd2`` applications is only tested against GNU Readline.
+
+There are several ways GNU Readline can be installed within a Python environment on a Mac, detailed in the following subsections.
+
+gnureadline Python module
+-------------------------
+Install the `gnureadline <https://pypi.python.org/pypi/gnureadline>`_ Python module which is statically linked against a specific compatible version of GNU Readline::
+
+  pip install -U gnureadline
+
+readline via conda
+------------------
+Install the **readline** package using the ``conda`` package manager included with the Anaconda Python distribution::
+
+  conda install readline
+
+readline via brew
+-----------------
+Install the **readline** package using the Homebrew package manager (compiles from source)::
+
+  brew install openssl
+  brew install pyenv
+  brew install readline
+
+Then use pyenv to compile Python and link against the installed readline


### PR DESCRIPTION
About 10 months ago preference for the ``gnureadline`` Python module over the ``readline`` module was removed due to a crash bug in the ``gnureadline`` module:
https://github.com/python-cmd2/cmd2/commit/59f80590a742a6461d5a3535f25853a34aae13c8#commitcomment-28143061

Since that bug is now fixed, this PR adds back in the preference for ``gnureadline``.  ``gnureadline`` is intended for use on macOS and it is statically linked against a specific compatible version of GNU Readline.  ``gnureadline`` is easily installable via **pip** and can thus be an easier way to get a GNU Readline library as compared to either **conda** or **brew**.

Also updated documentation to make it a little more clear how to get a compatible version of GNU Readline installed on macOS.