### PR TITLE
Deleted the CmdResult helper class

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,4 +4,4 @@ install:
 build: off
 
 test_script:
-  - python -m tox -e py35-win,py36-win
+  - python -m tox -e py35-win,py36-win,py37-win

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Bug Fixes
     * Fixed bug when StatementParser ``__init__()`` was called with ``terminators`` equal to ``None``
     * Fixed bug when ``Cmd.onecmd()`` was called with a raw ``str``
+* Deletions
+    * The ``CmdResult`` helper class which was *deprecated* in the previous release has now been deleted
+        * It has been replaced by the improved ``CommandResult`` class
 
 ## 0.9.2 (June 28, 2018)
 * Bug Fixes

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3220,25 +3220,3 @@ class Statekeeper(object):
         if self.obj:
             for attrib in self.attribs:
                 setattr(self.obj, attrib, getattr(self, attrib))
-
-
-class CmdResult(utils.namedtuple_with_two_defaults('CmdResult', ['out', 'err', 'war'])):
-    """DEPRECATED: Derive a class to store results from a named tuple so we can tweak dunder methods for convenience.
-
-    This is provided as a convenience and an example for one possible way for end users to store results in
-    the self._last_result attribute of cmd2.Cmd class instances.  See the "python_scripting.py" example for how it can
-    be used to enable conditional control flow.
-
-    Named tuple attributes
-    ----------------------
-    out - this is intended to store normal output data from the command and can be of any type that makes sense
-    err: str - (optional) this is intended to store an error message and it being non-empty indicates there was an error
-                Defaults to an empty string
-    war: str - (optional) this is intended to store a warning message which isn't quite an error, but of note
-               Defaults to an empty string.
-
-    NOTE: Named tuples are immutable.  So the contents are there for access, not for modification.
-    """
-    def __bool__(self) -> bool:
-        """If err is an empty string, treat the result as a success; otherwise treat it as a failure."""
-        return not self.err

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -61,22 +61,6 @@ def namedtuple_with_defaults(typename: str, field_names: Union[str, List[str]],
     return T
 
 
-def namedtuple_with_two_defaults(typename: str, field_names: Union[str, List[str]],
-                                 default_values: collections.Iterable=('', '')):
-    """Wrapper around namedtuple which lets you treat the last value as optional.
-
-    :param typename: str - type name for the Named tuple
-    :param field_names: List[str] or space-separated string of field names
-    :param default_values: (optional) 2-element tuple containing the default values for last 2 parameters in named tuple
-                            Defaults to an empty string for both of them
-    :return: namedtuple type
-    """
-    T = collections.namedtuple(typename, field_names)
-    # noinspection PyUnresolvedReferences
-    T.__new__.__defaults__ = default_values
-    return T
-
-
 def cast(current: Any, new: str) -> Any:
     """Tries to force a new value into the same type as the current when trying to set the value for a parameter.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,py35-win,py36-win
+envlist = py34,py35,py36,py37,py35-win,py36-win,py37-win
 
 [pytest]
 testpaths = tests
@@ -73,3 +73,13 @@ deps =
   wcwidth
 commands = py.test -v
 
+[testenv:py37-win]
+deps =
+  codecov
+  pyperclip
+  pyreadline
+  pytest
+  pytest-cov
+commands =
+  py.test {posargs} --cov
+  codecov


### PR DESCRIPTION
The CmdResult helper class was deprecated in the previous release.  This commit deletes it.
- The new CommandResult class is an improved replacement

Also:
- Deleted the namedtuple_with_two_defaults helper function which is now no longer used
- Modified AppVeyor / tox config to now also test with Python 3.7 on Windows