### PR TITLE
Minor formatting changes to argcomplete_bridge.py

### DIFF
--- a/cmd2/argcomplete_bridge.py
+++ b/cmd2/argcomplete_bridge.py
@@ -16,7 +16,6 @@ else:
     except AttributeError:
         DEFAULT_COMPLETER = argcomplete.completers.FilesCompleter()
 
-    from cmd2.argparse_completer import ACTION_ARG_CHOICES, ACTION_SUPPRESS_HINT
     from contextlib import redirect_stdout
     import copy
     from io import StringIO
@@ -106,18 +105,18 @@ else:
     class CompletionFinder(argcomplete.CompletionFinder):
         """Hijack the functor from argcomplete to call AutoCompleter"""
 
-        def __call__(self, argument_parser, completer=None, always_complete_options=True, exit_method=os._exit, output_stream=None,
-                     exclude=None, validator=None, print_suppressed=False, append_space=None,
+        def __call__(self, argument_parser, completer=None, always_complete_options=True, exit_method=os._exit,
+                     output_stream=None, exclude=None, validator=None, print_suppressed=False, append_space=None,
                      default_completer=DEFAULT_COMPLETER):
             """
             :param argument_parser: The argument parser to autocomplete on
             :type argument_parser: :class:`argparse.ArgumentParser`
             :param always_complete_options:
-                Controls the autocompletion of option strings if an option string opening character (normally ``-``) has not
-                been entered. If ``True`` (default), both short (``-x``) and long (``--x``) option strings will be
-                suggested. If ``False``, no option strings will be suggested. If ``long``, long options and short options
-                with no long variant will be suggested. If ``short``, short options and long options with no short variant
-                will be suggested.
+                Controls the autocompletion of option strings if an option string opening character (normally ``-``) has
+                not been entered. If ``True`` (default), both short (``-x``) and long (``--x``) option strings will be
+                suggested. If ``False``, no option strings will be suggested. If ``long``, long options and short
+                options with no long variant will be suggested. If ``short``, short options and long options with no
+                short variant will be suggested.
             :type always_complete_options: boolean or string
             :param exit_method:
                 Method used to stop the program after printing completions. Defaults to :meth:`os._exit`. If you want to
@@ -126,8 +125,8 @@ else:
             :param exclude: List of strings representing options to be omitted from autocompletion
             :type exclude: iterable
             :param validator:
-                Function to filter all completions through before returning (called with two string arguments, completion
-                and prefix; return value is evaluated as a boolean)
+                Function to filter all completions through before returning (called with two string arguments,
+                completion and prefix; return value is evaluated as a boolean)
             :type validator: callable
             :param print_suppressed:
                 Whether or not to autocomplete options that have the ``help=argparse.SUPPRESS`` keyword argument set.
@@ -142,18 +141,18 @@ else:
 
             Produces tab completions for ``argument_parser``. See module docs for more info.
 
-            Argcomplete only executes actions if their class is known not to have side effects. Custom action classes can be
-            added to argcomplete.safe_actions, if their values are wanted in the ``parsed_args`` completer argument, or
-            their execution is otherwise desirable.
+            Argcomplete only executes actions if their class is known not to have side effects. Custom action classes
+            can be added to argcomplete.safe_actions, if their values are wanted in the ``parsed_args`` completer
+            argument, or their execution is otherwise desirable.
             """
             # Older versions of argcomplete have fewer keyword arguments
             if sys.version_info >= (3, 5):
                 self.__init__(argument_parser, always_complete_options=always_complete_options, exclude=exclude,
-                            validator=validator, print_suppressed=print_suppressed, append_space=append_space,
-                            default_completer=default_completer)
+                              validator=validator, print_suppressed=print_suppressed, append_space=append_space,
+                              default_completer=default_completer)
             else:
                 self.__init__(argument_parser, always_complete_options=always_complete_options, exclude=exclude,
-                            validator=validator, print_suppressed=print_suppressed)
+                              validator=validator, print_suppressed=print_suppressed)
 
             if "_ARGCOMPLETE" not in os.environ:
                 # not an argument completion invocation
