### PR TITLE
Fixes problem with not passing the parameter hint suppression down to…

### DIFF
--- a/cmd2/argcomplete_bridge.py
+++ b/cmd2/argcomplete_bridge.py
@@ -16,6 +16,7 @@ else:
     except AttributeError:
         DEFAULT_COMPLETER = argcomplete.completers.FilesCompleter()
 
+    from cmd2.argparse_completer import ACTION_ARG_CHOICES, ACTION_SUPPRESS_HINT
     from contextlib import redirect_stdout
     import copy
     from io import StringIO
@@ -245,7 +246,10 @@ else:
                 if comp_type == 63:  # type is 63 for second tab press
                     print(outstr.rstrip(), file=argcomplete.debug_stream, end='')
 
-                output_stream.write(ifs.join([ifs, ' ']).encode(argcomplete.sys_encoding))
+                if completions is not None:
+                    output_stream.write(ifs.join([ifs, ' ']).encode(argcomplete.sys_encoding))
+                else:
+                    output_stream.write(ifs.join([]).encode(argcomplete.sys_encoding))
             else:
                 # if completions is None we assume we don't know how to handle it so let bash
                 # go forward with normal filesystem completion
@@ -253,3 +257,11 @@ else:
             output_stream.flush()
             argcomplete.debug_stream.flush()
             exit_method(0)
+
+
+    def bash_complete(action, show_hint: bool=True):
+        """Helper function to configure an argparse action to fall back to bash completion"""
+        def complete_none(*args, **kwargs):
+            return None
+        setattr(action, ACTION_SUPPRESS_HINT, not show_hint)
+        setattr(action, ACTION_ARG_CHOICES, (complete_none,))

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -19,6 +19,10 @@ base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcomma
 parser_foo = base_subparsers.add_parser('foo', help='foo help')
 parser_foo.add_argument('-x', type=int, default=1, help='integer')
 parser_foo.add_argument('y', type=float, help='float')
+input_file = parser_foo.add_argument('input_file', type=str, help='Input File')
+if __name__ == '__main__':
+    from cmd2.argcomplete_bridge import bash_complete
+    bash_complete(input_file)
 
 # create the parser for the "bar" subcommand
 parser_bar = base_subparsers.add_parser('bar', help='bar help')


### PR DESCRIPTION
… sub-commands

Added hint suppression on a per-parameter basis
Added helper function to force an parameter to fall back to bash completion instead of using Cmd2 completion.
  - Hinting is still enabled by default but can be suppressed in the helper function.