### PR TITLE
Fixed a couple potential crashes on opening files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.8 (TBD, 2018)
+* Bug Fixes
+    * Prevent crashes that could occur attempting to open a file in non-existent directory or with very long filename
+    
 ## 0.9.1 (May 28, 2018)
 * Bug Fixes
     * fix packaging error for 0.8.x versions (yes we had to deploy a new version

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1842,7 +1842,7 @@ class Cmd(cmd.Cmd):
                     mode = 'a'
                 try:
                     sys.stdout = self.stdout = open(os.path.expanduser(statement.output_to), mode)
-                except (FileNotFoundError, OSError) as ex:
+                except OSError as ex:
                     self.perror('Not Redirecting because - {}'.format(ex), traceback_war=False)
                     self.redirecting = False
             else:
@@ -2885,7 +2885,7 @@ a..b, a:b, a:, ..b  items by indices (inclusive)
         try:
             with open(transcript_file, 'w') as fout:
                 fout.write(transcript)
-        except (FileNotFoundError, OSError) as ex:
+        except OSError as ex:
             self.perror('Failed to save transcript: {}'.format(ex), traceback_war=False)
         else:
             # and let the user know what we did

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -615,6 +615,44 @@ def test_output_redirection(base_app):
     finally:
         os.remove(filename)
 
+def test_output_redirection_to_nonexistent_directory(base_app):
+    filename = '~/fakedir/this_does_not_exist.txt'
+
+    # Verify that writing to a file in a non-existent directory doesn't work
+    run_cmd(base_app, 'help > {}'.format(filename))
+    expected = normalize(BASE_HELP)
+    with pytest.raises(FileNotFoundError):
+        with open(filename) as f:
+            content = normalize(f.read())
+        assert content == expected
+
+    # Verify that appending to a file also works
+    run_cmd(base_app, 'help history >> {}'.format(filename))
+    expected = normalize(BASE_HELP + '\n' + HELP_HISTORY)
+    with pytest.raises(FileNotFoundError):
+        with open(filename) as f:
+            content = normalize(f.read())
+        assert content == expected
+
+def test_output_redirection_to_too_long_filename(base_app):
+    filename = '~/sdkfhksdjfhkjdshfkjsdhfkjsdhfkjdshfkjdshfkjshdfkhdsfkjhewfuihewiufhweiufhiweufhiuewhiuewhfiuwehfiuewhfiuewhfiuewhfiuewhiuewhfiuewhfiuewfhiuwehewiufhewiuhfiweuhfiuwehfiuewfhiuwehiuewfhiuewhiewuhfiuewhfiuwefhewiuhewiufhewiufhewiufhewiufhewiufhewiufhewiufhewiuhewiufhewiufhewiuheiufhiuewheiwufhewiufheiufheiufhieuwhfewiuhfeiufhiuewfhiuewheiwuhfiuewhfiuewhfeiuwfhewiufhiuewhiuewhfeiuwhfiuwehfuiwehfiuehiuewhfieuwfhieufhiuewhfeiuwfhiuefhueiwhfw'
+
+    # Verify that writing to a file in a non-existent directory doesn't work
+    run_cmd(base_app, 'help > {}'.format(filename))
+    expected = normalize(BASE_HELP)
+    with pytest.raises(OSError):
+        with open(filename) as f:
+            content = normalize(f.read())
+        assert content == expected
+
+    # Verify that appending to a file also works
+    run_cmd(base_app, 'help history >> {}'.format(filename))
+    expected = normalize(BASE_HELP + '\n' + HELP_HISTORY)
+    with pytest.raises(OSError):
+        with open(filename) as f:
+            content = normalize(f.read())
+        assert content == expected
+
 
 def test_feedback_to_output_true(base_app):
     base_app.feedback_to_output = True

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -154,6 +154,32 @@ this is a \/multiline\/ command
 
     assert transcript == expected
 
+def test_history_transcript_bad_filename(request, capsys):
+    app = CmdLineApp()
+    app.stdout = StdOut()
+    run_cmd(app, 'orate this is\na /multiline/\ncommand;\n')
+    run_cmd(app, 'speak /tmp/file.txt is not a regex')
+
+    expected = r"""(Cmd) orate this is
+> a /multiline/
+> command;
+this is a \/multiline\/ command
+(Cmd) speak /tmp/file.txt is not a regex
+\/tmp\/file.txt is not a regex
+"""
+
+    # make a tmp file
+    history_fname = '~/fakedir/this_does_not_exist.txt'
+
+    # tell the history command to create a transcript
+    run_cmd(app, 'history -t "{}"'.format(history_fname))
+
+    # read in the transcript created by the history command
+    with pytest.raises(FileNotFoundError):
+        with open(history_fname) as f:
+            transcript = f.read()
+        assert transcript == expected
+
 @pytest.mark.parametrize('expected, transformed', [
     # strings with zero or one slash or with escaped slashes means no regular
     # expression present, so the result should just be what re.escape returns.


### PR DESCRIPTION
Fixed crashes that occur when attempting to open a file in a non-existent directory or a when the filename is too long.

Specifically fixed this when redirecting output to a file and when saving a transcript based on the history.

Also added a couple unit tests related to the fixes.

This closes #430