### PR TITLE
New quoted completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.3 (TBD)
 * Bug Fixes
     * Fixed ``help`` command not calling functions for help topics
+    * Fixed not being able to use quoted paths when redirecting with ``<`` and ``>``
 
 * Enhancements
     * Tab completion has been overhauled and now supports completion of strings with quotes and spaces.
@@ -8,9 +9,7 @@
     * Added more control over tab completion behavior including the following flags. The use of these flags is documented in cmd2.py
         * ``allow_appended_space``
         * ``allow_closing_quote``
-        * ``display_entire_match``
-        * ``display_match_delimiter``
-        
+
 * Attribute Changes (Breaks backward compatibility)
     * ``exclude_from_help`` is now called ``hidden_commands`` since these commands are hidden from things other than help, including tab completion
         * This list also no longer takes the function names of commands (``do_history``), but instead uses the command names themselves (``history``)
@@ -33,7 +32,7 @@
         * See [alias_startup.py](https://github.com/python-cmd2/cmd2/blob/master/examples/alias_startup.py) for an example
     * Added a default SIGINT handler which terminates any open pipe subprocesses and re-raises a KeyboardInterrupt
     * For macOS, will load the ``gnureadline`` module if available and ``readline`` if not
-    
+
 ## 0.8.1 (March 9, 2018)
 
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
         * ``display_entire_match``
         * ``display_match_delimiter``
         
-* Attributes Changes
-    * ``exclude_from_help`` is now called ``hidden_commands`` since these commands hidden from things other than help, including tab completion
+* Attribute Changes (Breaks backward compatibility)
+    * ``exclude_from_help`` is now called ``hidden_commands`` since these commands are hidden from things other than help, including tab completion
+        * This list also no longer takes the function names of commands (``do_history``), but instead uses the command names themselves (``history``)
     * ``excludeFromHistory`` is now called ``exclude_from_history``
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
     * ``exclude_from_help`` is now called ``hidden_commands`` since these commands are hidden from things other than help, including tab completion
         * This list also no longer takes the function names of commands (``do_history``), but instead uses the command names themselves (``history``)
     * ``excludeFromHistory`` is now called ``exclude_from_history``
+    * ``cmd_with_subs_completer()`` no longer takes an argument called ``base``. Adding tab completion to subcommands has been simplified to declaring it in the
+    subcommand parser's default settings. This easily allows arbitrary completers like path_complete to be used.
+    See [subcommands.py](https://github.com/python-cmd2/cmd2/blob/master/examples/subcommands.py) for an example of how to use
+    tab completion in subcommands. In addition, the docstring for ``cmd_with_subs_completer()`` offers more details.
 
 
 ## 0.8.2 (March 21, 2018)
@@ -75,7 +79,7 @@
     *  See the [Argument Processing](http://cmd2.readthedocs.io/en/latest/argument_processing.html) section of the documentation for more information on these decorators
         * Alternatively, see the [argparse_example.py](https://github.com/python-cmd2/cmd2/blob/master/examples/argparse_example.py)
         and [arg_print.py](https://github.com/python-cmd2/cmd2/blob/master/examples/arg_print.py) examples
-    * Added support for Argpasre sub-commands when using the **with_argument_parser** or **with_argparser_and_unknown_args** decorators
+    * Added support for Argparse sub-commands when using the **with_argument_parser** or **with_argparser_and_unknown_args** decorators
         * See [subcommands.py](https://github.com/python-cmd2/cmd2/blob/master/examples/subcommands.py) for an example of how to use subcommands
         * Tab-completion of sub-command names is automatically supported
     * The **__relative_load** command is now hidden from the help menu by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.8.3 (TBD)
+* Bug Fixes
+    * Fixed ``help`` command not calling functions for help topics
+
+* Enhancements
+    * Tab completion has been overhauled and now supports completion of strings with quotes and spaces.
+    * Tab completion will automatically add an opening quote if a string with a space is completed.
+    * Added more control over tab completion behavior including the following flags. The use of these flags is documented in cmd2.py
+        * ``allow_appended_space``
+        * ``allow_closing_quote``
+        * ``display_entire_match``
+        * ``display_match_delimiter``
+        
+* Attributes Changes
+    * ``exclude_from_help`` is now called ``hidden_commands`` since these commands hidden from things other than help, including tab completion
+    * ``excludeFromHistory`` is now called ``exclude_from_history``
+
+
 ## 0.8.2 (March 21, 2018)
 
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enhancements
     * Tab completion has been overhauled and now supports completion of strings with quotes and spaces.
     * Tab completion will automatically add an opening quote if a string with a space is completed.
+    * Added ``delimiter_complete`` function for tab completing delimited strings
     * Added more control over tab completion behavior including the following flags. The use of these flags is documented in cmd2.py
         * ``allow_appended_space``
         * ``allow_closing_quote``

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Instructions for implementing each feature follow.
 
 - Searchable command history
 
-    All commands will automatically be tracked in the session's history, unless the command is listed in Cmd's excludeFromHistory attribute.
+    All commands will automatically be tracked in the session's history, unless the command is listed in Cmd's exclude_from_history attribute.
     The history is accessed through the `history` command.
     If you wish to exclude some of your custom commands from the history, append their names
-    to the list at `Cmd.ExcludeFromHistory`.
+    to the list at `Cmd.exclude_from_history`.
 
 - Load commands from file, save to file, edit commands in file
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -584,7 +584,7 @@ def path_complete(text, line, begidx, endidx, dir_exe_only=False, dir_only=False
             # This is a directory, so don't add a space or quote
             set_allow_appended_space(False)
             set_allow_closing_quote(False)
-            return ["~" + os.path.sep]
+            return [completion_token + os.path.sep]
 
         elif completion_token.startswith('~'):
             # Tilde without separator between path is invalid

--- a/cmd2.py
+++ b/cmd2.py
@@ -1930,15 +1930,7 @@ class Cmd(cmd.Cmd):
                             return self.completion_matches[state]
 
                 # Check if a valid command was entered
-                if command not in self.get_all_commands():
-                    # Check if this command should be run as a shell command
-                    if self.default_to_shell and command in get_exes_in_path(command):
-                        compfunc = functools.partial(path_complete)
-                    else:
-                        compfunc = self.completedefault
-
-                # A valid command was entered
-                else:
+                if command in self.get_all_commands():
                     # Get the completer function for this command
                     try:
                         compfunc = getattr(self, 'complete_' + command)
@@ -1953,6 +1945,14 @@ class Cmd(cmd.Cmd):
                         compfunc = functools.partial(index_based_complete,
                                                      index_dict=index_dict,
                                                      all_else=compfunc)
+
+                # A valid command was not entered
+                else:
+                    # Check if this command should be run as a shell command
+                    if self.default_to_shell and command in get_exes_in_path(command):
+                        compfunc = functools.partial(path_complete)
+                    else:
+                        compfunc = self.completedefault
 
                 # Call the completer function
                 self.completion_matches = compfunc(text, line, begidx, endidx)

--- a/cmd2.py
+++ b/cmd2.py
@@ -134,14 +134,13 @@ except ImportError:
         pass
 
 
-# Tells what implementation of readline we are using
+# Check what implementation of readline we are using
 class RlType(Enum):
     GNU = 1
     PYREADLINE = 2
     NONE = 3
 
 
-# Check what implementation of readline we are using
 rl_type = RlType.NONE
 
 if 'pyreadline' in sys.modules:
@@ -151,24 +150,16 @@ if 'pyreadline' in sys.modules:
     # noinspection PyProtectedMember
     orig_pyreadline_display = readline.rl.mode._display_completions
 
-else:
-    readline_lib_path = ''
-
-    if 'gnureadline' in sys.modules:
-        readline_lib_path = sys.modules['gnureadline'].__dict__['__file__']
-    elif 'readline' in sys.modules:
-        readline_lib_path = sys.modules['readline'].__dict__['__file__']
+elif 'gnureadline' in sys.modules or 'readline' in sys.modules:
+    rl_type = RlType.GNU
 
     # Load the readline lib so we can make changes to it
-    if readline_lib_path:
-        rl_type = RlType.GNU
+    import ctypes
+    readline_lib = ctypes.CDLL(readline.__file__)
 
-        import ctypes
-        readline_lib = ctypes.CDLL(readline_lib_path)
-
-        # Save address that rl_basic_quote_characters is pointing to since we need to override and restore it
-        rl_basic_quote_characters = ctypes.c_char_p.in_dll(readline_lib, "rl_basic_quote_characters")
-        orig_rl_basic_quote_characters_addr = ctypes.cast(rl_basic_quote_characters, ctypes.c_void_p).value
+    # Save address that rl_basic_quote_characters is pointing to since we need to override and restore it
+    rl_basic_quote_characters = ctypes.c_char_p.in_dll(readline_lib, "rl_basic_quote_characters")
+    orig_rl_basic_quote_characters_addr = ctypes.cast(rl_basic_quote_characters, ctypes.c_void_p).value
 
 
 # BrokenPipeError and FileNotFoundError exist only in Python 3. Use IOError for Python 2.

--- a/cmd2.py
+++ b/cmd2.py
@@ -323,9 +323,8 @@ def tokens_for_completion(line, begidx, endidx, preserve_quotes=False):
 
     while True:
         try:
-            # This type of parsing works better than shlex.split() which doesn't seem to treat > as an individual token.
             # Use non-POSIX parsing to keep the quotes around the tokens.
-            tokens = list(shlex.shlex(tmp_line[:tmp_endidx], posix=False))
+            tokens = shlex.split(tmp_line[:tmp_endidx], posix=False)
             break
         except ValueError:
             # ValueError can be caused by missing closing quote

--- a/cmd2.py
+++ b/cmd2.py
@@ -1906,17 +1906,17 @@ class Cmd(cmd.Cmd):
                     return None
 
                 # Get the status of quotes in the token being completed
-                completion_token = raw_tokens[-1]
+                raw_completion_token = raw_tokens[-1]
 
-                if len(completion_token) == 1:
+                if len(raw_completion_token) == 1:
                     # Check if the token being completed has an unclosed quote
-                    first_char = completion_token[0]
+                    first_char = raw_completion_token[0]
                     if first_char in QUOTES:
                         unclosed_quote = first_char
 
-                elif len(completion_token) > 1:
-                    first_char = completion_token[0]
-                    last_char = completion_token[-1]
+                elif len(raw_completion_token) > 1:
+                    first_char = raw_completion_token[0]
+                    last_char = raw_completion_token[-1]
 
                     # Check if the token being completed has an unclosed quote
                     if first_char in QUOTES and first_char != last_char:
@@ -1925,7 +1925,7 @@ class Cmd(cmd.Cmd):
                     # If the cursor is right after a closed quote, then insert a space
                     else:
                         prior_char = line[begidx - 1]
-                        if not unclosed_quote and prior_char in QUOTES:
+                        if prior_char in QUOTES:
                             self.completion_matches = [' ']
                             return self.completion_matches[state]
 
@@ -1963,11 +1963,11 @@ class Cmd(cmd.Cmd):
                     common_prefix = os.path.commonprefix(self.completion_matches)
 
                     # Check if we need to add an opening quote
-                    if len(completion_token) == 0 or completion_token[0] not in QUOTES:
+                    if len(raw_completion_token) == 0 or raw_completion_token[0] not in QUOTES:
 
                         # If anything that will be in the token being completed contains a space, then
                         # we must add an opening quote to the token on screen
-                        if ' ' in completion_token or ' ' in common_prefix:
+                        if ' ' in raw_completion_token or ' ' in common_prefix:
 
                             # Mark that there is now an unclosed quote
                             unclosed_quote = '"'
@@ -2012,7 +2012,7 @@ class Cmd(cmd.Cmd):
                                     # the original values of begidx and endidx and we can't change them. Therefore we
                                     # must prepend to every match the character right before the text variable so it
                                     # doesn't get erased.
-                                    saved_char = completion_token[(len(text) + 1) * -1]
+                                    saved_char = raw_completion_token[(len(text) + 1) * -1]
                                     self.completion_matches = [saved_char + match for match in self.completion_matches]
 
                                 # pyreadline specific way to insert an opening quote

--- a/cmd2.py
+++ b/cmd2.py
@@ -1667,6 +1667,10 @@ class Cmd(cmd.Cmd):
             # have to use ctypes to do it since Python's readline API does not wrap the function
             readline_lib.rl_forced_update_display()
 
+            # Let readline know that we manually did a redisplay
+            display_fixed = ctypes.c_int.in_dll(readline_lib, "rl_display_fixed")
+            display_fixed.value = 1
+
     @staticmethod
     def _display_matches_pyreadline(matches):
         """

--- a/cmd2.py
+++ b/cmd2.py
@@ -1887,6 +1887,13 @@ class Cmd(cmd.Cmd):
                 # Get all tokens through the one being completed
                 tokens = tokens_for_completion(line, begidx, endidx, preserve_quotes=True)
 
+                # Either had a parsing error or are trying to complete the command token
+                # The latter can happen if default_to_shell is True and parseline() allowed
+                # assumed something like " or ' was a command.
+                if tokens is None or len(tokens) == 1:
+                    self.completion_matches = []
+                    return None
+
                 # Get the status of quotes in the token being completed
                 completion_token = tokens[-1]
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -44,7 +44,11 @@ import tempfile
 import traceback
 import unittest
 from code import InteractiveConsole
-from enum import Enum
+
+try:
+    from enum34 import Enum
+except ImportError:
+    from enum import Enum
 
 import pyparsing
 import pyperclip
@@ -2137,7 +2141,7 @@ class Cmd(cmd.Cmd):
                 if self.allow_appended_space and endidx == len(line):
                     str_to_append += ' '
 
-                self.completion_matches[0] = self.completion_matches[0] + str_to_append
+                self.completion_matches[0] += str_to_append
 
         try:
             return self.completion_matches[state]

--- a/cmd2.py
+++ b/cmd2.py
@@ -1576,15 +1576,15 @@ class Cmd(cmd.Cmd):
             self.allow_closing_quote = False
 
         # Build display_matches and add a slash to directories
-        for cur_match in completion_matches:
+        for index, cur_match in enumerate(completion_matches):
 
             # Display only the basename of this path in the tab-completion suggestions
             self.display_matches.append(os.path.basename(cur_match))
 
             # Add a separator after directories if the next character isn't already a separator
             if os.path.isdir(cur_match) and add_trailing_sep_if_dir:
-                completion_matches[-1] += os.path.sep
-                self.display_matches[-1] += os.path.sep
+                completion_matches[index] += os.path.sep
+                self.display_matches[index] += os.path.sep
 
         # Remove cwd if it was added
         if cwd_added:

--- a/cmd2.py
+++ b/cmd2.py
@@ -1373,7 +1373,7 @@ class Cmd(cmd.Cmd):
 
             # Since redirection is enabled, we need to treat redirection characters (|, <, >)
             # as word breaks when they are in unquoted strings. Go through each token
-            # and further split them these characters. Each run of redirect characters
+            # and further split them on these characters. Each run of redirect characters
             # is treated as a single token.
             raw_tokens = []
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -1777,32 +1777,30 @@ class Cmd(cmd.Cmd):
                             self.completion_matches = [' ']
                             return self.completion_matches[state]
 
-                # Otherwise select a completer function
-                if command == '':
-                    compfunc = self.completedefault
-                else:
+                # Check if a valid command was entered
+                if command not in self.get_command_names():
+                    # Check if this command should be run as a shell command
+                    if self.default_to_shell and command in self._get_exes_in_path(command):
+                        compfunc = functools.partial(path_complete)
+                    else:
+                        compfunc = self.completedefault
 
+                # A valid command was entered
+                else:
                     # Get the completer function for this command
-                    is_shell_command = False
                     try:
                         compfunc = getattr(self, 'complete_' + command)
                     except AttributeError:
-                        # Check if this command should be run as a shell command
-                        if self.default_to_shell and command in self._get_exes_in_path(command):
-                            compfunc = functools.partial(path_complete)
-                            is_shell_command = True
-                        else:
-                            compfunc = self.completedefault
+                        compfunc = self.completedefault
 
-                    if not is_shell_command:
-                        # If there are subcommands, then try completing those if the cursor is in
-                        # the token at index 1, otherwise default to using compfunc
-                        subcommands = self.get_subcommands(command)
-                        if subcommands is not None:
-                            index_dict = {1: subcommands}
-                            compfunc = functools.partial(index_based_complete,
-                                                         index_dict=index_dict,
-                                                         all_else=compfunc)
+                    # If there are subcommands, then try completing those if the cursor is in
+                    # the token at index 1, otherwise default to using compfunc
+                    subcommands = self.get_subcommands(command)
+                    if subcommands is not None:
+                        index_dict = {1: subcommands}
+                        compfunc = functools.partial(index_based_complete,
+                                                     index_dict=index_dict,
+                                                     all_else=compfunc)
 
                 # Call the completer function
                 self.completion_matches = compfunc(text, line, begidx, endidx)

--- a/cmd2.py
+++ b/cmd2.py
@@ -1878,7 +1878,6 @@ class Cmd(cmd.Cmd):
         :return: None
         """
         orig_line = readline.get_line_buffer()
-        begidx = readline.get_begidx()
         endidx = readline.get_endidx()
 
         starting_index = orig_line[:endidx].rfind(raw_completion_token)

--- a/cmd2.py
+++ b/cmd2.py
@@ -2785,7 +2785,8 @@ Usage:  Usage: alias [<name> <value>]
         value - what the alias will be resolved to
                 this can contain spaces and does not need to be quoted
 
-    Without arguments, `alias' prints a list of all aliases in a resuable form
+    Without arguments, 'alias' prints a list of all aliases in a reusable form which
+    can be outputted to a startup_script to preserve aliases across sessions.
 
     Example: alias ls !ls -lF
 """

--- a/cmd2.py
+++ b/cmd2.py
@@ -1346,7 +1346,7 @@ class Cmd(cmd.Cmd):
         Performs tab completion against a list
         This is ultimately called by many completer functions like flag_based_complete and index_based_complete.
         It can also be used by custom completer functions and that is the suggested approach since this function
-        handles things like tab completions with spaces as well as the display_entire_match flag.
+        handles things like tab completions with spaces.
 
         :param text: str - the string prefix we are attempting to match (all returned matches must begin with it)
         :param line: str - the current input line with leading whitespace removed

--- a/cmd2.py
+++ b/cmd2.py
@@ -54,10 +54,14 @@ import pyperclip
 try:
     from collections.abc import Collection
 except ImportError:
-    import collections.abc as abc
+
+    if six.PY3:
+        from collections.abc import Sized, Iterable, Container
+    else:
+        from collections import Sized, Iterable, Container
 
     # noinspection PyAbstractClass
-    class Collection(abc.Sized, abc.Iterable, abc.Container):
+    class Collection(Sized, Iterable, Container):
 
         __slots__ = ()
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -3106,13 +3106,12 @@ Usage:  Usage: unalias [-a] name [name ...]
             begidx -= diff
             endidx -= diff
 
-            # Call the subcommand specific completer
+            # Call the subcommand specific completer if it exists
             completer = 'complete_{}_{}'.format(base, subcommand)
-            try:
-                compfunc = getattr(self, completer)
+            compfunc = getattr(self, completer, None)
+
+            if compfunc is not None:
                 matches = compfunc(text, line, begidx, endidx)
-            except AttributeError:
-                pass
 
         return matches
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -1924,7 +1924,7 @@ class Cmd(cmd.Cmd):
                 else:
                     # Check if this command should be run as a shell command
                     if self.default_to_shell and command in self.get_exes_in_path(command):
-                        compfunc = functools.partial(self.path_complete)
+                        compfunc = self.path_complete
                     else:
                         compfunc = self.completedefault
 

--- a/cmd2.py
+++ b/cmd2.py
@@ -1036,7 +1036,7 @@ class Cmd(cmd.Cmd):
         self.allow_closing_quote = True
 
         # If the tab-completion matches should be displayed in a way that is different than the actual match values,
-        # then place those results in this list.
+        # then place those results in this list. path_complete uses this to show only the basename of completions.
         self.display_matches = []
 
     # -----  Methods related to presenting output to the user -----

--- a/cmd2.py
+++ b/cmd2.py
@@ -203,7 +203,7 @@ STRIP_QUOTES_FOR_NON_POSIX = True
 # For @options commands, pass a list of argument strings instead of a single argument string to the do_* methods
 USE_ARG_LIST = True
 
-# Used for tab completion. Do not change.
+# Used for tab completion and word breaks. Do not change.
 QUOTES = ['"', "'"]
 REDIRECTION_CHARS = ['|', '<', '>']
 
@@ -1061,7 +1061,7 @@ class Cmd(cmd.Cmd):
         self.allow_appended_space = True
 
         # If true and a single match is returned to complete(), then a closing quote
-        # will be added if there is an umatched opening quote
+        # will be added if there is an unmatched opening quote
         self.allow_closing_quote = True
 
         # If the tab-completion matches should be displayed in a way that is different than the actual match values,
@@ -2718,7 +2718,7 @@ class Cmd(cmd.Cmd):
                 readline.set_completer(self.complete)
 
                 # Break words on whitespace and quotes when tab completing
-                completer_delims = " \t\n\"'"
+                completer_delims = " \t\n" + ''.join(QUOTES)
 
                 if self.allow_redirection:
                     # If redirection is allowed, then break words on those characters too

--- a/cmd2.py
+++ b/cmd2.py
@@ -1911,14 +1911,14 @@ class Cmd(cmd.Cmd):
                     except AttributeError:
                         compfunc = self.completedefault
 
-                    # If there are subcommands, then try completing those if the cursor is in
-                    # the token at index 1, otherwise default to using compfunc
                     subcommands = self.get_subcommands(command)
                     if subcommands is not None:
+                        # Since there are subcommands, then try completing those if the cursor is in
+                        # the token at index 1, otherwise default to using compfunc
                         index_dict = {1: subcommands}
-                        compfunc = functools.partialmethod(self.index_based_complete,
-                                                           index_dict=index_dict,
-                                                           all_else=compfunc)
+                        compfunc = functools.partial(self.index_based_complete,
+                                                     index_dict=index_dict,
+                                                     all_else=compfunc)
 
                 # A valid command was not entered
                 else:
@@ -2904,10 +2904,11 @@ Usage:  Usage: unalias [-a] name [name ...]
             To make sure these functions get called, set the tab-completer for the print function
             in a similar fashion to what follows where base is the name of the root command (print)
 
-            complete_print = functools.partialmethod(cmd2.Cmd.cmd_with_subs_completer, base='print')
+            def complete_print(self, text, line, begidx, endidx):
+                return self.cmd_with_subs_completer(text, line, begidx, endidx, base='print')
 
             When the subcommand's completer is called, this function will have stripped off all content from the
-            beginning of he command line before the subcommand, meaning the line parameter always starts with the
+            beginning of the command line before the subcommand, meaning the line parameter always starts with the
             subcommand name and the index parameters reflect this change.
 
             For instance, the command "print names -d 2" becomes "names -d 2"

--- a/cmd2.py
+++ b/cmd2.py
@@ -1330,8 +1330,8 @@ class Cmd(cmd.Cmd):
 
             for cur_initial_token in initial_tokens:
 
-                # Keep empty and quoted tokens
-                if len(cur_initial_token) == 0 or cur_initial_token[0] in QUOTES:
+                # Save tokens up to 1 character in length or quoted tokens. No need to parse these.
+                if len(cur_initial_token) <= 1 or cur_initial_token[0] in QUOTES:
                     raw_tokens.append(cur_initial_token)
                     continue
 
@@ -2068,20 +2068,23 @@ class Cmd(cmd.Cmd):
                         self.completion_matches = []
                         return None
 
-                    # Check if we need to remove text from the beginning of tab completions
-                    if text_to_remove:
-                        self.completion_matches = [m.replace(text_to_remove, '', 1) for m in self.completion_matches]
-
-                    # Check if we need to restore a shortcut in the tab completions
-                    if shortcut_to_restore:
+                    if text_to_remove or shortcut_to_restore:
                         # If self.display_matches is empty, then set it to self.completion_matches
-                        # before we restore the shortcut so the tab completion suggestions that display to
-                        # the user don't have the shortcut character.
+                        # before we alter them. That way the suggestions will reflect how we parsed
+                        # the token being completed and not how readline did.
                         if len(self.display_matches) == 0:
                             self.display_matches = self.completion_matches
 
-                        # Prepend all tab completions with the shortcut so it doesn't get erased from the command line
-                        self.completion_matches = [shortcut_to_restore + match for match in self.completion_matches]
+                        # Check if we need to remove text from the beginning of tab completions
+                        if text_to_remove:
+                            self.completion_matches = \
+                                [m.replace(text_to_remove, '', 1) for m in self.completion_matches]
+
+                        # Check if we need to restore a shortcut in the tab completions
+                        # so it doesn't get erased from the command line
+                        if shortcut_to_restore:
+                            self.completion_matches = \
+                                [shortcut_to_restore + match for match in self.completion_matches]
 
                     # Check if the token being completed has an unclosed quote
                     if len(raw_completion_token) == 1:

--- a/cmd2.py
+++ b/cmd2.py
@@ -1856,7 +1856,7 @@ class Cmd(cmd.Cmd):
                     orig_line = readline.get_line_buffer()
                     endidx = readline.get_endidx()
 
-                    # If we are at the end of the line, then add a space
+                    # If we are at the end of the line, then add a space if allowed
                     if allow_appended_space and endidx == len(orig_line):
                         str_to_append += ' '
 
@@ -1999,20 +1999,7 @@ class Cmd(cmd.Cmd):
                     self.completion_matches = []
                     return None
 
-                # Get the status of quotes in the token being completed
                 raw_completion_token = raw_tokens[-1]
-
-                # Check if the token being completed has an unclosed quote
-                if len(raw_completion_token) == 1:
-                    first_char = raw_completion_token[0]
-                    if first_char in QUOTES:
-                        unclosed_quote = first_char
-
-                elif len(raw_completion_token) > 1:
-                    first_char = raw_completion_token[0]
-                    last_char = raw_completion_token[-1]
-                    if first_char in QUOTES and first_char != last_char:
-                        unclosed_quote = first_char
 
                 # Check what character appears before the token being completed
                 starting_index = line[:endidx].rfind(raw_completion_token)
@@ -2073,6 +2060,18 @@ class Cmd(cmd.Cmd):
                         # Prepend all tab completions with the shortcut so it doesn't get erased from the command line
                         self.completion_matches = [shortcut_to_restore + match for match in self.completion_matches]
 
+                    # Check if the token being completed has an unclosed quote
+                    if len(raw_completion_token) == 1:
+                        first_char = raw_completion_token[0]
+                        if first_char in QUOTES:
+                            unclosed_quote = first_char
+
+                    elif len(raw_completion_token) > 1:
+                        first_char = raw_completion_token[0]
+                        last_char = raw_completion_token[-1]
+                        if first_char in QUOTES and first_char != last_char:
+                            unclosed_quote = first_char
+
             else:
                 # Complete token against aliases and command names
                 alias_names = set(self.aliases.keys())
@@ -2089,11 +2088,11 @@ class Cmd(cmd.Cmd):
             if len(self.completion_matches) == 1:
                 str_to_append = ''
 
-                # Add a closing quote if needed
+                # Add a closing quote if needed and allowed
                 if allow_closing_quote and unclosed_quote:
                     str_to_append += unclosed_quote
 
-                # If we are at the end of the line, then add a space
+                # If we are at the end of the line, then add a space if allowed
                 if allow_appended_space and endidx == len(line):
                     str_to_append += ' '
 
@@ -2635,7 +2634,10 @@ class Cmd(cmd.Cmd):
                 readline.set_completer(self.complete)
 
                 # For tab completion, break words on whitespace and quotes
+                # We will perform further delimitation later
                 readline.set_completer_delims(" \t\n\"'")
+
+                # Enable tab completion
                 readline.parse_and_bind(self.completekey + ": complete")
             except NameError:
                 pass

--- a/cmd2.py
+++ b/cmd2.py
@@ -1779,7 +1779,13 @@ class Cmd(cmd.Cmd):
             # If common_prefix contains a space, then we must add an opening quote to it
             if ' ' in common_prefix:
 
-                new_completion_token = '"' + common_prefix
+                # Figure out what kind of quote to add
+                if '"' in common_prefix:
+                    quote = "'"
+                else:
+                    quote = '"'
+
+                new_completion_token = quote + common_prefix
 
                 # Handle a single result
                 if len(self.completion_matches) == 1:
@@ -1787,7 +1793,7 @@ class Cmd(cmd.Cmd):
 
                     # Add a closing quote if allowed
                     if self.allow_closing_quote:
-                        str_to_append += '"'
+                        str_to_append += quote
 
                     orig_line = readline.get_line_buffer()
                     endidx = readline.get_endidx()

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -345,3 +345,8 @@ which inherits from ``cmd2.Cmd``::
 
     # Make sure you have an "import functools" somewhere at the top
     complete_bar = functools.partialmethod(cmd2.Cmd.path_complete, dir_only=True)
+
+    # Since Python 2 does not have functools.partialmethod(), you can achieve the
+    # same thing by implementing a tab completion function
+    def complete_bar(self, text, line, begidx, endidx):
+        return self.path_complete(text, line, begidx, endidx, dir_only=True)

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -333,8 +333,7 @@ Additionally, it is trivial to add identical file system path completion to your
 have defined a custom command ``foo`` by implementing the ``do_foo`` method.  To enable path completion for the ``foo``
 command, then add a line of code similar to the following to your class which inherits from ``cmd2.Cmd``::
 
-    # Make sure you have an "import functools" somewhere at the top
-    complete_foo = functools.partial(path_complete)
+    complete_foo = self.path_complete
 
 This will effectively define the ``complete_foo`` readline completer method in your class and make it utilize the same
 path completion logic as the built-in commands.
@@ -345,4 +344,4 @@ path completion of directories only for this command by adding a line of code si
 which inherits from ``cmd2.Cmd``::
 
     # Make sure you have an "import functools" somewhere at the top
-    complete_bar = functools.partial(path_complete, dir_only=True)
+    complete_bar = functools.partialmethod(cmd2.Cmd.path_complete, dir_only=True)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ pyparsing
 six
 pyperclip
 contextlib2
+enum34
+subprocess32

--- a/examples/paged_output.py
+++ b/examples/paged_output.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 """A simple example demonstrating the using paged output via the ppaged() method.
 """
-import functools
 
 import cmd2
 from cmd2 import with_argument_list
@@ -25,7 +24,7 @@ class PagedOutput(cmd2.Cmd):
             text = f.read()
         self.ppaged(text)
 
-    complete_page_file = functools.partial(cmd2.path_complete)
+    complete_page_file = cmd2.Cmd.path_complete
 
 
 if __name__ == '__main__':

--- a/examples/python_scripting.py
+++ b/examples/python_scripting.py
@@ -15,7 +15,6 @@ command and the "pyscript <script> [arguments]" syntax comes into play.
 This application and the "scripts/conditional.py" script serve as an example for one way in which this can be done.
 """
 import argparse
-import functools
 import os
 
 import cmd2
@@ -82,8 +81,9 @@ class CmdLineApp(cmd2.Cmd):
             self.perror(err, traceback_war=False)
         self._last_result = cmd2.CmdResult(out, err)
 
-    # Enable directory completion for cd command by freezing an argument to path_complete() with functools.partial
-    complete_cd = functools.partial(cmd2.path_complete, dir_only=True)
+    # Enable tab completion for cd command
+    def complete_cd(self, text, line, begidx, endidx):
+        return self.path_complete(text, line, begidx, endidx, dir_only=True)
 
     dir_parser = argparse.ArgumentParser()
     dir_parser.add_argument('-l', '--long', action='store_true', help="display in long format with one item per line")

--- a/examples/remove_unused.py
+++ b/examples/remove_unused.py
@@ -2,8 +2,8 @@
 # coding=utf-8
 """A simple example demonstrating how to remove unused commands.
 
-Commands can be removed from the help menu by appending their full command name (including "do_") to the
-"exclude_from_help" list.  These commands will still exist and can be executed and help can be retrieved for them by
+Commands can be removed from  help menu and tab completion by appending their command name to the hidden_commands list.
+These commands will still exist and can be executed and help can be retrieved for them by
 name, they just won't clutter the help menu.
 
 Commands can also be removed entirely by using Python's "del".
@@ -18,8 +18,8 @@ class RemoveUnusedBuiltinCommands(cmd2.Cmd):
     def __init__(self):
         cmd2.Cmd.__init__(self)
 
-        # To hide commands from displaying in the help menu, add their function name to the exclude_from_help list
-        self.exclude_from_help.append('do_py')
+        # To hide commands from displaying in the help menu, add them to the hidden_commands list
+        self.hidden_commands.append('py')
 
         # To remove built-in commands entirely, delete their "do_*" function from the cmd2.Cmd class
         del cmd2.Cmd.do_edit

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -11,7 +11,7 @@ import functools
 import sys
 
 import cmd2
-from cmd2 import with_argparser, index_based_complete
+from cmd2 import with_argparser
 
 
 class SubcommandsExample(cmd2.Cmd):
@@ -38,7 +38,7 @@ class SubcommandsExample(cmd2.Cmd):
         """ Adds tab completion to base sport subcommand """
         sports = ['Football', 'Hockey', 'Soccer', 'Baseball']
         index_dict = {1: sports}
-        return index_based_complete(text, line, begidx, endidx, index_dict)
+        return self.index_based_complete(text, line, begidx, endidx, index_dict)
 
     # create the top-level parser for the base command
     base_parser = argparse.ArgumentParser(prog='base')
@@ -71,10 +71,8 @@ class SubcommandsExample(cmd2.Cmd):
             # No subcommand was provided, so call help
             self.do_help('base')
 
-    # functools.partialmethod was added in Python 3.4
-    if sys.version_info >= (3, 4):
-        # This makes sure correct tab completion functions are called based on the selected subcommand
-        complete_base = functools.partialmethod(cmd2.Cmd.cmd_with_subs_completer, base='base')
+    def complete_base(self, text, line, begidx, endidx):
+        return self.cmd_with_subs_completer(text, line, begidx, endidx, base='base')
 
 
 if __name__ == '__main__':

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -7,8 +7,6 @@ This example shows an easy way for a single command to have many subcommands, ea
 and provides separate contextual help.
 """
 import argparse
-import functools
-import sys
 
 import cmd2
 from cmd2 import with_argparser

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -11,9 +11,13 @@ import argparse
 import cmd2
 from cmd2 import with_argparser
 
+sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
 class SubcommandsExample(cmd2.Cmd):
-    """ Example cmd2 application where we a base command which has a couple subcommands."""
+    """
+    Example cmd2 application where we a base command which has a couple subcommands
+    and the "sport" subcommand has tab completion enabled.
+    """
 
     def __init__(self):
         cmd2.Cmd.__init__(self)
@@ -34,8 +38,7 @@ class SubcommandsExample(cmd2.Cmd):
     # noinspection PyUnusedLocal
     def complete_base_sport(self, text, line, begidx, endidx):
         """ Adds tab completion to base sport subcommand """
-        sports = ['Football', 'Hockey', 'Soccer', 'Baseball']
-        index_dict = {1: sports}
+        index_dict = {1: sport_item_strs}
         return self.index_based_complete(text, line, begidx, endidx, index_dict)
 
     # create the top-level parser for the base command
@@ -56,7 +59,9 @@ class SubcommandsExample(cmd2.Cmd):
     # create the parser for the "sport" subcommand
     parser_sport = base_subparsers.add_parser('sport', help='sport help')
     parser_sport.add_argument('sport', help='Enter name of a sport')
-    parser_sport.set_defaults(func=base_sport)
+
+    # Set both a function and tab completer for the "sport" subcommand
+    parser_sport.set_defaults(func=base_sport, completer=complete_base_sport)
 
     @with_argparser(base_parser)
     def do_base(self, args):
@@ -69,8 +74,8 @@ class SubcommandsExample(cmd2.Cmd):
             # No subcommand was provided, so call help
             self.do_help('base')
 
-    def complete_base(self, text, line, begidx, endidx):
-        return self.cmd_with_subs_completer(text, line, begidx, endidx, base='base')
+    # Enable tab completion of base to make sure the subcommands' completers get called.
+    complete_base = cmd2.Cmd.cmd_with_subs_completer
 
 
 if __name__ == '__main__':

--- a/examples/tab_completion.py
+++ b/examples/tab_completion.py
@@ -3,33 +3,13 @@
 """A simple example demonstrating how to use flag and index based tab-completion functions
 """
 import argparse
-import functools
 
 import cmd2
-from cmd2 import with_argparser, with_argument_list, flag_based_complete, index_based_complete, path_complete
+from cmd2 import with_argparser, with_argument_list
 
 # List of strings used with flag and index based completion functions
 food_item_strs = ['Pizza', 'Hamburger', 'Ham', 'Potato']
 sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football']
-
-# Dictionary used with flag based completion functions
-flag_dict = \
-    {
-        '-f': food_item_strs,        # Tab-complete food items after -f flag in command line
-        '--food': food_item_strs,    # Tab-complete food items after --food flag in command line
-        '-s': sport_item_strs,       # Tab-complete sport items after -s flag in command line
-        '--sport': sport_item_strs,  # Tab-complete sport items after --sport flag in command line
-        '-o': path_complete,         # Tab-complete using path_complete function after -o flag in command line
-        '--other': path_complete,    # Tab-complete using path_complete function after --other flag in command line
-    }
-
-# Dictionary used with index based completion functions
-index_dict = \
-    {
-        1: food_item_strs,   # Tab-complete food items at index 1 in command line
-        2: sport_item_strs,  # Tab-complete sport items at index 2 in command line
-        3: path_complete,    # Tab-complete using path_complete function at index 3 in command line
-    }
 
 
 class TabCompleteExample(cmd2.Cmd):
@@ -59,7 +39,23 @@ class TabCompleteExample(cmd2.Cmd):
         self.poutput("You added {}".format(add_item))
 
     # Add flag-based tab-completion to add_item command
-    complete_add_item = functools.partial(flag_based_complete, flag_dict=flag_dict)
+    def complete_add_item(self, text, line, begidx, endidx):
+        flag_dict = \
+            {
+                # Tab-complete food items after -f and --food flags in command line
+                '-f': food_item_strs,
+                '--food': food_item_strs,
+
+                # Tab-complete sport items after -s and --sport flags in command line
+                '-s': sport_item_strs,
+                '--sport': sport_item_strs,
+
+                # Tab-complete using path_complete function after -o and --other flags in command line
+                '-o': self.path_complete,
+                '--other': self.path_complete,
+            }
+
+        return self.flag_based_complete(text, line, begidx, endidx, flag_dict=flag_dict)
 
     @with_argument_list
     def do_list_item(self, args):
@@ -67,7 +63,15 @@ class TabCompleteExample(cmd2.Cmd):
         self.poutput("You listed {}".format(args))
 
     # Add index-based tab-completion to list_item command
-    complete_list_item = functools.partial(index_based_complete, index_dict=index_dict)
+    def complete_list_item(self, text, line, begidx, endidx):
+        index_dict = \
+            {
+                1: food_item_strs,  # Tab-complete food items at index 1 in command line
+                2: sport_item_strs,  # Tab-complete sport items at index 2 in command line
+                3: self.path_complete,  # Tab-complete using path_complete function at index 3 in command line
+            }
+
+        return self.index_based_complete(text, line, begidx, endidx, index_dict=index_dict)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ EXTRAS_REQUIRE = {
     ":sys_platform=='win32'": ['pyreadline'],
     # Python 3.4 and earlier require contextlib2 for temporarily redirecting stderr and stdout
     ":python_version<'3.5'": ['contextlib2'],
+    # Python 3.3 and earlier require enum34 backport of enum module from Python 3.4
+    ":python_version<'3.4'": ['enum34'],
     # Python 2.7 also requires subprocess32
     ":python_version<'3.0'": ['subprocess32'],
 }
@@ -81,6 +83,8 @@ if int(setuptools.__version__.split('.')[0]) < 18:
         INSTALL_REQUIRES.append('pyreadline')
     if sys.version_info < (3, 5):
         INSTALL_REQUIRES.append('contextlib2')
+    if sys.version_info < (3, 4):
+        INSTALL_REQUIRES.append('enum34')
     if sys.version_info < (3, 0):
         INSTALL_REQUIRES.append('subprocess32')
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -194,17 +194,6 @@ class SubcommandApp(cmd2.Cmd):
         """bar subcommand of base command"""
         self.poutput('((%s))' % args.z)
 
-    def base_sport(self, args):
-        """sport subcommand of base command"""
-        self.poutput('Sport is {}'.format(args.sport))
-
-    # noinspection PyUnusedLocal
-    def complete_base_sport(self, text, line, begidx, endidx):
-        """ Adds tab completion to base sport subcommand """
-        sports = ['Football', 'Hockey', 'Soccer', 'Baseball']
-        index_dict = {1: sports}
-        return self.index_based_complete(text, line, begidx, endidx, index_dict)
-
     # create the top-level parser for the base command
     base_parser = argparse.ArgumentParser(prog='base')
     base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
@@ -220,11 +209,6 @@ class SubcommandApp(cmd2.Cmd):
     parser_bar.add_argument('z', help='string')
     parser_bar.set_defaults(func=base_bar)
 
-    # create the parser for the "sport" subcommand
-    parser_sport = base_subparsers.add_parser('sport', help='sport help')
-    parser_sport.add_argument('sport', help='Enter name of a sport')
-    parser_sport.set_defaults(func=base_sport)
-
     @cmd2.with_argparser(base_parser)
     def do_base(self, args):
         """Base command help"""
@@ -235,9 +219,6 @@ class SubcommandApp(cmd2.Cmd):
         else:
             # No subcommand was provided, so call help
             self.do_help('base')
-
-    def complete_base(self, text, line, begidx, endidx):
-        return self.cmd_with_subs_completer(text, line, begidx, endidx, base='base')
 
 @pytest.fixture
 def subcommand_app():
@@ -279,55 +260,3 @@ def test_subcommand_invalid_help(subcommand_app):
     out = run_cmd(subcommand_app, 'help base baz')
     assert out[0].startswith('usage: base')
     assert out[1].startswith("base: error: invalid choice: 'baz'")
-
-def test_subcommand_tab_completion(subcommand_app):
-    # This makes sure the correct completer for the sport subcommand is called
-    text = 'Foot'
-    line = 'base sport Foot'
-    endidx = len(line)
-    begidx = endidx - len(text)
-    state = 0
-
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = subcommand_app.complete(text, state)
-
-    # It is at end of line, so extra space is present
-    assert first_match is not None and subcommand_app.completion_matches == ['Football ']
-
-def test_subcommand_tab_completion_with_no_completer(subcommand_app):
-    # This tests what happens when a subcommand has no completer
-    # In this case, the foo subcommand has no completer defined
-    text = 'Foot'
-    line = 'base foo Foot'
-    endidx = len(line)
-    begidx = endidx - len(text)
-    state = 0
-
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = subcommand_app.complete(text, state)
-
-    assert first_match is None

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -33,6 +33,7 @@ except ImportError:
 
 # List of strings used with basic, flag, and index based completion functions
 weird_strings = ['string with space', '@a symbol']
+delimited_strings = ['bob::tampa::car', 'bill::tampa::truck', 'frank::atlanta::motorcycle']
 food_item_strs = ['Pizza', 'Hamburger', 'Ham', 'Potato']
 sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football']
 
@@ -57,7 +58,7 @@ index_dict = \
 
 
 class Cmd2App(cmd2.Cmd):
-    """ Example cmd2 application with a command for completion tests """
+    """ Example cmd2 application with commands for completion tests """
 
     def __init__(self):
         cmd2.Cmd.__init__(self)
@@ -67,6 +68,10 @@ class Cmd2App(cmd2.Cmd):
 
     def complete_completion_cmd(self, text, line, begidx, endidx):
         return basic_complete(text, line, begidx, endidx, weird_strings)
+
+    def do_delimited_completion(self, args):
+        pass
+
 
 @pytest.fixture
 def cmd2_app():
@@ -834,12 +839,12 @@ def test_cmd2_submenu_completion_after_submenu_nomatch(sb_app):
 
 
 def test_cmd2_help_submenu_completion_multiple(sb_app):
-    text = 'e'
+    text = 'p'
     line = 'help second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    expected = ['edit', 'eof', 'eos']
+    expected = ['py', 'pyscript']
 
     # These matches would normally be sorted by complete()
     matches = sb_app.complete_help(text, line, begidx, endidx)
@@ -857,12 +862,12 @@ def test_cmd2_help_submenu_completion_nomatch(sb_app):
 
 
 def test_cmd2_help_submenu_completion_subcommands(sb_app):
-    text = 'e'
+    text = 'p'
     line = 'help second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    expected = ['edit', 'eof', 'eos']
+    expected = ['py', 'pyscript']
 
     # These matches would normally be sorted by complete()
     matches = sb_app.complete_help(text, line, begidx, endidx)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -35,9 +35,10 @@ def cmd2_app():
     return c
 
 
-# List of strings used with basic, flag, and index based completion functions
+# List of strings used with completion functions
 food_item_strs = ['Pizza', 'Hamburger', 'Ham', 'Potato', 'Space Food']
 sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football']
+delimited_strs = ['/home/user/file.txt', '/home/user/prog.c', '/home/otheruser/maps']
 
 # Dictionary used with flag based completion functions
 flag_dict = \
@@ -410,6 +411,20 @@ def test_basic_completion_nomatch(cmd2_app):
 
     assert cmd2_app.basic_complete(text, line, begidx, endidx, food_item_strs) == []
 
+def test_delimiter_completion(cmd2_app):
+    text = '/home/'
+    line = 'load {}'.format(text)
+    endidx = len(line)
+    begidx = endidx - len(text)
+
+    cmd2_app.delimiter_complete(text, line, begidx, endidx, delimited_strs, '/')
+
+    # Remove duplicates from display_matches and sort it. This is typically done in the display function.
+    display_set = set(cmd2_app.display_matches)
+    display_list = list(display_set)
+    display_list.sort()
+
+    assert display_list == ['otheruser', 'user']
 
 def test_flag_based_completion_single(cmd2_app):
     text = 'Pi'

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -350,52 +350,34 @@ def test_path_completion_user_expansion():
     else:
         cmd = 'ls'
 
+    # Use a ~ which will be expanded into the user's home directory
     text = '~{}'.format(os.path.sep)
     line = 'shell {} {}'.format(cmd, text)
     endidx = len(line)
     begidx = endidx - len(text)
-    completions_tilde_slash = path_complete(text, line, begidx, endidx)
+    completions_tilde_slash = [match.replace(text, '', 1) for match in path_complete(text, line, begidx, endidx)]
 
     # Run path complete on the user's home directory
     text = os.path.expanduser('~') + os.path.sep
     line = 'shell {} {}'.format(cmd, text)
     endidx = len(line)
     begidx = endidx - len(text)
-    completions_home = path_complete(text, line, begidx, endidx)
+    completions_home = [match.replace(text, '', 1) for match in path_complete(text, line, begidx, endidx)]
 
-    # Verify that the results are the same in both cases
     assert completions_tilde_slash == completions_home
 
 def test_path_completion_directories_only(request):
     test_dir = os.path.dirname(request.module.__file__)
 
-    text = 's'
-    path = os.path.join(test_dir, text)
-    line = 'shell cat {}'.format(path)
+    text = os.path.join(test_dir, 's')
+    line = 'shell cat {}'.format(text)
 
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert path_complete(text, line, begidx, endidx, dir_only=True) == ['scripts' + os.path.sep]
+    expected = [text + 'cripts' + os.path.sep]
 
-def test_path_completion_syntax_err(request):
-    test_dir = os.path.dirname(request.module.__file__)
-
-    text = 'c'
-    path = os.path.join(test_dir, text)
-    line = 'shell cat " {}'.format(path)
-
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    assert path_complete(text, line, begidx, endidx) == []
-
-def test_path_completion_no_tokens():
-    text = ''
-    line = 'shell'
-    endidx = len(line)
-    begidx = 0
-    assert path_complete(text, line, begidx, endidx) == []
+    assert path_complete(text, line, begidx, endidx, dir_only=True) == expected
 
 
 # List of strings used with basic, flag, and index based completion functions

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -174,10 +174,7 @@ def test_complete_empty_arg(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
     expected = cmd2_app.complete_help(text, line, begidx, endidx)
-    expected.sort()
-
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
 
     assert first_match is not None and \
@@ -228,11 +225,7 @@ def test_cmd2_help_completion_multiple(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
-    matches = cmd2_app.complete_help(text, line, begidx, endidx)
-    matches.sort()
-
-    assert matches == ['help', 'history']
+    assert cmd2_app.complete_help(text, line, begidx, endidx) == ['help', 'history']
 
 def test_cmd2_help_completion_nomatch(cmd2_app):
     text = 'fakecommand'
@@ -337,13 +330,7 @@ def test_path_completion_multiple(request):
     begidx = endidx - len(text)
 
     expected = [text + 'cript.py', text + 'cript.txt', text + 'cripts' + os.path.sep]
-    expected.sort()
-
-    # These matches would normally be sorted by complete()
-    matches = path_complete(text, line, begidx, endidx)
-    matches.sort()
-
-    assert expected == matches
+    assert expected == path_complete(text, line, begidx, endidx)
 
 def test_path_completion_nomatch(request):
     test_dir = os.path.dirname(request.module.__file__)
@@ -369,7 +356,7 @@ def test_default_to_shell_completion(cmd2_app, request):
         command = 'egrep'
 
     # Make sure the command is on the testing system
-    assert command in cmd2.Cmd._get_exes_in_path(command)
+    assert command in cmd2.get_exes_in_path(command)
     line = '{} {}'.format(command, text)
 
     endidx = len(line)
@@ -482,11 +469,7 @@ def test_basic_completion_multiple():
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
-    matches = basic_complete(text, line, begidx, endidx, food_item_strs)
-    matches.sort()
-
-    assert matches == sorted(food_item_strs)
+    assert basic_complete(text, line, begidx, endidx, food_item_strs) == sorted(food_item_strs)
 
 def test_basic_completion_nomatch():
     text = 'q'
@@ -527,11 +510,7 @@ def test_flag_based_completion_multiple():
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
-    matches = flag_based_complete(text, line, begidx, endidx, flag_dict)
-    matches.sort()
-
-    assert matches == sorted(food_item_strs)
+    assert flag_based_complete(text, line, begidx, endidx, flag_dict) == sorted(food_item_strs)
 
 def test_flag_based_completion_nomatch():
     text = 'q'
@@ -577,11 +556,7 @@ def test_index_based_completion_multiple():
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
-    matches = index_based_complete(text, line, begidx, endidx, index_dict)
-    matches.sort()
-
-    assert matches == sorted(sport_item_strs)
+    assert index_based_complete(text, line, begidx, endidx, index_dict) == sorted(sport_item_strs)
 
 def test_index_based_completion_nomatch():
     text = 'q'
@@ -732,11 +707,7 @@ def test_cmd2_help_subcommand_completion_multiple(sc_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    # These matches would normally be sorted by complete()
-    matches = sc_app.complete_help(text, line, begidx, endidx)
-    matches.sort()
-
-    assert matches == ['bar', 'foo']
+    assert sc_app.complete_help(text, line, begidx, endidx) == ['bar', 'foo']
 
 
 def test_cmd2_help_subcommand_completion_nomatch(sc_app):
@@ -844,13 +815,7 @@ def test_cmd2_help_submenu_completion_multiple(sb_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    expected = ['py', 'pyscript']
-
-    # These matches would normally be sorted by complete()
-    matches = sb_app.complete_help(text, line, begidx, endidx)
-    matches.sort()
-
-    assert matches == expected
+    assert sb_app.complete_help(text, line, begidx, endidx) == ['py', 'pyscript']
 
 
 def test_cmd2_help_submenu_completion_nomatch(sb_app):
@@ -867,10 +832,4 @@ def test_cmd2_help_submenu_completion_subcommands(sb_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    expected = ['py', 'pyscript']
-
-    # These matches would normally be sorted by complete()
-    matches = sb_app.complete_help(text, line, begidx, endidx)
-    matches.sort()
-
-    assert matches == expected
+    assert sb_app.complete_help(text, line, begidx, endidx) == ['py', 'pyscript']

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -397,7 +397,7 @@ flag_dict = \
 
 def test_basic_completion_single():
     text = 'Pi'
-    line = 'list_food -f Pi'
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
@@ -405,15 +405,18 @@ def test_basic_completion_single():
 
 def test_basic_completion_multiple():
     text = ''
-    line = 'list_food -f '
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert basic_complete(text, line, begidx, endidx, food_item_strs) == sorted(food_item_strs)
+    matches = basic_complete(text, line, begidx, endidx, food_item_strs)
+    matches.sort()
+
+    assert matches == sorted(food_item_strs)
 
 def test_basic_completion_nomatch():
     text = 'q'
-    line = 'list_food -f q'
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
@@ -422,7 +425,7 @@ def test_basic_completion_nomatch():
 
 def test_flag_based_completion_single():
     text = 'Pi'
-    line = 'list_food -f Pi'
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
@@ -430,15 +433,18 @@ def test_flag_based_completion_single():
 
 def test_flag_based_completion_multiple():
     text = ''
-    line = 'list_food -f '
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert flag_based_complete(text, line, begidx, endidx, flag_dict) == sorted(food_item_strs)
+    matches = flag_based_complete(text, line, begidx, endidx, flag_dict)
+    matches.sort()
+
+    assert matches == sorted(food_item_strs)
 
 def test_flag_based_completion_nomatch():
     text = 'q'
-    line = 'list_food -f q'
+    line = 'list_food -f {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
@@ -447,34 +453,24 @@ def test_flag_based_completion_nomatch():
 def test_flag_based_default_completer(request):
     test_dir = os.path.dirname(request.module.__file__)
 
-    text = 'c'
-    path = os.path.join(test_dir, text)
-    line = 'list_food {}'.format(path)
+    text = os.path.join(test_dir, 'c')
+    line = 'list_food {}'.format(text)
 
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert flag_based_complete(text, line, begidx, endidx, flag_dict, path_complete) == ['conftest.py']
+    assert flag_based_complete(text, line, begidx, endidx, flag_dict, path_complete) == [text + 'onftest.py']
 
 def test_flag_based_callable_completer(request):
     test_dir = os.path.dirname(request.module.__file__)
 
-    text = 'c'
-    path = os.path.join(test_dir, text)
-    line = 'list_food -o {}'.format(path)
+    text = os.path.join(test_dir, 'c')
+    line = 'list_food -o {}'.format(text)
 
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert flag_based_complete(text, line, begidx, endidx, flag_dict, path_complete) == ['conftest.py']
-
-def test_flag_based_completion_no_tokens():
-    text = ''
-    line = 'list_food'
-    endidx = len(line)
-    begidx = 0
-
-    assert flag_based_complete(text, line, begidx, endidx, flag_dict) == []
+    assert flag_based_complete(text, line, begidx, endidx, flag_dict, path_complete) == [text + 'onftest.py']
 
 
 # Dictionary used with index based completion functions
@@ -487,7 +483,7 @@ index_dict = \
 
 def test_index_based_completion_single():
     text = 'Foo'
-    line = 'command Pizza Foo'
+    line = 'command Pizza {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
@@ -495,14 +491,18 @@ def test_index_based_completion_single():
 
 def test_index_based_completion_multiple():
     text = ''
-    line = 'command Pizza '
+    line = 'command Pizza {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    assert index_based_complete(text, line, begidx, endidx, index_dict) == sorted(sport_item_strs)
+
+    matches = index_based_complete(text, line, begidx, endidx, index_dict)
+    matches.sort()
+
+    assert matches == sorted(sport_item_strs)
 
 def test_index_based_completion_nomatch():
     text = 'q'
-    line = 'command q'
+    line = 'command {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
     assert index_based_complete(text, line, begidx, endidx, index_dict) == []
@@ -510,26 +510,24 @@ def test_index_based_completion_nomatch():
 def test_index_based_default_completer(request):
     test_dir = os.path.dirname(request.module.__file__)
 
-    text = 'c'
-    path = os.path.join(test_dir, text)
-    line = 'command Pizza Bat Computer {}'.format(path)
+    text = os.path.join(test_dir, 'c')
+    line = 'command Pizza Bat Computer {}'.format(text)
 
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert index_based_complete(text, line, begidx, endidx, index_dict, path_complete) == ['conftest.py']
+    assert index_based_complete(text, line, begidx, endidx, index_dict, path_complete) == [text + 'onftest.py']
 
 def test_index_based_callable_completer(request):
     test_dir = os.path.dirname(request.module.__file__)
 
-    text = 'c'
-    path = os.path.join(test_dir, text)
-    line = 'command Pizza Bat {}'.format(path)
+    text = os.path.join(test_dir, 'c')
+    line = 'command Pizza Bat {}'.format(text)
 
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert index_based_complete(text, line, begidx, endidx, index_dict) == ['conftest.py']
+    assert index_based_complete(text, line, begidx, endidx, index_dict) == [text + 'onftest.py']
 
 
 def test_parseline_command_and_args(cmd2_app):
@@ -559,35 +557,6 @@ def test_parseline_expands_shortcuts(cmd2_app):
     assert command == 'shell'
     assert args == 'cat foobar.txt'
     assert line.replace('!', 'shell ') == out_line
-
-
-# Test command completer functions to extend testing coverage
-def test_edit_completer(cmd2_app):
-    text = ''
-    line = 'edit '
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    # Verify there are results
-    assert cmd2_app.complete_edit(text, line, begidx, endidx)
-
-def test_load_completer(cmd2_app):
-    text = ''
-    line = 'load '
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    # Verify there are results
-    assert cmd2_app.complete_load(text, line, begidx, endidx)
-
-def test_pyscript_completer(cmd2_app):
-    text = ''
-    line = 'pyscript '
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    # Verify there are results
-    assert cmd2_app.complete_pyscript(text, line, begidx, endidx)
 
 
 class SubcommandsExample(cmd2.Cmd):
@@ -623,10 +592,10 @@ class SubcommandsExample(cmd2.Cmd):
     @cmd2.with_argparser(base_parser)
     def do_base(self, args):
         """Base command help"""
-        try:
+        if args.func is not None:
             # Call whatever sub-command function was selected
             args.func(self, args)
-        except AttributeError:
+        else:
             # No sub-command was provided, so as called
             self.do_help('base')
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -222,9 +222,9 @@ def test_shell_command_completion_nomatch(cmd2_app):
 
 def test_shell_command_completion_doesnt_complete_when_just_shell(cmd2_app):
     text = ''
-    line = 'shell'
+    line = 'shell {}'.format(text)
     endidx = len(line)
-    begidx = 0
+    begidx = endidx - len(text)
     assert cmd2_app.complete_shell(text, line, begidx, endidx) == []
 
 def test_shell_command_completion_does_path_completion_when_after_command(cmd2_app, request):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -714,25 +714,11 @@ def sb_app():
 
 def test_cmd2_submenu_completion_single_end(sb_app):
     text = 'f'
-    line = 'second f'
+    line = 'second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
 
     # It is at end of line, so extra space is present
     assert first_match is not None and sb_app.completion_matches == ['foo ']
@@ -743,204 +729,94 @@ def test_cmd2_submenu_completion_single_mid(sb_app):
     line = 'second fo'
     endidx = len(line) - 1
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
-
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
     assert first_match is not None and sb_app.completion_matches == ['foo']
 
 
 def test_cmd2_submenu_completion_multiple(sb_app):
-    text = ''
-    line = 'second '
+    text = 'e'
+    line = 'second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
+    expected = ['edit', 'eof', 'eos']
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
 
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
-
-    assert first_match is not None and sb_app.completion_matches == [
-        '_relative_load',
-        'alias',
-        'edit',
-        'eof',
-        'eos',
-        'foo',
-        'help',
-        'history',
-        'load',
-        'py',
-        'pyscript',
-        'quit',
-        'set',
-        'shell',
-        'shortcuts',
-        'unalias'
-    ]
+    assert first_match is not None and sb_app.completion_matches == expected
 
 
 def test_cmd2_submenu_completion_nomatch(sb_app):
     text = 'z'
-    line = 'second z'
+    line = 'second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
-
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
     assert first_match is None
 
 
 def test_cmd2_submenu_completion_after_submenu_match(sb_app):
     text = 'a'
-    line = 'second foo a'
+    line = 'second foo {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
-
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
     assert first_match is not None and sb_app.completion_matches == ['asd ']
 
 
 def test_cmd2_submenu_completion_after_submenu_nomatch(sb_app):
     text = 'b'
-    line = 'second foo b'
+    line = 'second foo {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    state = 0
 
-    def get_line():
-        return line
-
-    def get_begidx():
-        return begidx
-
-    def get_endidx():
-        return endidx
-
-    with mock.patch.object(readline, 'get_line_buffer', get_line):
-        with mock.patch.object(readline, 'get_begidx', get_begidx):
-            with mock.patch.object(readline, 'get_endidx', get_endidx):
-                # Run the readline tab-completion function with readline mocks in place
-                first_match = sb_app.complete(text, state)
-
+    first_match = complete_tester(text, line, begidx, endidx, sb_app)
     assert first_match is None
 
 
 def test_cmd2_help_submenu_completion_single_mid(sb_app):
     text = 'sec'
     line = 'help seco'
-    begidx = len(line) - 4
-    endidx = begidx + len(text)
+    endidx = len(line) - 1
+    begidx = endidx - len(text)
     assert sb_app.complete_help(text, line, begidx, endidx) == ['second']
 
 
 def test_cmd2_help_submenu_completion_multiple(sb_app):
-    text = ''
-    line = 'help second '
+    text = 'e'
+    line = 'help second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    assert sb_app.complete_help(text, line, begidx, endidx) == [
-        '_relative_load',
-        'alias',
-        'edit',
-        'eof',
-        'eos',
-        'foo',
-        'help',
-        'history',
-        'load',
-        'py',
-        'pyscript',
-        'quit',
-        'set',
-        'shell',
-        'shortcuts',
-        'unalias'
-    ]
+
+    expected = ['edit', 'eof', 'eos']
+
+    # These matches would normally be sorted by complete()
+    matches = sb_app.complete_help(text, line, begidx, endidx)
+    matches.sort()
+
+    assert matches == expected
 
 
 def test_cmd2_help_submenu_completion_nomatch(sb_app):
-    text = 'b'
-    line = 'help second b'
+    text = 'fake'
+    line = 'help second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
     assert sb_app.complete_help(text, line, begidx, endidx) == []
 
 
 def test_cmd2_help_submenu_completion_subcommands(sb_app):
-    text = ''
-    line = 'help second '
+    text = 'e'
+    line = 'help second {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
-    assert sb_app.complete_help(text, line, begidx, endidx) == [
-        '_relative_load',
-        'alias',
-        'edit',
-        'eof',
-        'eos',
-        'foo',
-        'help',
-        'history',
-        'load',
-        'py',
-        'pyscript',
-        'quit',
-        'set',
-        'shell',
-        'shortcuts',
-        'unalias'
-    ]
+
+    expected = ['edit', 'eof', 'eos']
+
+    # These matches would normally be sorted by complete()
+    matches = sb_app.complete_help(text, line, begidx, endidx)
+    matches.sort()
+
+    assert matches == expected

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -631,12 +631,15 @@ def test_parseline_expands_shortcuts(cmd2_app):
 
 
 class SubcommandsExample(cmd2.Cmd):
-    """ Example cmd2 application where we a base command which has a couple subcommands."""
+    """
+    Example cmd2 application where we a base command which has a couple subcommands
+    and the "sport" subcommand has tab completion enabled.
+    """
 
     def __init__(self):
         cmd2.Cmd.__init__(self)
 
-    # sub-command functions for the base command
+    # subcommand functions for the base command
     def base_foo(self, args):
         """foo subcommand of base command"""
         self.poutput(args.x * args.y)
@@ -649,6 +652,7 @@ class SubcommandsExample(cmd2.Cmd):
         """sport subcommand of base command"""
         self.poutput('Sport is {}'.format(args.sport))
 
+    # noinspection PyUnusedLocal
     def complete_base_sport(self, text, line, begidx, endidx):
         """ Adds tab completion to base sport subcommand """
         index_dict = {1: sport_item_strs}
@@ -658,13 +662,13 @@ class SubcommandsExample(cmd2.Cmd):
     base_parser = argparse.ArgumentParser(prog='base')
     base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
-    # create the parser for the "foo" sub-command
+    # create the parser for the "foo" subcommand
     parser_foo = base_subparsers.add_parser('foo', help='foo help')
     parser_foo.add_argument('-x', type=int, default=1, help='integer')
     parser_foo.add_argument('y', type=float, help='float')
     parser_foo.set_defaults(func=base_foo)
 
-    # create the parser for the "bar" sub-command
+    # create the parser for the "bar" subcommand
     parser_bar = base_subparsers.add_parser('bar', help='bar help')
     parser_bar.add_argument('z', help='string')
     parser_bar.set_defaults(func=base_bar)
@@ -672,7 +676,9 @@ class SubcommandsExample(cmd2.Cmd):
     # create the parser for the "sport" subcommand
     parser_sport = base_subparsers.add_parser('sport', help='sport help')
     parser_sport.add_argument('sport', help='Enter name of a sport')
-    parser_sport.set_defaults(func=base_sport)
+
+    # Set both a function and tab completer for the "sport" subcommand
+    parser_sport.set_defaults(func=base_sport, completer=complete_base_sport)
 
     @cmd2.with_argparser(base_parser)
     def do_base(self, args):
@@ -682,11 +688,11 @@ class SubcommandsExample(cmd2.Cmd):
             # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so as called
+            # No subcommand was provided, so call help
             self.do_help('base')
 
-    def complete_base(self, text, line, begidx, endidx):
-        return self.cmd_with_subs_completer(text, line, begidx, endidx, base='base')
+    # Enable tab completion of base to make sure the subcommands' completers get called.
+    complete_base = cmd2.Cmd.cmd_with_subs_completer
 
 
 @pytest.fixture

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -92,17 +92,6 @@ def complete_tester(text, line, begidx, endidx, app):
 
     return first_match
 
-def test_complete_add_opening_quote(cmd2_app):
-    text = 'Space'
-    line = 'command -f {}'.format(text)
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    import readline
-    new_line = readline.get_line_buffer()
-
-    assert new_line == cmd2_app.flag_based_complete(text, line, begidx, endidx, index_dict) == ['Football"']
-
 
 def test_cmd2_command_completion_single(cmd2_app):
     text = 'he'

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv =
 [testenv:py27]
 deps =
   codecov
+  enum34
   mock
   pyparsing
   pyperclip
@@ -28,6 +29,7 @@ commands =
 [testenv:py27-win]
 deps =
   codecov
+  enum34
   mock
   pyparsing
   pyperclip


### PR DESCRIPTION
Tab completing tokens with spaces now works.
If a completion has a space and no opening quote, then an opening quote will be written to the screen.
Closing quotes are added if completion type allows it.
Added more interaction with the readline library that Python wrapper does not offer.
Added tab completion after redirection strings (|, >, >>, <) for every command.
Moved all tab completion functions into the cmd2 class since they now depend on allow_redirection flag.
