### PR TITLE
Pyshell readline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Bug Fixes
     * If self.default_to_shell is true, then redirection and piping are now properly passed to the shell. Previously it was truncated.
     * Submenus now call all hooks, it used to just call precmd and postcmd.
+    * Fixed ``AttributeError`` on Windows when running a ``select`` command cause by **pyreadline** not implementing ``remove_history_item``
 * Enhancements
     * Automatic completion of ``argparse`` arguments via ``cmd2.argparse_completer.AutoCompleter``
         * See the [tab_autocompletion.py](https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocompletion.py) example for a demonstration of how to use this feature
@@ -16,6 +17,9 @@
         * ``identchars`` is now ignored. The standardlibrary cmd uses those characters to split the first "word" of the input, but cmd2 hasn't used those for a while, and the new parsing logic parses on whitespace, which has the added benefit of full unicode support, unlike cmd or prior versions of cmd2.
         * ``set_posix_shlex`` function and ``POSIX_SHLEX`` variable have been removed. Parsing behavior is now always the more forgiving ``posix=false``.
         * ``set_strip_quotes`` function and ``STRIP_QUOTES_FOR_NON_POSIX`` have been removed. Quotes are stripped from arguments when presented as a list (a la ``sys.argv``), and present when arguments are presented as a string (like the string passed to do_*).
+    * Enhanced the ``py`` console in the following ways
+        * Added tab completion of Python identifiers instead of **cmd2** commands
+        * Separated the ``py`` console history from the **cmd2** history
 * Changes
     * ``strip_ansi()`` and ``strip_quotes()`` functions have moved to new utils module
     * Several constants moved to new constants module

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2510,14 +2510,18 @@ Usage:  Usage: unalias [-a] name [name ...]
         return self.index_based_complete(text, line, begidx, endidx, index_dict, self.path_complete)
 
     @staticmethod
-    def _reset_sys() -> None:
+    def _reset_py_display() -> None:
         """
-        Resets the dynamic objects in the sys modules that the py and ipy consoles fight over
-        This makes it so the py console doesn't end up looking like the ipy console in terms of
-        prompt and exception text. That happens if a user runs py after being in an IPython console.
+        Resets the dynamic objects in the sys module that the py and ipy consoles fight over.
+        When a Python console starts it adopts certain display settings if they've already been set.
+        If an ipy console has previously been run, then py uses its settings and ends up looking
+        like an ipy console in terms of prompt and exception text. This method forces the Python
+        console to create its own display settings since they won't exist.
 
+        IPython does not have this problem since it always overwrites the display settings when it
+        is run. Therefore this method only needs to be called before creating a Python console.
         """
-        # Delete any prompts set by the interactive consoles
+        # Delete any prompts that have been set
         attributes = ['ps1', 'ps2', 'ps3']
         for cur_attr in attributes:
             try:
@@ -2640,8 +2644,8 @@ Usage:  Usage: unalias [-a] name [name ...]
                         interp.runcode("import readline")
                         interp.runcode("readline.set_completer(Completer(locals()).complete)")
 
-                # Set up sys for the console
-                self._reset_sys()
+                # Set up sys module for the Python console
+                self._reset_py_display()
                 keepstate = Statekeeper(sys, ('stdin', 'stdout'))
                 sys.stdout = self.stdout
                 sys.stdin = self.stdin
@@ -2738,7 +2742,6 @@ Paths or arguments that contain spaces must be enclosed in quotes
             End with ``Ctrl-D`` (Unix) / ``Ctrl-Z`` (Windows), ``quit()``, '`exit()``.
             """
             from .pyscript_bridge import PyscriptBridge
-            self._reset_sys()
             bridge = PyscriptBridge(self)
 
             if self.locals_in_py:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2508,7 +2508,6 @@ Usage:  Usage: unalias [-a] name [name ...]
         index_dict = {1: self.shell_cmd_complete}
         return self.index_based_complete(text, line, begidx, endidx, index_dict, self.path_complete)
 
-    # noinspection PyBroadException
     def do_py(self, arg):
         """
         Invoke python command, shell, or script
