### PR TITLE
Fix unexpected redirection behavior

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1840,7 +1840,7 @@ class Cmd(cmd.Cmd):
                 # REDIRECTION_APPEND or REDIRECTION_OUTPUT
                 if statement.output == constants.REDIRECTION_APPEND:
                     mode = 'a'
-                sys.stdout = self.stdout = open(os.path.expanduser(shlex.split(statement.output_to)[0]), mode)
+                sys.stdout = self.stdout = open(statement.output_to, mode)
             else:
                 # going to a paste buffer
                 sys.stdout = self.stdout = tempfile.TemporaryFile(mode="w+")

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1840,7 +1840,7 @@ class Cmd(cmd.Cmd):
                 # REDIRECTION_APPEND or REDIRECTION_OUTPUT
                 if statement.output == constants.REDIRECTION_APPEND:
                     mode = 'a'
-                sys.stdout = self.stdout = open(os.path.expanduser(statement.output_to), mode)
+                sys.stdout = self.stdout = open(os.path.expanduser(shlex.split(statement.output_to)[0]), mode)
             else:
                 # going to a paste buffer
                 sys.stdout = self.stdout = tempfile.TemporaryFile(mode="w+")


### PR DESCRIPTION
New behavior:
- help > name with space
    - redirects to a file called "name" (without the quotes)
- help > "name with space"
    - redirects to a file called "name with space" (without the quotes)

TODO:
- [x] Fix Windows unit tests


This closes #431 