### PR TITLE
Removed non-working Module Index link from the main Sphinx docs page

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -nvWT
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,10 +75,7 @@ Compatibility
 
 Tested and working with Python 3.4+ on Windows, macOS, and Linux.
 
-Indices and tables
-==================
+Index
+=====
 
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-

--- a/tasks.py
+++ b/tasks.py
@@ -89,11 +89,12 @@ namespace_clean.add_task(tox_clean, 'tox')
 #####
 DOCS_SRCDIR = 'docs'
 DOCS_BUILDDIR = os.path.join('docs', '_build')
+SPHINX_OPTS = '-nvWT'   # Be nitpicky, verbose, and treat warnings as errors
 
 @invoke.task()
 def docs(context, builder='html'):
     "Build documentation using sphinx"
-    cmdline = 'python -msphinx -M {} {} {}'.format(builder, DOCS_SRCDIR, DOCS_BUILDDIR)
+    cmdline = 'python -msphinx -M {} {} {} {}'.format(builder, DOCS_SRCDIR, DOCS_BUILDDIR, SPHINX_OPTS)
     context.run(cmdline)
 namespace.add_task(docs)
 


### PR DESCRIPTION
Removed non-working Module Index link from the main Sphinx docs page

Also:
* Improved Sphinx build options in Makefile and via invoke by adding the following options:
    * -n : nit-picky mode, warn about all missing references
    * -v : increase verbosity (can be repeated)
    * -W : turn warnings into errors
    * -T : show full traceback on exception

This closes #490 