@@ -171,10 +170,6 @@ else:
                     argcomplete.debug("Unable to open fd 8 for writing, quitting")
                     exit_method(1)
 
-            # print("", stream=debug_stream)
-            # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():
-            #     print(v, os.environ[v], stream=debug_stream)
-
             ifs = os.environ.get("_ARGCOMPLETE_IFS", "\013")
             if len(ifs) != 1:
                 argcomplete.debug("Invalid value for IFS, quitting [{v}]".format(v=ifs))
@@ -190,8 +185,6 @@ else:
             #
             # Replaced with our own tokenizer function
             ##############################
-
-            # cword_prequote, cword_prefix, cword_suffix, comp_words, last_wordbreak_pos = split_line(comp_line, comp_point)
             tokens, _, begidx, endidx = tokens_for_completion(comp_line, comp_point)
 
             # _ARGCOMPLETE is set by the shell script to tell us where comp_words
@@ -257,11 +250,3 @@ else:
             output_stream.flush()
             argcomplete.debug_stream.flush()
             exit_method(0)
-
-
-    def bash_complete(action, show_hint: bool=True):
-        """Helper function to configure an argparse action to fall back to bash completion"""
-        def complete_none(*args, **kwargs):
-            return None
-        setattr(action, ACTION_SUPPRESS_HINT, not show_hint)
-        setattr(action, ACTION_ARG_CHOICES, (complete_none,))

--- a/cmd2/argcomplete_bridge.py
+++ b/cmd2/argcomplete_bridge.py
@@ -16,6 +16,7 @@ else:
     except AttributeError:
         DEFAULT_COMPLETER = argcomplete.completers.FilesCompleter()
 
+    from cmd2.argparse_completer import ACTION_ARG_CHOICES, ACTION_SUPPRESS_HINT
     from contextlib import redirect_stdout
     import copy
     from io import StringIO
@@ -250,3 +251,15 @@ else:
             output_stream.flush()
             argcomplete.debug_stream.flush()
             exit_method(0)
+
+
+    def bash_complete(action, show_hint: bool = True):
+        """Helper function to configure an argparse action to fall back to bash completion.
+
+        This function tags a parameter for bash completion, bypassing the autocompleter (for file input).
+        """
+        def complete_none(*args, **kwargs):
+            return None
+
+        setattr(action, ACTION_SUPPRESS_HINT, not show_hint)
+        setattr(action, ACTION_ARG_CHOICES, (complete_none,))

--- a/tasks.py
+++ b/tasks.py
@@ -54,6 +54,21 @@ def pytest_clean(context):
 namespace_clean.add_task(pytest_clean, 'pytest')
 
 @invoke.task
+def mypy(context):
+    "Run mypy optional static type checker"
+    context.run("mypy main.py")
+    namespace.add_task(mypy)
+namespace.add_task(mypy)
+
+@invoke.task
+def mypy_clean(context):
+    "Remove mypy cache directory"
+    #pylint: disable=unused-argument
+    dirs = ['.mypy_cache']
+    rmrf(dirs)
+namespace_clean.add_task(mypy_clean, 'mypy')
+
+@invoke.task
 def tox(context):
     "Run unit and integration tests on multiple python versions using tox"
     context.run("tox")

--- a/tasks.py
+++ b/tasks.py
@@ -49,7 +49,7 @@ namespace.add_task(pytest)
 def pytest_clean(context):
     "Remove pytest cache and code coverage files and directories"
     #pylint: disable=unused-argument
-    dirs = ['.pytest-cache', '.cache', 'htmlcov', '.coverage']
+    dirs = ['.pytest_cache', '.cache', 'htmlcov', '.coverage']
     rmrf(dirs)
 namespace_clean.add_task(pytest_clean, 'pytest')
 


### PR DESCRIPTION
Made some minor formatting changes in argcomplete_bridge.py to make PyCharm happy.

Also:
- Fixed typo where "invoke clean" was cleaning up .pytest-cache instead of .pytest_cache
- Added invoke command for running the mypy optional static type checker
- Added invoke command for cleaning up the mypy cache directory