### PR TITLE
Fixed bug where preparse() wasn't called before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
         * Replaced by default AutoCompleter implementation for all commands using argparse
     * Deleted support for old method of calling application commands with ``cmd()`` and ``self``
     * ``cmd2.redirector`` is no longer supported. Output redirection can only be done with '>' or '>>'
+    * Deleted ``postparse()`` hook since it was redundant with ``postparsing_precmd``
 * Python 2 no longer supported
     * ``cmd2`` now supports Python 3.4+
 * Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 0.9.0 (TBD, 2018)
+## 0.9.0 (May TBD, 2018)
 * Bug Fixes
     * If self.default_to_shell is true, then redirection and piping are now properly passed to the shell. Previously it was truncated.
     * Submenus now call all hooks, it used to just call precmd and postcmd.
-    * Fixed ``AttributeError`` on Windows when running a ``select`` command cause by **pyreadline** not implementing ``remove_history_item``
 * Enhancements
     * Automatic completion of ``argparse`` arguments via ``cmd2.argparse_completer.AutoCompleter``
         * See the [tab_autocompletion.py](https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocompletion.py) example for a demonstration of how to use this feature
@@ -17,9 +16,6 @@
         * ``identchars`` is now ignored. The standardlibrary cmd uses those characters to split the first "word" of the input, but cmd2 hasn't used those for a while, and the new parsing logic parses on whitespace, which has the added benefit of full unicode support, unlike cmd or prior versions of cmd2.
         * ``set_posix_shlex`` function and ``POSIX_SHLEX`` variable have been removed. Parsing behavior is now always the more forgiving ``posix=false``.
         * ``set_strip_quotes`` function and ``STRIP_QUOTES_FOR_NON_POSIX`` have been removed. Quotes are stripped from arguments when presented as a list (a la ``sys.argv``), and present when arguments are presented as a string (like the string passed to do_*).
-    * Enhanced the ``py`` console in the following ways
-        * Added tab completion of Python identifiers instead of **cmd2** commands
-        * Separated the ``py`` console history from the **cmd2** history
 * Changes
     * ``strip_ansi()`` and ``strip_quotes()`` functions have moved to new utils module
     * Several constants moved to new constants module
@@ -39,6 +35,18 @@
 * Known Issues
     * Some developers have noted very slow performance when importing the ``cmd2`` module. The issue
     it intermittant, and investigation of the root cause is ongoing.
+    
+## 0.8.6 (May 27, 2018)
+* Bug Fixes
+    * Commands using the @with_argparser_and_unknown_args were not correctly recognized when tab completing 
+    * Fixed issue where completion display function was overwritten when a submenu quits
+    * Fixed ``AttributeError`` on Windows when running a ``select`` command cause by **pyreadline** not implementing ``remove_history_item``
+* Enhancements
+    * Added warning about **libedit** variant of **readline** not being supported on macOS
+    * Added tab-completion of alias names in value filed of **alias** command
+    * Enhanced the ``py`` console in the following ways
+        * Added tab completion of Python identifiers instead of **cmd2** commands
+        * Separated the ``py`` console history from the **cmd2** history
 
 ## 0.8.5 (April 15, 2018)
 * Bug Fixes

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1620,15 +1620,6 @@ class Cmd(cmd.Cmd):
         return raw
 
     # noinspection PyMethodMayBeStatic
-    def postparse(self, statement: Statement) -> Statement:
-        """Hook that runs immediately after parsing the user input.
-
-        :param statement: Statement object populated by parsing
-        :return: Statement - potentially modified Statement object
-        """
-        return statement
-
-    # noinspection PyMethodMayBeStatic
     def postparsing_precmd(self, statement: Statement) -> Tuple[bool, Statement]:
         """This runs after parsing the command-line, but before anything else; even before adding cmd to history.
 
@@ -1688,7 +1679,7 @@ class Cmd(cmd.Cmd):
         import datetime
         stop = False
         try:
-            statement = self._complete_statement(line)
+            statement = self._complete_statement(self.preparse(line))
             (stop, statement) = self.postparsing_precmd(statement)
             if stop:
                 return self.postparsing_postcmd(stop)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1679,7 +1679,7 @@ class Cmd(cmd.Cmd):
         import datetime
         stop = False
         try:
-            statement = self._complete_statement(self.preparse(line))
+            statement = self._complete_statement(line)
             (stop, statement) = self.postparsing_precmd(statement)
             if stop:
                 return self.postparsing_postcmd(stop)

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -50,8 +50,6 @@ the various hook methods, presented in chronological order starting with the one
 
 .. automethod:: cmd2.cmd2.Cmd.preparse
 
-.. automethod:: cmd2.cmd2.Cmd.postparse
-
 .. automethod:: cmd2.cmd2.Cmd.postparsing_precmd
 
 .. automethod:: cmd2.cmd2.Cmd.precmd


### PR DESCRIPTION
Deleted ``postparse()`` since it was redundant with ``postparsing_precmd()``
    - Decided to keep ``postparsing_precmd()`` because of its more self-documenting name
- Removed reference to ``postparse()`` in the docs

This partially addresses #417 