### PR TITLE
Removed unused function

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2569,15 +2569,6 @@ Usage:  Usage: unalias [-a] name [name ...]
                 except IOError as e:
                     self.perror(e)
 
-            # noinspection PyUnusedLocal
-            def onecmd_plus_hooks(cmd_plus_args):
-                """Run a cmd2.Cmd command from a Python script or the interactive Python console.
-
-                :param cmd_plus_args: str - command line including command and arguments to run
-                :return: bool - True if cmdloop() should exit once leaving the interactive Python console
-                """
-                return self.onecmd_plus_hooks(cmd_plus_args + '\n')
-
             bridge = PyscriptBridge(self)
             self.pystate['run'] = run
             self.pystate[self.pyscript_name] = bridge

--- a/examples/python_scripting.py
+++ b/examples/python_scripting.py
@@ -28,6 +28,7 @@ class CmdLineApp(cmd2.Cmd):
         super().__init__(use_ipython=True)
         self._set_prompt()
         self.intro = 'Happy 𝛑 Day.  Note the full Unicode support:  😇  (Python 3 only)  💩'
+        self.locals_in_py = True
 
     def _set_prompt(self):
         """Set prompt so it displays the current working directory."""

--- a/examples/scripts/conditional.py
+++ b/examples/scripts/conditional.py
@@ -24,16 +24,16 @@ else:
 original_dir = os.getcwd()
 
 # Try to change to the specified directory
-cmd('cd {}'.format(directory))
+app('cd {}'.format(directory))
 
 # Conditionally do something based on the results of the last command
 if self._last_result:
     print('\nContents of directory {!r}:'.format(directory))
-    cmd('dir -l')
+    app('dir -l')
 
     # Change back to where we were
     print('Changing back to original directory: {!r}'.format(original_dir))
-    cmd('cd {}'.format(original_dir))
+    app('cd {}'.format(original_dir))
 else:
     # cd command failed, print a warning
     print('Failed to change directory to {!r}'.format(directory))

--- a/main.py
+++ b/main.py
@@ -8,4 +8,5 @@ if __name__ == '__main__':
     # Set "use_ipython" to True to include the ipy command if IPython is installed, which supports advanced interactive
     # debugging of your application via introspection on self.
     app = cmd2.Cmd(use_ipython=True)
+    app.locals_in_py = True
     app.cmdloop()


### PR DESCRIPTION
The **PyscriptBridge** functionality makes the `onecmd_plus_hooks()` function in `do_py()` unnecessary.

@anselor @tleonhardt 
Someone needs to update [conditional.py](https://github.com/python-cmd2/cmd2/blob/master/examples/scripts/conditional.py) to use **PyscriptBridge** since the script is currently broken.

Please include that fix as part of this PR.