### PR TITLE
Improve type hinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ htmlcov
 
 # Visual Studio Code
 .vscode
+
+# mypy optional static type checker
+.mypy_cache

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -1,4 +1,5 @@
 #
 # -*- coding: utf-8 -*-
+"""This simply imports certain things for backwards compatibility."""
 from .cmd2 import __version__, Cmd, CmdResult, Statement, EmptyStatement, categorize
 from .cmd2 import with_argument_list, with_argparser, with_argparser_and_unknown_args, with_category

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -80,16 +80,16 @@ ACTION_SUPPRESS_HINT = 'suppress_hint'
 
 
 class CompletionItem(str):
-    def __new__(cls, o, desc='', *args, **kwargs):
+    def __new__(cls, o, desc='', *args, **kwargs) -> str:
         return str.__new__(cls, o, *args, **kwargs)
 
     # noinspection PyMissingConstructor,PyUnusedLocal
-    def __init__(self, o, desc='', *args, **kwargs):
+    def __init__(self, o, desc='', *args, **kwargs) -> None:
         self.description = desc
 
 
 class _RangeAction(object):
-    def __init__(self, nargs: Union[int, str, Tuple[int, int], None]):
+    def __init__(self, nargs: Union[int, str, Tuple[int, int], None]) -> None:
         self.nargs_min = None
         self.nargs_max = None
 
@@ -128,7 +128,7 @@ class _StoreRangeAction(argparse._StoreAction, _RangeAction):
                  choices=None,
                  required=False,
                  help=None,
-                 metavar=None):
+                 metavar=None) -> None:
 
         _RangeAction.__init__(self, nargs)
 
@@ -157,7 +157,7 @@ class _AppendRangeAction(argparse._AppendAction, _RangeAction):
                  choices=None,
                  required=False,
                  help=None,
-                 metavar=None):
+                 metavar=None) -> None:
 
         _RangeAction.__init__(self, nargs)
 
@@ -174,7 +174,7 @@ class _AppendRangeAction(argparse._AppendAction, _RangeAction):
                                         metavar=metavar)
 
 
-def register_custom_actions(parser: argparse.ArgumentParser):
+def register_custom_actions(parser: argparse.ArgumentParser) -> None:
     """Register custom argument action types"""
     parser.register('action', None, _StoreRangeAction)
     parser.register('action', 'store', _StoreRangeAction)
@@ -185,14 +185,14 @@ class AutoCompleter(object):
     """Automatically command line tab completion based on argparse parameters"""
 
     class _ArgumentState(object):
-        def __init__(self):
+        def __init__(self) -> None:
             self.min = None
             self.max = None
             self.count = 0
             self.needed = False
             self.variable = False
 
-        def reset(self):
+        def reset(self) -> None:
             """reset tracking values"""
             self.min = None
             self.max = None
@@ -206,7 +206,7 @@ class AutoCompleter(object):
                  arg_choices: Dict[str, Union[List, Tuple, Callable]] = None,
                  subcmd_args_lookup: dict = None,
                  tab_for_arg_help: bool = True,
