### PR TITLE
Move constants and utility functions into separate files.

### DIFF
--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -2,6 +2,11 @@
 # coding=utf-8
 """Constants and definitions"""
 
+import re
+
 # Used for command parsing, tab completion and word breaks. Do not change.
 QUOTES = ['"', "'"]
 REDIRECTION_CHARS = ['|', '<', '>']
+
+# Regular expression to match ANSI escape codes
+ANSI_ESCAPE_RE = re.compile(r'\x1b[^m]*m')

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -1,0 +1,13 @@
+#
+# coding=utf-8
+"""Shared utility functions"""
+
+from . import constants
+
+def strip_ansi(text: str) -> str:
+    """Strip ANSI escape codes from a string.
+
+    :param text: string which may contain ANSI escape codes
+    :return: the same string with any ANSI escape codes removed
+    """
+    return constants.ANSI_ESCAPE_RE.sub('', text)


### PR DESCRIPTION
From a discussion on review of PR #370, @anselor suggested we move constants into a separate file. I am using relative imports to keep the namespace clean and tidy.