### PR TITLE
Make sure get_all_commands() returns functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.5 (TBD, 2018)
+* Bug Fixes
+    * Fixed bug where ``get_all_commands`` could return non-callable attributes
+    
 ## 0.9.4 (August 21, 2018)
 * Bug Fixes
     * Fixed bug where ``preparse`` was not getting called

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2470,7 +2470,7 @@ Usage:  Usage: unalias [-a] name [name ...]
         self._should_quit = True
         return self._STOP_AND_EXIT
 
-    def select(self, opts: Union[str, List[str], List[Tuple[str, Optional[str]]]], prompt: str='Your choice? ') -> str:
+    def select(self, opts: Union[str, List[str], List[Tuple[Any, Optional[str]]]], prompt: str='Your choice? ') -> str:
         """Presents a numbered menu to the user.  Modelled after
            the bash shell's SELECT.  Returns the item chosen.
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1553,7 +1553,8 @@ class Cmd(cmd.Cmd):
 
     def get_all_commands(self) -> List[str]:
         """Returns a list of all commands."""
-        return [cur_name[3:] for cur_name in self.get_names() if cur_name.startswith('do_')]
+        return [name[3:] for name in self.get_names()
+                if name.startswith('do_') and isinstance(getattr(self, name), Callable)]
 
     def get_visible_commands(self) -> List[str]:
         """Returns a list of commands that have not been hidden."""
@@ -1568,7 +1569,8 @@ class Cmd(cmd.Cmd):
 
     def get_help_topics(self) -> List[str]:
         """ Returns a list of help topics """
-        return [name[5:] for name in self.get_names() if name.startswith('help_')]
+        return [name[5:] for name in self.get_names()
+                if name.startswith('help_') and isinstance(getattr(self, name), Callable)]
 
     def complete_help(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
         """

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ EXTRAS_REQUIRE = {
         # for python 3.5 and earlier we need the third party mock module
         "mock ; python_version<'3.6'",
         'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'pylint',
-        'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'invoke', 'twine>=1.11',
+        'sphinx<1.7.7', 'sphinx-rtd-theme', 'sphinx-autobuild', 'invoke', 'twine>=1.11',
     ]
 }
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1916,3 +1916,17 @@ def test_bad_history_file_path(capsys, request):
     else:
         # GNU readline raises an exception upon trying to read the directory as a file
         assert 'readline cannot read' in err
+
+
+
+def test_get_all_commands(base_app):
+    # Verify that the base app has the expected commands
+    commands = base_app.get_all_commands()
+    expected_commands = ['_relative_load', 'alias', 'edit', 'eof', 'eos', 'help', 'history', 'load', 'py', 'pyscript',
+                         'quit', 'set', 'shell', 'shortcuts', 'unalias']
+    assert commands == expected_commands
+
+def test_get_help_topics(base_app):
+    # Verify that the base app has no additional help_foo methods
+    custom_help = base_app.get_help_topics()
+    assert len(custom_help) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 [testenv:docs]
 basepython = python3.5
 deps =
-  sphinx
+  sphinx<1.7.7
   sphinx-rtd-theme
 changedir = docs
 commands = sphinx-build -a -W -T -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
Previously ``get_all_commands()`` returned any attribute that started with **do_** - it didn't confirm that the attribute was actually callable.