-                 cmd2_app=None):
+                 cmd2_app=None) -> None:
         """
         Create an AutoCompleter
 
@@ -439,7 +439,7 @@ class AutoCompleter(object):
 
         return completion_results
 
-    def _format_completions(self, action, completions: List[Union[str, CompletionItem]]):
+    def _format_completions(self, action, completions: List[Union[str, CompletionItem]]) -> List[str]:
         if completions and len(completions) > 1 and isinstance(completions[0], CompletionItem):
             token_width = len(action.dest)
             completions_with_desc = []
@@ -665,7 +665,7 @@ class AutoCompleter(object):
 class ACHelpFormatter(argparse.HelpFormatter):
     """Custom help formatter to configure ordering of help text"""
 
-    def _format_usage(self, usage, actions, groups, prefix):
+    def _format_usage(self, usage, actions, groups, prefix) -> str:
         if prefix is None:
             prefix = _('Usage: ')
 
@@ -778,7 +778,7 @@ class ACHelpFormatter(argparse.HelpFormatter):
         # prefix with 'usage:'
         return '%s%s\n\n' % (prefix, usage)
 
-    def _format_action_invocation(self, action):
+    def _format_action_invocation(self, action) -> str:
         if not action.option_strings:
             default = self._get_default_metavar_for_positional(action)
             metavar, = self._metavar_formatter(action, default)(1)
@@ -803,7 +803,7 @@ class ACHelpFormatter(argparse.HelpFormatter):
                 return ', '.join(action.option_strings) + ' ' + args_string
             # End cmd2 customization
 
-    def _metavar_formatter(self, action, default_metavar):
+    def _metavar_formatter(self, action, default_metavar) -> Callable:
         if action.metavar is not None:
             result = action.metavar
         elif action.choices is not None:
@@ -822,7 +822,7 @@ class ACHelpFormatter(argparse.HelpFormatter):
                 return (result, ) * tuple_size
         return format
 
-    def _format_args(self, action, default_metavar):
+    def _format_args(self, action, default_metavar) -> str:
         get_metavar = self._metavar_formatter(action, default_metavar)
         # Begin cmd2 customization (less verbose)
         if isinstance(action, _RangeAction) and \
@@ -837,7 +837,7 @@ class ACHelpFormatter(argparse.HelpFormatter):
             result = super()._format_args(action, default_metavar)
         return result
 
-    def _split_lines(self, text, width):
+    def _split_lines(self, text: str, width) -> List[str]:
         return text.splitlines()
 
 
@@ -845,7 +845,7 @@ class ACHelpFormatter(argparse.HelpFormatter):
 class ACArgumentParser(argparse.ArgumentParser):
     """Custom argparse class to override error method to change default help text."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         if 'formatter_class' not in kwargs:
             kwargs['formatter_class'] = ACHelpFormatter
 
@@ -855,7 +855,7 @@ class ACArgumentParser(argparse.ArgumentParser):
         self._custom_error_message = ''
 
     # Begin cmd2 customization
-    def set_custom_message(self, custom_message=''):
+    def set_custom_message(self, custom_message: str='') -> None:
         """
         Allows an error message override to the error() function, useful when forcing a
         re-parse of arguments with newly required parameters
@@ -863,7 +863,7 @@ class ACArgumentParser(argparse.ArgumentParser):
         self._custom_error_message = custom_message
     # End cmd2 customization
 
-    def error(self, message):
+    def error(self, message: str) -> None:
         """Custom error override. Allows application to control the error being displayed by argparse"""
         if len(self._custom_error_message) > 0:
             message = self._custom_error_message
@@ -884,7 +884,7 @@ class ACArgumentParser(argparse.ArgumentParser):
         self.print_help()
         sys.exit(1)
 
-    def format_help(self):
+    def format_help(self) -> str:
         """Copy of format_help() from argparse.ArgumentParser with tweaks to separately display required parameters"""
         formatter = self._get_formatter()
 
@@ -934,7 +934,7 @@ class ACArgumentParser(argparse.ArgumentParser):
         # determine help from format above
         return formatter.format_help()
 
-    def _get_nargs_pattern(self, action):
+    def _get_nargs_pattern(self, action) -> str:
         # Override _get_nargs_pattern behavior to use the nargs ranges provided by AutoCompleter
         if isinstance(action, _RangeAction) and \
                 action.nargs_min is not None and action.nargs_max is not None:
@@ -947,7 +947,7 @@ class ACArgumentParser(argparse.ArgumentParser):
             return nargs_pattern
         return super(ACArgumentParser, self)._get_nargs_pattern(action)
 
-    def _match_argument(self, action, arg_strings_pattern):
+    def _match_argument(self, action, arg_strings_pattern) -> int:
         # match the pattern for this action to the arg strings
         nargs_pattern = self._get_nargs_pattern(action)
         match = _re.match(nargs_pattern, arg_strings_pattern)
@@ -963,7 +963,7 @@ class ACArgumentParser(argparse.ArgumentParser):
 
     # This is the official python implementation with a 5 year old patch applied
     # See the comment below describing the patch
-    def _parse_known_args(self, arg_strings, namespace):  # pragma: no cover
+    def _parse_known_args(self, arg_strings, namespace) -> Tuple[argparse.Namespace, List[str]]:  # pragma: no cover
         # replace arg strings that are file references
         if self.fromfile_prefix_chars is not None:
             arg_strings = self._read_args_from_files(arg_strings)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -39,7 +39,7 @@ import platform
 import re
 import shlex
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import pyperclip
 
@@ -940,7 +940,7 @@ class Cmd(cmd.Cmd):
         return completions_matches
 
     def index_based_complete(self, text: str, line: str, begidx: int, endidx: int,
-                             index_dict: Dict[int, Union[Iterable, Callable]],
+                             index_dict: Mapping[int, Union[Iterable, Callable]],
                              all_else: Union[None, Iterable, Callable] = None) -> List[str]:
         """
         Tab completes based on a fixed position in the input string
