### PR TITLE
Fix unit tests on macOS when gnureadline is installed

### DIFF
--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -5,7 +5,6 @@ Cmd2 testing for argument parsing
 import argparse
 import functools
 import pytest
-import readline
 import sys
 
 import cmd2
@@ -13,6 +12,18 @@ import mock
 import six
 
 from conftest import run_cmd, StdOut
+
+# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
+try:
+    import gnureadline as readline
+except ImportError:
+    # Try to import readline, but allow failure for convenience in Windows unit testing
+    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
+    try:
+        # noinspection PyUnresolvedReferences
+        import readline
+    except ImportError:
+        pass
 
 
 class ArgparseApp(cmd2.Cmd):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -10,7 +10,6 @@ Released under MIT license, see LICENSE file
 """
 import argparse
 import os
-import readline
 import sys
 
 import cmd2
@@ -18,6 +17,19 @@ import mock
 import pytest
 
 from cmd2 import path_complete, basic_complete, flag_based_complete, index_based_complete
+
+# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
+try:
+    import gnureadline as readline
+except ImportError:
+    # Try to import readline, but allow failure for convenience in Windows unit testing
+    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
+    try:
+        # noinspection PyUnresolvedReferences
+        import readline
+    except ImportError:
+        pass
+
 
 @pytest.fixture
 def cmd2_app():


### PR DESCRIPTION
As similar try/except needed to be added to a couple unit test files to try to import gnureadline as readline and fallback to importing readline.