### PR TITLE
Enable a few more bash completion tests on TravisCI

### DIFF
--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -16,22 +16,22 @@ from cmd2.argparse_completer import ACArgumentParser, AutoCompleter
 
 try:
     from cmd2.argcomplete_bridge import CompletionFinder, tokens_for_completion
-    skip_reason1 = False
+    skip_no_argcomplete = False
     skip_reason = ''
 except ImportError:
     # Don't test if argcomplete isn't present (likely on Windows)
-    skip_reason1 = True
+    skip_no_argcomplete = True
     skip_reason = "argcomplete isn't installed\n"
 
-skip_reason2 = "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true"
-if skip_reason2:
+skip_travis = "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true"
+if skip_travis:
     skip_reason += 'These tests cannot run on TRAVIS\n'
 
-skip_reason3 = sys.platform.startswith('win')
-if skip_reason3:
+skip_windows = sys.platform.startswith('win')
+if skip_windows:
     skip_reason = 'argcomplete doesn\'t support Windows'
 
-skip = skip_reason1 or skip_reason2 or skip_reason3
+skip = skip_no_argcomplete or skip_travis or skip_windows
 
 skip_mac = sys.platform.startswith('dar')
 
@@ -103,7 +103,7 @@ def parser1():
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip_reason1 or skip_reason3, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete or skip_windows, reason=skip_reason)
 def test_bash_nocomplete(parser1):
     completer = CompletionFinder()
     result = completer(parser1, AutoCompleter(parser1))
@@ -122,7 +122,7 @@ def my_fdopen(fd, mode, *args):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip_reason1 or skip_reason3, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete or skip_windows, reason=skip_reason)
 def test_invalid_ifs(parser1, mock):
     completer = CompletionFinder()
 