@@ -1950,7 +1950,8 @@ class Cmd(cmd.Cmd):
         """
         funcname = self._func_named(statement.command)
         if not funcname:
-            return self.default(statement)
+            self.default(statement)
+            return
 
         # Since we have a valid command store it in the history
         if statement.command not in self.exclude_from_history:
@@ -1959,7 +1960,8 @@ class Cmd(cmd.Cmd):
         try:
             func = getattr(self, funcname)
         except AttributeError:
-            return self.default(statement)
+            self.default(statement)
+            return
 
         stop = func(statement)
         return stop
@@ -2420,8 +2422,8 @@ Usage:  Usage: unalias [-a] name [name ...]
                     readline.remove_history_item(hlen - 1)
 
             try:
-                response = int(response)
-                result = fulloptions[response - 1][0]
+                choice = int(response)
+                result = fulloptions[choice - 1][0]
                 break
             except (ValueError, IndexError):
                 self.poutput("{!r} isn't a valid choice. Pick a number between 1 and {}:\n".format(response,

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1304,7 +1304,7 @@ class Cmd(cmd.Cmd):
 
     # -----  Methods which override stuff in cmd -----
 
-    def complete(self, text, state):
+    def complete(self, text: str, state: int) -> Optional[str]:
         """Override of command method which returns the next possible completion for 'text'.
 
         If a command has not been entered, then complete against command list.
@@ -1315,8 +1315,8 @@ class Cmd(cmd.Cmd):
         This completer function is called as complete(text, state), for state in 0, 1, 2, …, until it returns a
         non-string value. It should return the next possible completion starting with text.
 
-        :param text: str - the current word that user is typing
-        :param state: int - non-negative integer
+        :param text: the current word that user is typing
+        :param state: non-negative integer
         """
         import functools
         if state == 0 and rl_type != RlType.NONE:
@@ -1532,16 +1532,12 @@ class Cmd(cmd.Cmd):
 
         return results
 
-    def get_all_commands(self):
-        """
-        Returns a list of all commands
-        """
+    def get_all_commands(self) -> List[str]:
+        """Returns a list of all commands."""
         return [cur_name[3:] for cur_name in self.get_names() if cur_name.startswith('do_')]
 
-    def get_visible_commands(self):
-        """
-        Returns a list of commands that have not been hidden
-        """
+    def get_visible_commands(self) -> List[str]:
+        """Returns a list of commands that have not been hidden."""
         commands = self.get_all_commands()
 
         # Remove the hidden commands
@@ -1551,11 +1547,11 @@ class Cmd(cmd.Cmd):
 
         return commands
 
-    def get_help_topics(self):
+    def get_help_topics(self) -> List[str]:
         """ Returns a list of help topics """
         return [name[5:] for name in self.get_names() if name.startswith('help_')]
 
-    def complete_help(self, text, line, begidx, endidx):
+    def complete_help(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
         """
         Override of parent class method to handle tab completing subcommands and not showing hidden commands
         Returns a list of possible tab completions
@@ -1599,12 +1595,12 @@ class Cmd(cmd.Cmd):
         return matches
 
     # noinspection PyUnusedLocal
-    def sigint_handler(self, signum, frame):
+    def sigint_handler(self, signum: int, frame) -> None:
         """Signal handler for SIGINTs which typically come from Ctrl-C events.
 
         If you need custom SIGINT behavior, then override this function.
 
-        :param signum: int - signal number
+        :param signum: signal number
         :param frame
         """
 