@@ -2525,6 +2524,7 @@ Usage:  Usage: unalias [-a] name [name ...]
             return
         self._in_py = True
 
+        # noinspection PyBroadException
         try:
             arg = arg.strip()
 
@@ -2581,12 +2581,11 @@ Usage:  Usage: unalias [-a] name [name ...]
                         for i in range(1, readline.get_current_history_length() + 1):
                             saved_cmd2_history.append(readline.get_history_item(i))
 
-                        # Keep a list of commands run in the Python console
-                        # noinspection PyAttributeOutsideInit
-                        self.py_history = getattr(self, 'py_history', [])
+                        readline.clear_history()
 
                         # Restore py's history
-                        readline.clear_history()
+                        # noinspection PyAttributeOutsideInit
+                        self.py_history = getattr(self, 'py_history', [])
                         for item in self.py_history:
                             readline.add_history(item)
 
@@ -2639,11 +2638,14 @@ Usage:  Usage: unalias [-a] name [name ...]
 
                     if rl_type != RlType.NONE:
                         # Save py's history
+                        # noinspection PyAttributeOutsideInit
+                        self.py_history = []
                         for i in range(1, readline.get_current_history_length() + 1):
                             self.py_history.append(readline.get_history_item(i))
 
-                        # Restore cmd2's history
                         readline.clear_history()
+
+                        # Restore cmd2's history
                         for item in saved_cmd2_history:
                             readline.add_history(item)
 

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -33,8 +33,17 @@ rl_type = RlType.NONE
 if 'pyreadline' in sys.modules:
     rl_type = RlType.PYREADLINE
 
-    # pyreadline is incomplete in terms of the Python readline API
-    # Add the missing functions we need
+    ############################################################################################################
+    # pyreadline is incomplete in terms of the Python readline API. Add the missing functions we need.
+    ############################################################################################################
+    # readline.redisplay()
+    try:
+        getattr(readline, 'redisplay')
+    except AttributeError:
+        # noinspection PyProtectedMember
+        readline.redisplay = readline.rl.mode._update_line
+
+    # readline.remove_history_item()
     try:
         getattr(readline, 'remove_history_item')
     except AttributeError:

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -33,6 +33,29 @@ rl_type = RlType.NONE
 if 'pyreadline' in sys.modules:
     rl_type = RlType.PYREADLINE
 
+    # pyreadline is incomplete in terms of the Python readline API
+    # Add the missing functions we need
+    try:
+        getattr(readline, 'remove_history_item')
+    except AttributeError:
+        # noinspection PyProtectedMember
+        def pyreadline_remove_history_item(pos: int) -> None:
+            """
+            An implementation of remove_history_item() for pyreadline
+            :param pos: The 0-based position in history to remove
+            """
+            # Save of the current location of the history cursor
+            saved_cursor = readline.rl.mode._history.history_cursor
+
+            # Delete the history item
+            del(readline.rl.mode._history.history[pos])
+
+            # Update the cursor if needed
+            if saved_cursor > pos:
+                readline.rl.mode._history.history_cursor -= 1
+
+        readline.remove_history_item = pyreadline_remove_history_item
+
 elif 'gnureadline' in sys.modules or 'readline' in sys.modules:
     # We don't support libedit
     if 'libedit' not in readline.__doc__:


### PR DESCRIPTION
Addresses #404, #414, and #415.

* Added tab completion of Python identifiers to `py` console.
* Separated **cmd2's** history from `py` console's
* Implemented missing functions in **pyreadline**
* Fixed issue where `py` console could resemble `ipy` console.

Tab completion in a Python console only works if  you've typed a character. This is normal behavior and not related to **cmd2**.