### PR TITLE
Moved clipboard/pastebuffer functionality to new file clipboard.py

### DIFF
--- a/cmd2/clipboard.py
+++ b/cmd2/clipboard.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+"""
+This module provides basic ability to copy from and paste to the clipboard/pastebuffer.
+"""
+import sys
+
+import pyperclip
+
+# Newer versions of pyperclip are released as a single file, but older versions had a more complicated structure
+try:
+    from pyperclip.exceptions import PyperclipException
+except ImportError:  # pragma: no cover
+    # noinspection PyUnresolvedReferences
+    from pyperclip import PyperclipException
+
+# Can we access the clipboard?  Should always be true on Windows and Mac, but only sometimes on Linux
+# noinspection PyUnresolvedReferences
+try:
+    # Get the version of the pyperclip module as a float
+    pyperclip_ver = float('.'.join(pyperclip.__version__.split('.')[:2]))
+
+    # The extraneous output bug in pyperclip on Linux using xclip was fixed in more recent versions of pyperclip
+    if sys.platform.startswith('linux') and pyperclip_ver < 1.6:
+        # Avoid extraneous output to stderr from xclip when clipboard is empty at cost of overwriting clipboard contents
+        pyperclip.copy('')
+    else:
+        # Try getting the contents of the clipboard
+        _ = pyperclip.paste()
+except PyperclipException:
+    can_clip = False
+else:
+    can_clip = True
+
+
+def get_paste_buffer() -> str:
+    """Get the contents of the clipboard / paste buffer.
+
+    :return: contents of the clipboard
+    """
+    pb_str = pyperclip.paste()
+    return pb_str
+
+
+def write_to_paste_buffer(txt: str) -> None:
+    """Copy text to the clipboard / paste buffer.
+
+    :param txt: text to copy to the clipboard
+    """
+    pyperclip.copy(txt)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -22,6 +22,7 @@ except ImportError:
     from unittest import mock
 
 import cmd2
+from cmd2 import clipboard
 from cmd2 import utils
 from .conftest import run_cmd, normalize, BASE_HELP, BASE_HELP_VERBOSE, \
     HELP_HISTORY, SHORTCUTS_TXT, SHOW_TXT, SHOW_LONG, StdOut
@@ -735,7 +736,7 @@ def test_pipe_to_shell_error(base_app, capsys):
     assert err.startswith("EXCEPTION of type '{}' occurred with message:".format(expected_error))
 
 
-@pytest.mark.skipif(not cmd2.cmd2.can_clip,
+@pytest.mark.skipif(not clipboard.can_clip,
                     reason="Pyperclip could not find a copy/paste mechanism for your system")
 def test_send_to_paste_buffer(base_app):
     # Test writing to the PasteBuffer/Clipboard
@@ -1454,13 +1455,12 @@ def test_multiline_complete_statement_without_terminator(multiline_app):
     assert statement.command == command
 
 
-def test_clipboard_failure(capsys):
+def test_clipboard_failure(base_app, capsys):
     # Force cmd2 clipboard to be disabled
-    cmd2.cmd2.disable_clip()
-    app = cmd2.Cmd()
+    base_app.can_clip = False
 
     # Redirect command output to the clipboard when a clipboard isn't present
-    app.onecmd_plus_hooks('help > ')
+    base_app.onecmd_plus_hooks('help > ')
 
     # Make sure we got the error output
     out, err = capsys.readouterr()


### PR DESCRIPTION
Cleaned up clipboard/pastebuffer functionality by moving it from cmd2.py to a new file **clipboard.py**.

Also:
- Converted global can_clip variable to an instance attribute of cmd2.Cmd class

This closes #412 