@@ -1617,7 +1613,7 @@ class Cmd(cmd.Cmd):
         # Re-raise a KeyboardInterrupt so other parts of the code can catch it
         raise KeyboardInterrupt("Got a keyboard interrupt")
 
-    def preloop(self):
+    def preloop(self) -> None:
         """"Hook method executed once when the cmdloop() method is called."""
         import signal
         # Register a default SIGINT signal handler for Ctrl+C
@@ -1626,8 +1622,8 @@ class Cmd(cmd.Cmd):
     def precmd(self, statement: Statement) -> Statement:
         """Hook method executed just before the command is processed by ``onecmd()`` and after adding it to the history.
 
-        :param statement: Statement - subclass of str which also contains the parsed input
-        :return: Statement - a potentially modified version of the input Statement object
+        :param statement: subclass of str which also contains the parsed input
+        :return: a potentially modified version of the input Statement object
         """
         return statement
 
@@ -1637,8 +1633,8 @@ class Cmd(cmd.Cmd):
     def preparse(self, raw: str) -> str:
         """Hook method executed just before the command line is interpreted, but after the input prompt is generated.
 
-        :param raw: str - raw command line input
-        :return: str - potentially modified raw command line input
+        :param raw: raw command line input
+        :return: potentially modified raw command line input
         """
         return raw
 
@@ -1679,25 +1675,24 @@ class Cmd(cmd.Cmd):
                 proc.communicate()
         return stop
 
-    def parseline(self, line):
+    def parseline(self, line: str) -> Tuple[str, str, str]:
         """Parse the line into a command name and a string containing the arguments.
 
         NOTE: This is an override of a parent class method.  It is only used by other parent class methods.
 
         Different from the parent class method, this ignores self.identchars.
 
-        :param line: str - line read by readline
-        :return: (str, str, str) - tuple containing (command, args, line)
+        :param line: line read by readline
+        :return: tuple containing (command, args, line)
         """
-
         statement = self.statement_parser.parse_command_only(line)
         return statement.command, statement.args, statement.command_and_args
 
-    def onecmd_plus_hooks(self, line):
+    def onecmd_plus_hooks(self, line: str) -> bool:
         """Top-level function called by cmdloop() to handle parsing a line and running the command and all of its hooks.
 
-        :param line: str - line of text read from input
-        :return: bool - True if cmdloop() should exit, False otherwise
+        :param line: line of text read from input
+        :return: True if cmdloop() should exit, False otherwise
         """
         import datetime
         stop = False
@@ -1731,7 +1726,7 @@ class Cmd(cmd.Cmd):
         finally:
             return self.postparsing_postcmd(stop)
 
-    def runcmds_plus_hooks(self, cmds):
+    def runcmds_plus_hooks(self, cmds: List[str]) -> bool:
         """Convenience method to run multiple commands by onecmd_plus_hooks.
 
         This method adds the given cmds to the command queue and processes the
@@ -1749,8 +1744,8 @@ class Cmd(cmd.Cmd):
 
         Example: cmd_obj.runcmds_plus_hooks(['load myscript.txt'])
 
-        :param cmds: list - Command strings suitable for onecmd_plus_hooks.
-        :return: bool - True implies the entire application should exit.
+        :param cmds: command strings suitable for onecmd_plus_hooks.
+        :return: True implies the entire application should exit.
 
         """
         stop = False
@@ -1773,7 +1768,7 @@ class Cmd(cmd.Cmd):
             # necessary/desired here.
             return stop
 
-    def _complete_statement(self, line):
+    def _complete_statement(self, line: str) -> Statement:
         """Keep accepting lines of input until the command is complete.
 
         There is some pretty hacky code here to handle some quirks of
@@ -1814,10 +1809,10 @@ class Cmd(cmd.Cmd):
             raise EmptyStatement()
         return statement
 
-    def _redirect_output(self, statement):
+    def _redirect_output(self, statement: Statement) -> None:
         """Handles output redirection for >, >>, and |.
 