@@ -136,7 +136,7 @@ def test_invalid_ifs(parser1, mock):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip or skip_mac, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete or skip_windows or skip_mac, reason=skip_reason)
 @pytest.mark.parametrize('comp_line, exp_out, exp_err', [
     ('media ', 'movies\013shows', ''),
     ('media mo', 'movies', ''),
@@ -232,7 +232,7 @@ Hint:
     assert out == exp_out
     assert err == exp_err
 
-@pytest.mark.skipif(skip_reason1, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete, reason=skip_reason)
 def test_argcomplete_tokens_for_completion_simple():
     line = 'this is "a test"'
     endidx = len(line)
@@ -243,7 +243,7 @@ def test_argcomplete_tokens_for_completion_simple():
     assert begin_idx == line.rfind("is ") + len("is ")
     assert end_idx == end_idx
 
-@pytest.mark.skipif(skip_reason1, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete, reason=skip_reason)
 def test_argcomplete_tokens_for_completion_unclosed_quotee_exception():
     line = 'this is "a test'
     endidx = len(line)

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -103,7 +103,7 @@ def parser1():
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip, reason=skip_reason)
+@pytest.mark.skipif(skip, reason=(skip_reason1 or skip_reason3))
 def test_bash_nocomplete(parser1):
     completer = CompletionFinder()
     result = completer(parser1, AutoCompleter(parser1))

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -138,7 +138,7 @@ def test_invalid_ifs(parser1, mock):
 # noinspection PyShadowingNames
 @pytest.mark.skipif(skip_no_argcomplete or skip_windows or skip_mac, reason=skip_reason)
 @pytest.mark.parametrize('comp_line, exp_out, exp_err', [
-    ('media ', 'movies\013shows', ''),
+    ('media mo', 'movies', ''),
 ])
 def test_commands_travis(parser1, capfd, mock, comp_line, exp_out, exp_err):
     mock.patch.dict(os.environ, {'_ARGCOMPLETE': '1',
@@ -164,7 +164,7 @@ def test_commands_travis(parser1, capfd, mock, comp_line, exp_out, exp_err):
 # noinspection PyShadowingNames
 @pytest.mark.skipif(skip or skip_mac, reason=skip_reason)
 @pytest.mark.parametrize('comp_line, exp_out, exp_err', [
-    ('media mo', 'movies', ''),
+    ('media ', 'movies\013shows', ''),
     ('media movies list -a "J', '"John Boyega"\013"Jake Lloyd"', ''),
     ('media movies list ', '', ''),
     ('media movies add ', '\013\013 ', '''

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -176,7 +176,7 @@ def fdopen_fail_8(fd, mode, *args):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete or skip_windows, reason=skip_reason)
 def test_fail_alt_stdout(parser1, mock):
     completer = CompletionFinder()
 

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -205,7 +205,7 @@ def fdopen_fail_9(fd, mode, *args):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip or skip_mac, reason=skip_reason)
+@pytest.mark.skipif(skip_no_argcomplete or skip_windows or skip_mac, reason=skip_reason)
 def test_fail_alt_stderr(parser1, capfd, mock):
     completer = CompletionFinder()
 

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -122,7 +122,7 @@ def my_fdopen(fd, mode, *args):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip, reason=skip_reason)
+@pytest.mark.skipif(skip_reason1 or skip_reason3, reason=skip_reason)
 def test_invalid_ifs(parser1, mock):
     completer = CompletionFinder()
 

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -103,7 +103,7 @@ def parser1():
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip, reason=(skip_reason1 or skip_reason3))
+@pytest.mark.skipif(skip_reason1 or skip_reason3, reason=skip_reason)
 def test_bash_nocomplete(parser1):
     completer = CompletionFinder()
     result = completer(parser1, AutoCompleter(parser1))

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -136,7 +136,7 @@ def test_invalid_ifs(parser1, mock):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip_no_argcomplete or skip_windows or skip_mac, reason=skip_reason)
+@pytest.mark.skipif(skip or skip_mac, reason=skip_reason)
 @pytest.mark.parametrize('comp_line, exp_out, exp_err', [
     ('media ', 'movies\013shows', ''),
     ('media mo', 'movies', ''),

--- a/tests/test_bashcompletion.py
+++ b/tests/test_bashcompletion.py
@@ -136,42 +136,17 @@ def test_invalid_ifs(parser1, mock):
 
 
 # noinspection PyShadowingNames
-@pytest.mark.skipif(skip_no_argcomplete or skip_windows or skip_mac, reason=skip_reason)
-@pytest.mark.parametrize('comp_line, exp_out, exp_err', [
-    ('media mo', 'movies', ''),
-])
-def test_commands_travis(parser1, capfd, mock, comp_line, exp_out, exp_err):
-    mock.patch.dict(os.environ, {'_ARGCOMPLETE': '1',
-                                 '_ARGCOMPLETE_IFS': '\013',
-                                 'COMP_TYPE': '63',
-                                 'COMP_LINE': comp_line,
-                                 'COMP_POINT': str(len(comp_line))})
-
-    mock.patch.object(os, 'fdopen', my_fdopen)
-
-    with pytest.raises(SystemExit):
-        completer = CompletionFinder()
-
-        choices = {'actor': query_actors,  # function
-                   }
-        autocompleter = AutoCompleter(parser1, arg_choices=choices)
-        completer(parser1, autocompleter, exit_method=sys.exit)
-
-    out, err = capfd.readouterr()
-    assert out == exp_out
-    assert err == exp_err
-
-# noinspection PyShadowingNames
 @pytest.mark.skipif(skip or skip_mac, reason=skip_reason)
 @pytest.mark.parametrize('comp_line, exp_out, exp_err', [
     ('media ', 'movies\013shows', ''),
+    ('media mo', 'movies', ''),
     ('media movies list -a "J', '"John Boyega"\013"Jake Lloyd"', ''),
     ('media movies list ', '', ''),
     ('media movies add ', '\013\013 ', '''
 Hint:
   TITLE                   Movie Title'''),
 ])
-def test_commands_local(parser1, capfd, mock, comp_line, exp_out, exp_err):
+def test_commands(parser1, capfd, mock, comp_line, exp_out, exp_err):
     mock.patch.dict(os.environ, {'_ARGCOMPLETE': '1',
                                  '_ARGCOMPLETE_IFS': '\013',
                                  'COMP_TYPE': '63',


### PR DESCRIPTION
Most of the unit tests of the code in **argcomplete_bridge.py** were disabled on TravisCI since some of them fail there.

This PR selectively enables some more bash completion unit tests on TravisCI.

It also renamed a few variables used to determine when certain tests should be skipped to make them more self-documenting.

This partially addresses #268 