### PR TITLE
Deleted a line which was added to support the SubMenu feature

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2464,7 +2464,6 @@ Usage:  Usage: unalias [-a] name [name ...]
     def do_eof(self, _: str) -> bool:
         """Called when <Ctrl>-D is pressed."""
         # End of script should not exit app, but <Ctrl>-D should.
-        print('')  # Required for clearing line when exiting submenu
         return self._STOP_AND_EXIT
 
     def do_quit(self, _: str) -> bool:


### PR DESCRIPTION
The SubMenu feature is now a plugin in a separate repo and is no longer part of the main cmd2 package so I deleted this line which was added to purely support that.