-        :param statement: Statement - a parsed statement from the user
+        :param statement: a parsed statement from the user
         """
         import io
         import subprocess
@@ -1874,12 +1869,11 @@ class Cmd(cmd.Cmd):
                 if statement.output == constants.REDIRECTION_APPEND:
                     self.poutput(get_paste_buffer())
 
-    def _restore_output(self, statement):
+    def _restore_output(self, statement: Statement) -> None:
         """Handles restoring state after output redirection as well as
         the actual pipe operation if present.
 
-        :param statement: Statement object which contains the parsed
-                          input from the user
+        :param statement: Statement object which contains the parsed input from the user
         """
         # If we have redirected output to a file or the clipboard or piped it to a shell command, then restore state
         if self.kept_state is not None:
@@ -1910,11 +1904,11 @@ class Cmd(cmd.Cmd):
 
         self.redirecting = False
 
-    def _func_named(self, arg):
+    def _func_named(self, arg: str) -> str:
         """Gets the method name associated with a given command.
 
-        :param arg: str - command to look up method name which implements it
-        :return: str - method name which implements the given command
+        :param arg: command to look up method name which implements it
+        :return: method name which implements the given command
         """
         result = None
         target = 'do_' + arg
@@ -1922,13 +1916,13 @@ class Cmd(cmd.Cmd):
             result = target
         return result
 
-    def onecmd(self, statement):
+    def onecmd(self, statement: Statement) -> Optional[bool]:
         """ This executes the actual do_* method for a command.
 
         If the command provided doesn't exist, then it executes _default() instead.
 
         :param statement: Command - a parsed command from the input stream
-        :return: bool - a flag indicating whether the interpretation of commands should stop
+        :return: a flag indicating whether the interpretation of commands should stop
         """
         funcname = self._func_named(statement.command)
         if not funcname:
@@ -1946,11 +1940,10 @@ class Cmd(cmd.Cmd):
         stop = func(statement)
         return stop
 
-    def default(self, statement):
+    def default(self, statement: Statement) -> None:
         """Executed when the command given isn't a recognized command implemented by a do_* method.
 
         :param statement: Statement object with parsed input
-        :return:
         """
         arg = statement.raw
         if self.default_to_shell:
@@ -1963,13 +1956,13 @@ class Cmd(cmd.Cmd):
         self.poutput('*** Unknown syntax: {}\n'.format(arg))
 
     @staticmethod
-    def _surround_ansi_escapes(prompt, start="\x01", end="\x02"):
+    def _surround_ansi_escapes(prompt: str, start: str="\x01", end: str="\x02") -> str:
         """Overcome bug in GNU Readline in relation to calculation of prompt length in presence of ANSI escape codes.
 
-        :param prompt: str - original prompt
-        :param start: str - start code to tell GNU Readline about beginning of invisible characters
-        :param end: str - end code to tell GNU Readline about end of invisible characters
-        :return: str - prompt safe to pass to GNU Readline
+        :param prompt: original prompt
+        :param start: start code to tell GNU Readline about beginning of invisible characters
+        :param end: end code to tell GNU Readline about end of invisible characters
+        :return: prompt safe to pass to GNU Readline
         """
         # Windows terminals don't use ANSI escape codes and Windows readline isn't based on GNU Readline
         if sys.platform == "win32":
@@ -1990,9 +1983,8 @@ class Cmd(cmd.Cmd):
 
         return result
 
-    def pseudo_raw_input(self, prompt):
-        """
-        began life as a copy of cmd's cmdloop; like raw_input but
+    def pseudo_raw_input(self, prompt: str) -> str:
+        """Began life as a copy of cmd's cmdloop; like raw_input but
 
         - accounts for changed stdin, stdout
         - if input is a pipe (instead of a tty), look at self.echo
@@ -2033,14 +2025,14 @@ class Cmd(cmd.Cmd):
                     line = 'eof'
         return line.strip()
 
-    def _cmdloop(self):
+    def _cmdloop(self) -> bool:
         """Repeatedly issue a prompt, accept input, parse an initial prefix
         off the received input, and dispatch to action methods, passing them
         the remainder of the line as argument.
 
         This serves the same role as cmd.cmdloop().
 
