### PR TITLE
Add missing dependency on attrs to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+attrs
 colorama
 pyperclip
 wcwidth


### PR DESCRIPTION
This is an attempt at fixing the Sphinx autodoc embedded API documentation.

This partly addresses #479, but I'm going to leave that open while we think about a possible unit test for the autodoc portion of the Sphinx documentation.