-        :return: bool - True implies the entire application should exit.
+        :return: True implies the entire application should exit.
         """
         # An almost perfect copy from Cmd; however, the pseudo_raw_input portion
         # has been split out so that it can be called separately
@@ -2070,7 +2062,7 @@ class Cmd(cmd.Cmd):
             # Enable tab completion
             readline.parse_and_bind(self.completekey + ": complete")
 
-        stop = None
+        stop = False
         try:
             while not stop:
                 if self.cmdqueue:
@@ -2111,7 +2103,7 @@ class Cmd(cmd.Cmd):
             return stop
 
     @with_argument_list
-    def do_alias(self, arglist):
+    def do_alias(self, arglist: List[str]) -> None:
         """Define or display aliases
 
 Usage:  Usage: alias [name] | [<name> <value>]
@@ -2167,7 +2159,7 @@ Usage:  Usage: alias [name] | [<name> <value>]
                 errmsg = "Aliases can not contain: {}".format(invalidchars)
                 self.perror(errmsg, traceback_war=False)
 
-    def complete_alias(self, text, line, begidx, endidx):
+    def complete_alias(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
         """ Tab completion for alias """
         alias_names = set(self.aliases.keys())
         visible_commands = set(self.get_visible_commands())
@@ -2180,7 +2172,7 @@ Usage:  Usage: alias [name] | [<name> <value>]
         return self.index_based_complete(text, line, begidx, endidx, index_dict, self.path_complete)
 
     @with_argument_list
-    def do_unalias(self, arglist):
+    def do_unalias(self, arglist: List[str]) -> None:
         """Unsets aliases
 
 Usage:  Usage: unalias [-a] name [name ...]
@@ -2191,7 +2183,7 @@ Usage:  Usage: unalias [-a] name [name ...]
         -a     remove all alias definitions
 """
         if not arglist:
-            self.do_help('unalias')
+            self.do_help(['unalias'])
 
         if '-a' in arglist:
             self.aliases.clear()
@@ -2208,12 +2200,12 @@ Usage:  Usage: unalias [-a] name [name ...]
                 else:
                     self.perror("Alias {!r} does not exist".format(cur_arg), traceback_war=False)
 
-    def complete_unalias(self, text, line, begidx, endidx):
+    def complete_unalias(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
         """ Tab completion for unalias """
         return self.basic_complete(text, line, begidx, endidx, self.aliases)
 
     @with_argument_list
-    def do_help(self, arglist):
+    def do_help(self, arglist: List[str]) -> None:
         """List available commands with "help" or detailed help with "help cmd"."""
         if not arglist or (len(arglist) == 1 and arglist[0] in ('--verbose', '-v')):
             verbose = len(arglist) == 1 and arglist[0] in ('--verbose', '-v')
@@ -2240,7 +2232,7 @@ Usage:  Usage: unalias [-a] name [name ...]
                 # This could be a help topic
                 cmd.Cmd.do_help(self, arglist[0])
 
-    def _help_menu(self, verbose=False):
+    def _help_menu(self, verbose: bool=False) -> None:
         """Show a list of commands which help can be displayed for.
         """
         # Get a sorted list of help topics
@@ -2283,7 +2275,7 @@ Usage:  Usage: unalias [-a] name [name ...]
         self.print_topics(self.misc_header, help_topics, 15, 80)
         self.print_topics(self.undoc_header, cmds_undoc, 15, 80)
 
-    def _print_topics(self, header, cmds, verbose):
+    def _print_topics(self, header: str, cmds: List[str], verbose: bool) -> None:
         """Customized version of print_topics that can switch between verbose or traditional output"""
         import io
 
@@ -2354,7 +2346,7 @@ Usage:  Usage: unalias [-a] name [name ...]
                         command = ''
                 self.stdout.write("\n")
 
-    def do_shortcuts(self, _):
+    def do_shortcuts(self, _: str) -> None:
         """Lists shortcuts (aliases) available."""
         result = "\n".join('%s: %s' % (sc[0], sc[1]) for sc in sorted(self.shortcuts))
         self.poutput("Shortcuts for other commands:\n{}\n".format(result))
@@ -2722,7 +2714,7 @@ Paths or arguments that contain spaces must be enclosed in quotes
 """
         if not arglist:
             self.perror("pyscript command requires at least 1 argument ...", traceback_war=False)
-            self.do_help('pyscript')
+            self.do_help(['pyscript'])
             return
 
         # Get the absolute path of the script

--- a/cmd2/pyscript_bridge.py
+++ b/cmd2/pyscript_bridge.py
@@ -10,7 +10,7 @@ Released under MIT license, see LICENSE file
 import argparse
 import functools
 import sys
-from typing import List, Tuple, Callable
+from typing import List, Callable
 
 # Python 3.4 require contextlib2 for temporarily redirecting stderr and stdout
 if sys.version_info < (3, 5):
@@ -298,4 +298,5 @@ class PyscriptBridge(object):
         return commands
 
     def __call__(self, args: str):
-        return _exec_cmd(self._cmd2_app, functools.partial(self._cmd2_app.onecmd_plus_hooks, args + '\n'), self.cmd_echo)
+        return _exec_cmd(self._cmd2_app, functools.partial(self._cmd2_app.onecmd_plus_hooks, args + '\n'),
+                         self.cmd_echo)

--- a/cmd2/pyscript_bridge.py
+++ b/cmd2/pyscript_bridge.py
@@ -40,7 +40,7 @@ class CommandResult(namedtuple_with_defaults('CmdResult', ['stdout', 'stderr', '
 
 class CopyStream(object):
     """Copies all data written to a stream"""
-    def __init__(self, inner_stream, echo: bool = False):
+    def __init__(self, inner_stream, echo: bool = False) -> None:
         self.buffer = ''
         self.inner_stream = inner_stream
         self.echo = echo
@@ -212,7 +212,7 @@ class ArgparseFunctor:
         def process_flag(action, value):
             if isinstance(action, argparse._CountAction):
                 if isinstance(value, int):
-                    for c in range(value):
+                    for _ in range(value):
                         cmd_str[0] += '{} '.format(action.option_strings[0])
                     return
                 else:

--- a/cmd2/transcript.py
+++ b/cmd2/transcript.py
@@ -12,8 +12,10 @@ classes are used in cmd2.py::run_transcript_tests()
 import re
 import glob
 import unittest
+from typing import Tuple
 
 from . import utils
+
 
 class Cmd2TestCase(unittest.TestCase):
     """A unittest class used for transcript testing.
@@ -50,7 +52,7 @@ class Cmd2TestCase(unittest.TestCase):
             for (fname, transcript) in its:
                 self._test_transcript(fname, transcript)
 
-    def _test_transcript(self, fname, transcript):
+    def _test_transcript(self, fname: str, transcript):
         line_num = 0
         finished = False
         line = utils.strip_ansi(next(transcript))
@@ -103,7 +105,7 @@ class Cmd2TestCase(unittest.TestCase):
                       fname, line_num, command, expected, result)
             self.assertTrue(re.match(expected, result, re.MULTILINE | re.DOTALL), message)
 
-    def _transform_transcript_expected(self, s):
+    def _transform_transcript_expected(self, s: str) -> str:
         """Parse the string with slashed regexes into a valid regex.
 
         Given a string like:
@@ -151,7 +153,7 @@ class Cmd2TestCase(unittest.TestCase):
         return regex
 
     @staticmethod
-    def _escaped_find(regex, s, start, in_regex):
+    def _escaped_find(regex: str, s: str, start: int, in_regex: bool) -> Tuple[str, int, int]:
         """Find the next slash in {s} after {start} that is not preceded by a backslash.
 
         If we find an escaped slash, add everything up to and including it to regex,
@@ -162,7 +164,6 @@ class Cmd2TestCase(unittest.TestCase):
         {in_regex} specifies whether we are currently searching in a regex, we behave
         differently if we are or if we aren't.
         """
-
         while True:
             pos = s.find('/', start)
             if pos == -1:
@@ -211,14 +212,11 @@ class OutputTrap(object):
     def __init__(self):
         self.contents = ''
 
-    def write(self, txt):
-        """Add text to the internal contents.
-
-        :param txt: str
-        """
+    def write(self, txt: str):
+        """Add text to the internal contents."""
         self.contents += txt
 
-    def read(self):
+    def read(self) -> str:
         """Read from the internal contents and then clear them out.
 
         :return: str - text from the internal contents

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from . import constants
 
+
 def strip_ansi(text: str) -> str:
     """Strip ANSI escape codes from a string.
 
@@ -58,6 +59,7 @@ def namedtuple_with_defaults(typename, field_names, default_values=()):
     T.__new__.__defaults__ = tuple(prototype)
     return T
 
+
 def namedtuple_with_two_defaults(typename, field_names, default_values=('', '')):
     """Wrapper around namedtuple which lets you treat the last value as optional.
 
@@ -71,6 +73,7 @@ def namedtuple_with_two_defaults(typename, field_names, default_values=('', ''))
     # noinspection PyUnresolvedReferences
     T.__new__.__defaults__ = default_values
     return T
+
 
 def cast(current, new):
     """Tries to force a new value into the same type as the current when trying to set the value for a parameter.
@@ -101,6 +104,7 @@ def cast(current, new):
     print("Problem setting parameter (now %s) to %s; incorrect type?" % (current, new))
     return current
 
+
 def which(editor: str) -> Optional[str]:
     """Find the full path of a given editor.
 
@@ -118,7 +122,8 @@ def which(editor: str) -> Optional[str]:
         editor_path = None
     return editor_path
 
-def is_text_file(file_path):
+
+def is_text_file(file_path: str) -> bool:
     """Returns if a file contains only ASCII or UTF-8 encoded text
 
     :param file_path: path to the file being checked

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -4,7 +4,7 @@
 
 import collections
 import os
-from typing import Optional
+from typing import Any, List, Optional, Union
 
 from . import constants
 
@@ -31,7 +31,8 @@ def strip_quotes(arg: str) -> str:
     return arg
 
 
-def namedtuple_with_defaults(typename, field_names, default_values=()):
+def namedtuple_with_defaults(typename: str, field_names: Union[str, List[str]],
+                             default_values: collections.Iterable=()):
     """
     Convenience function for defining a namedtuple with default values
 
@@ -60,7 +61,8 @@ def namedtuple_with_defaults(typename, field_names, default_values=()):
     return T
 
 
-def namedtuple_with_two_defaults(typename, field_names, default_values=('', '')):
+def namedtuple_with_two_defaults(typename: str, field_names: Union[str, List[str]],
+                                 default_values: collections.Iterable=('', '')):
     """Wrapper around namedtuple which lets you treat the last value as optional.
 
     :param typename: str - type name for the Named tuple
@@ -75,7 +77,7 @@ def namedtuple_with_two_defaults(typename, field_names, default_values=('', ''))
     return T
 
 
-def cast(current, new):
+def cast(current: Any, new: str) -> Any:
     """Tries to force a new value into the same type as the current when trying to set the value for a parameter.
 
     :param current: current value for the parameter, type varies

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1309,7 +1309,7 @@ def test_select_invalid_option(select_app):
     expected = normalize("""
    1. sweet
    2. salty
-3 isn't a valid choice. Pick a number between 1 and 2:
+'3' isn't a valid choice. Pick a number between 1 and 2:
 {} with sweet sauce, yum!
 """.format(food))
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -230,7 +230,7 @@ def test_pyscript_with_nonexist_file(base_app, capsys):
     python_script = 'does_not_exist.py'
     run_cmd(base_app, "pyscript {}".format(python_script))
     out, err = capsys.readouterr()
-    assert err.startswith('ERROR: [Errno 2] No such file or directory:')
+    assert err.startswith("EXCEPTION of type 'FileNotFoundError' occurred with message:")
 
 def test_pyscript_with_exception(base_app, capsys, request):
     test_dir = os.path.dirname(request.module.__file__)


### PR DESCRIPTION
Working on improving type hinting

Also:
- Refactored perror() to remove a rarely used optional argument which was unnecessary

The initial type hinting is substantially complete - not 100%, but close to it.  Also, the type hinting isn't perfect - I'm sure over time we will refine it after running more with something like **mypy** - but it is a good initial approximately correct set of types for function/method arguments and return values.

This closes #355.

