### PR TITLE
Fixed bug where alias was dropping quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
       framework, see ``docs/hooks.rst`` for details.
     * New dependency on ``attrs`` third party module
     * Added ``matches_sorted`` member to support custom sorting of tab-completion matches
+    * Added [tab_autocomp_dynamic.py](https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocomp_dynamic.py) example
+        * Demonstrates updating the argparse object during init instead of during class construction
 * Deprecations
     * Deprecated the following hook methods, see ``hooks.rst`` for full details:
        * ``cmd2.Cmd.preparse()`` - equivalent functionality available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.9.5 (TBD, 2018)
+## 0.9.5 (September TBD, 2018)
 * Bug Fixes
     * Fixed bug where ``get_all_commands`` could return non-callable attributes
+    * Fixed bug where **alias** command was dropping quotes around arguments
 * Enhancements
     * Added ``exit_code`` attribute of ``cmd2.Cmd`` class
         * Enables applications to return a non-zero exit code when exiting from ``cmdloop``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.4 (August TBD, 2018)
+## 0.9.4 (August 21, 2018)
 * Bug Fixes
     * Fixed bug where ``preparse`` was not getting called
     * Fixed bug in parsing of multiline commands where matching quote is on another line 
@@ -18,7 +18,7 @@
        * ``cmd2.Cmd.postparsing_postcmd()`` - equivalent functionality available
          via ``cmd2.Cmd.register_postcmd_hook()``
 
-## 0.8.9 (August TBD, 2018)
+## 0.8.9 (August 20, 2018)
 * Bug Fixes
     * Fixed extra slash that could print when tab completing users on Windows
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Main Features
 
 Python 2.7 support is EOL
 -------------------------
-Support for adding new features to the Python 2.7 release of ``cmd2`` was discontinued on April 15, 2018.  Bug fixes will be supported for Python 2.7 via 0.8.x until August 31, 2018.
+The last version of cmd2 to support Python 2.7 is [0.8.9](https://pypi.org/project/cmd2/0.8.9/), released on August 21, 2018.
 
-Supporting Python 2 was an increasing burden on our limited resources.  Switching to support only Python 3 will allow
+Supporting Python 2 was an increasing burden on our limited resources.  Switching to support only Python 3 is allowing
 us to clean up the codebase, remove some cruft, and focus on developing new features.
 
 Installation

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1720,7 +1720,7 @@ class Cmd(cmd.Cmd):
         :return: tuple containing (command, args, line)
         """
         statement = self.statement_parser.parse_command_only(line)
-        return statement.command, statement, statement.command_and_args
+        return statement.command, statement.args, statement.command_and_args
 
     def onecmd_plus_hooks(self, line: str) -> bool:
         """Top-level function called by cmdloop() to handle parsing a line and running the command and all of its hooks.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -612,7 +612,7 @@ class Cmd(cmd.Cmd):
                               - truncated text is still accessible by scrolling with the right & left arrow keys
                               - chopping is ideal for displaying wide tabular data as is done in utilities like pgcli
                      False -> causes lines longer than the screen width to wrap to the next line
-                              - wrapping is ideal when you want to avoid users having to use horizontal scrolling
+                              - wrapping is ideal when you want to keep users from having to use horizontal scrolling
 
         WARNING: On Windows, the text always wraps regardless of what the chop argument is set to
         """

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2333,7 +2333,7 @@ Usage:  Usage: unalias [-a] name [name ...]
 
     @with_argument_list
     def do_help(self, arglist: List[str]) -> None:
-        """List available commands with "help" or detailed help with "help cmd"."""
+        """ List available commands with "help" or detailed help with "help cmd" """
         if not arglist or (len(arglist) == 1 and arglist[0] in ('--verbose', '-v')):
             verbose = len(arglist) == 1 and arglist[0] in ('--verbose', '-v')
             self._help_menu(verbose)
@@ -2472,22 +2472,22 @@ Usage:  Usage: unalias [-a] name [name ...]
                 self.stdout.write("\n")
 
     def do_shortcuts(self, _: str) -> None:
-        """Lists shortcuts (aliases) available."""
+        """Lists shortcuts available"""
         result = "\n".join('%s: %s' % (sc[0], sc[1]) for sc in sorted(self.shortcuts))
         self.poutput("Shortcuts for other commands:\n{}\n".format(result))
 
     def do_eof(self, _: str) -> bool:
-        """Called when <Ctrl>-D is pressed."""
+        """Called when <Ctrl>-D is pressed"""
         # End of script should not exit app, but <Ctrl>-D should.
         return self._STOP_AND_EXIT
 
     def do_quit(self, _: str) -> bool:
-        """Exits this application."""
+        """Exits this application"""
         self._should_quit = True
         return self._STOP_AND_EXIT
 
     def select(self, opts: Union[str, List[str], List[Tuple[Any, Optional[str]]]], prompt: str='Your choice? ') -> str:
-        """Presents a numbered menu to the user.  Modelled after
+        """Presents a numbered menu to the user.  Modeled after
            the bash shell's SELECT.  Returns the item chosen.
 
            Argument ``opts`` can be:
@@ -2611,7 +2611,7 @@ Usage:  Usage: unalias [-a] name [name ...]
             self.show(args, param)
 
     def do_shell(self, statement: Statement) -> None:
-        """Execute a command as if at the OS prompt.
+        """Execute a command as if at the OS prompt
 
     Usage:  shell <command> [arguments]"""
         import subprocess
@@ -2909,7 +2909,7 @@ a..b, a:b, a:, ..b  items by indices (inclusive)
 
     @with_argparser(history_parser)
     def do_history(self, args: argparse.Namespace) -> None:
-        """View, run, edit, save, or clear previously entered commands."""
+        """View, run, edit, save, or clear previously entered commands"""
 
         if args.clear:
             # Clear command and readline history
@@ -3053,7 +3053,7 @@ a..b, a:b, a:, ..b  items by indices (inclusive)
 
     @with_argument_list
     def do_edit(self, arglist: List[str]) -> None:
-        """Edit a file in a text editor.
+        """Edit a file in a text editor
 
 Usage:  edit [file_path]
     Where:
@@ -3085,7 +3085,7 @@ The editor used is determined by the ``editor`` settable parameter.
 
     @with_argument_list
     def do__relative_load(self, arglist: List[str]) -> None:
-        """Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+        """Runs commands in script file that is encoded as either ASCII or UTF-8 text
 
     Usage:  _relative_load <file_path>
 
@@ -3110,13 +3110,13 @@ NOTE: This command is intended to only be used within text file scripts.
         self.do_load([relative_path])
 
     def do_eos(self, _: str) -> None:
-        """Handles cleanup when a script has finished executing."""
+        """Handles cleanup when a script has finished executing"""
         if self._script_dir:
             self._script_dir.pop()
 
     @with_argument_list
     def do_load(self, arglist: List[str]) -> None:
-        """Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+        """Runs commands in script file that is encoded as either ASCII or UTF-8 text
 
     Usage:  load <file_path>
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2236,7 +2236,7 @@ Usage:  Usage: alias [name] | [<name> <value>]
 
     Example: alias ls !ls -lF
 
-    If you want to use redirection or pipes in the alias, then quote them to avoid
+    If you want to use redirection or pipes in the alias, then quote them to prevent
     the alias command itself from being redirected
 
     Examples:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -709,7 +709,7 @@ class Cmd(cmd.Cmd):
                      The last item in both lists is the token being tab completed
 
                  On Failure
-                    Both items are empty
+                    Two empty lists
         """
         import copy
         unclosed_quote = ''

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -398,6 +398,7 @@ class StatementParser:
 
         The Statement object returned by this method can at most contain
         values in the following attributes:
+          - args
           - raw
           - command
           - multiline_command

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -27,7 +27,8 @@ class Statement(str):
     the output redirection clauses.
     """
     def __new__(cls,
-                value: str,
+                obj: object,
+                *,
                 raw: str = '',
                 command: str = '',
                 arg_list: List[str] = None,
@@ -58,7 +59,7 @@ class Statement(str):
         We must override __new__ because we are subclassing `str` which is
         immutable.
         """
-        stmt = super().__new__(cls, value)
+        stmt = super().__new__(cls, obj)
         stmt.raw = raw
         stmt.command = command
 

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -59,18 +59,7 @@ class Statement(str):
     # if output was redirected, the destination file
     output_to = attr.ib(default='', validator=attr.validators.instance_of(str), type=str)
 
-    def __new__(cls,
-                args: object,
-                raw: str = '',
-                command: str = '',
-                arg_list: List[str] = None,
-                multiline_command: str = '',
-                terminator: str = '',
-                suffix: str = '',
-                pipe_to: List[str] = None,
-                output: str = '',
-                output_to: str = ''
-                ):
+    def __new__(cls, value: object, *pos_args, **kw_args):
         """Create a new instance of Statement.
 
         We must override __new__ because we are subclassing `str` which is immutable and takes a different number of
@@ -78,7 +67,7 @@ class Statement(str):
 
         NOTE:  attrs takes care of initializing other members in the __init__ it generates.
         """
-        stmt = super().__new__(cls, args)
+        stmt = super().__new__(cls, value)
         return stmt
 
     @property

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -425,7 +425,7 @@ class StatementParser:
         This method is used by tab completion code and therefore must not
         generate an exception if there are unclosed quotes.
 
-        The Statement object returned by this method can at most contained
+        The Statement object returned by this method can at most contain
         values in the following attributes:
           - raw
           - command

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -5,7 +5,7 @@
 import os
 import re
 import shlex
-from typing import List, Tuple, Dict, Union
+from typing import List, Tuple, Dict
 
 from . import constants
 from . import utils
@@ -106,13 +106,13 @@ class Statement(str):
         return rtn
 
     @property
-    def arg_list(self) -> Union[List[str], None]:
+    def arg_list(self) -> List[str]:
         """
         Returns a list of the arguments to the command, not including any output
         redirection or terminators. quoted arguments remain quoted.
         """
         if self.args is None:
-            return None
+            return []
 
         return self.args.split()
 

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -452,12 +452,15 @@ class StatementParser:
         This method is used by tab completion code and therefore must not
         generate an exception if there are unclosed quotes.
 
-        The Statement object returned by this method can at most contain values
+        The `Statement` object returned by this method can at most contain values
         in the following attributes:
           - args
           - raw
           - command
           - multiline_command
+
+        `Statement.args` includes all output redirection clauses and command
+        terminators.
 
         Different from parse(), this method does not remove redundant whitespace
         within args. However, it does ensure args has no leading or trailing
@@ -473,12 +476,10 @@ class StatementParser:
             # we got a match, extract the command
             command = match.group(1)
 
-            # the _command_pattern regex is designed to match the spaces
-            # between command and args with a second match group. Using
-            # the end of the second match group ensures that args has
-            # no leading whitespace. The rstrip() makes sure there is
-            # no trailing whitespace
-            args = line[match.end(2):].rstrip()
+            # take everything from the end of the first match group to
+            # the end of the line as the arguments (stripping leading
+            # and trailing spaces)
+            args = line[match.end(1):].strip()
             # if the command is empty that means the input was either empty
             # or something weird like '>'. args should be empty if we couldn't
             # parse a command

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -25,36 +25,9 @@ class Statement(str):
 
     The string portion of the class contains the arguments, but not the command, nor
     the output redirection clauses.
-
-    :var raw:               string containing exactly what we input by the user
-    :type raw:              str
-    :var command:           the command, i.e. the first whitespace delimited word
-    :type command:          str
-    :var multiline_command: if the command is a multiline command, the name of the
-                            command, otherwise empty
-    :type command:          str
-    :var arg_list:          list of arguments to the command, not including any output
-                            redirection or terminators. quoted arguments remain
-                            quoted.
-    :type arg_list:         list
-    :var terminator:        the character which terminated the multiline command, if
-                            there was one
-    :type terminator:       str
-    :var suffix:            characters appearing after the terminator but before output
-                            redirection, if any
-    :type suffix:           str
-    :var pipe_to:           if output was piped to a shell command, the shell command
-                            as a list of tokens
-    :type pipe_to:          list
-    :var output:            if output was redirected, the redirection token, i.e. '>>'
-    :type output:           str
-    :var output_to:         if output was redirected, the destination file
-    :type output_to:        str
-
     """
     def __new__(cls,
-                obj: object,
-                *,
+                value: str,
                 raw: str = '',
                 command: str = '',
                 arg_list: List[str] = None,
@@ -65,25 +38,49 @@ class Statement(str):
                 output: str = '',
                 output_to: str = ''
                 ):
+        """
+        :param value: The arguments, but not the command, nor the output redirection clauses.
+        :param raw: string containing exactly what we input by the user
+        :param command: the command, i.e. the first whitespace delimited word
+        :param arg_list: list of arguments to the command, not including any output
+                         redirection or terminators. quoted arguments remain quoted.
+        :param multiline_command: if the command is a multiline command, the name of the
+                                  command, otherwise empty
+        :param terminator: the character which terminated the multiline command, if
+                           there was one
+        :param suffix: characters appearing after the terminator but before output redirection, if any
+        :param pipe_to: if output was piped to a shell command, the shell command as a list of tokens
+        :param output: if output was redirected, the redirection token, i.e. '>>'
+        :param output_to: if output was redirected, the destination file
+        """
         """Create a new instance of Statement
 
         We must override __new__ because we are subclassing `str` which is
         immutable.
         """
-        stmt = str.__new__(cls, obj)
-        object.__setattr__(stmt, "raw", raw)
-        object.__setattr__(stmt, "command", command)
+        stmt = super().__new__(cls, value)
+        stmt.raw = raw
+        stmt.command = command
+
         if arg_list is None:
             arg_list = []
-        object.__setattr__(stmt, "arg_list", arg_list)
-        object.__setattr__(stmt, "multiline_command", multiline_command)
-        object.__setattr__(stmt, "terminator", terminator)
-        object.__setattr__(stmt, "suffix", suffix)
+        stmt.arg_list = arg_list
+
+        stmt.multiline_command = multiline_command
+        stmt.terminator = terminator
+        stmt.suffix = suffix
+
         if pipe_to is None:
             pipe_to = []
-        object.__setattr__(stmt, "pipe_to", pipe_to)
-        object.__setattr__(stmt, "output", output)
-        object.__setattr__(stmt, "output_to", output_to)
+        stmt.pipe_to = pipe_to
+
+        stmt.output = output
+        stmt.output_to = output_to
+
+        # Make Statement feel immutable by overriding these functions
+        stmt.__setattr__ = stmt.__stmt_setattr__
+        stmt.__delattr__ = stmt.__stmt_delattr__
+
         return stmt
 
     @property
@@ -123,11 +120,11 @@ class Statement(str):
 
         return rtn
 
-    def __setattr__(self, name, value):
+    def __stmt_setattr__(self, name, value):
         """Statement instances should feel immutable; raise ValueError"""
         raise ValueError
 
-    def __delattr__(self, name):
+    def __stmt_delattr__(self, name):
         """Statement instances should feel immutable; raise ValueError"""
         raise ValueError
 

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -5,7 +5,7 @@
 import os
 import re
 import shlex
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Union
 
 from . import constants
 from . import utils
@@ -104,6 +104,17 @@ class Statement(str):
         else:
             rtn = None
         return rtn
+
+    @property
+    def arg_list(self) -> Union[List[str], None]:
+        """
+        Returns a list of the arguments to the command, not including any output
+        redirection or terminators. quoted arguments remain quoted.
+        """
+        if self.args is None:
+            return None
+
+        return self.args.split()
 
     def __setattr__(self, name, value):
         """Statement instances should feel immutable; raise ValueError"""

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -434,9 +434,8 @@ class StatementParser:
           - command
           - multiline_command
 
-        Different from parse(), this method does not remove redundant whitespace
-        within the statement. It does however, ensure statement does not have
-        leading or trailing whitespace.
+        Different from parse(), this method does not remove redundant whitespace within args.
+        However, it does ensure args has no leading or trailing whitespace.
         """
         # expand shortcuts and aliases
         line = self._expand(rawinput)

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -453,7 +453,7 @@ class StatementParser:
             # no trailing whitespace
             args = line[match.end(2):].rstrip()
             # if the command is none that means the input was either empty
-            # or something wierd like '>'. args should be None if we couldn't
+            # or something weird like '>'. args should be None if we couldn't
             # parse a command
             if not command or not args:
                 args = None

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -5,7 +5,7 @@
 import os
 import re
 import shlex
-from typing import List, Tuple, Dict, Union
+from typing import List, Tuple, Dict
 
 from . import constants
 from . import utils

--- a/docs/argument_processing.rst
+++ b/docs/argument_processing.rst
@@ -296,7 +296,36 @@ Receiving an argument list
 ==========================
 
 The default behavior of ``cmd2`` is to pass the user input directly to your
-``do_*`` methods as a string. If you don't want to use the full argument parser support outlined above, you can still have ``cmd2`` apply shell parsing rules to the user input and pass you a list of arguments instead of a string. Apply the ``@with_argument_list`` decorator to those methods that should receive an argument list instead of a string::
+``do_*`` methods as a string. The object passed to your method is actually a
+``Statement`` object, which has additional attributes that may be helpful,
+including ``arg_list`` and ``argv``::
+
+    class CmdLineApp(cmd2.Cmd):
+        """ Example cmd2 application. """
+
+        def do_say(self, statement):
+            # statement contains a string
+            self.poutput(statement)
+
+        def do_speak(self, statement):
+            # statement also has a list of arguments
+            # quoted arguments remain quoted
+            for arg in statement.arg_list:
+                self.poutput(arg)
+
+        def do_articulate(self, statement):
+            # statement.argv contains the command
+            # and the arguments, which have had quotes
+            # stripped
+            for arg in statement.argv:
+                self.poutput(arg)
+
+
+If you don't want to access the additional attributes on the string passed to
+you``do_*`` method you can still have ``cmd2`` apply shell parsing rules to the
+user input and pass you a list of arguments instead of a string. Apply the
+``@with_argument_list`` decorator to those methods that should receive an
+argument list instead of a string::
 
     from cmd2 import with_argument_list
 

--- a/docs/argument_processing.rst
+++ b/docs/argument_processing.rst
@@ -278,16 +278,16 @@ the help categories with per-command Help Messages::
     ================================================================================
     alias               Define or display aliases
     config              Config command
-    edit                Edit a file in a text editor.
-    help                List available commands with "help" or detailed help with "help cmd".
+    edit                Edit a file in a text editor
+    help                List available commands with "help" or detailed help with "help cmd"
     history             usage: history [-h] [-r | -e | -s | -o FILE | -t TRANSCRIPT] [arg]
-    load                Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+    load                Runs commands in script file that is encoded as either ASCII or UTF-8 text
     py                  Invoke python command, shell, or script
     pyscript            Runs a python script file inside the console
-    quit                Exits this application.
+    quit                Exits this application
     set                 usage: set [-h] [-a] [-l] [settable [settable ...]]
-    shell               Execute a command as if at the OS prompt.
-    shortcuts           Lists shortcuts (aliases) available.
+    shell               Execute a command as if at the OS prompt
+    shortcuts           Lists shortcuts available
     unalias             Unsets aliases
     version             Version command
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,23 +35,23 @@ BASE_HELP_VERBOSE = """
 Documented commands (type help <topic>):
 ================================================================================
 alias               Define or display aliases
-edit                Edit a file in a text editor.
-help                List available commands with "help" or detailed help with "help cmd".
-history             View, run, edit, save, or clear previously entered commands.
-load                Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+edit                Edit a file in a text editor
+help                List available commands with "help" or detailed help with "help cmd"
+history             View, run, edit, save, or clear previously entered commands
+load                Runs commands in script file that is encoded as either ASCII or UTF-8 text
 py                  Invoke python command, shell, or script
 pyscript            Runs a python script file inside the console
-quit                Exits this application.
+quit                Exits this application
 set                 Sets a settable parameter or shows current settings of parameters
-shell               Execute a command as if at the OS prompt.
-shortcuts           Lists shortcuts (aliases) available.
+shell               Execute a command as if at the OS prompt
+shortcuts           Lists shortcuts available
 unalias             Unsets aliases
 """
 
 # Help text for the history command
 HELP_HISTORY = """Usage: history [arg] [-h] [-r | -e | -s | -o FILE | -t TRANSCRIPT | -c]
 
-View, run, edit, save, or clear previously entered commands.
+View, run, edit, save, or clear previously entered commands
 
 positional arguments:
   arg                   empty               all history items

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1244,15 +1244,15 @@ diddly              This command does diddly
 Other
 ================================================================================
 alias               Define or display aliases
-help                List available commands with "help" or detailed help with "help cmd".
-history             View, run, edit, save, or clear previously entered commands.
-load                Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+help                List available commands with "help" or detailed help with "help cmd"
+history             View, run, edit, save, or clear previously entered commands
+load                Runs commands in script file that is encoded as either ASCII or UTF-8 text
 py                  Invoke python command, shell, or script
 pyscript            Runs a python script file inside the console
-quit                Exits this application.
+quit                Exits this application
 set                 Sets a settable parameter or shows current settings of parameters
-shell               Execute a command as if at the OS prompt.
-shortcuts           Lists shortcuts (aliases) available.
+shell               Execute a command as if at the OS prompt
+shortcuts           Lists shortcuts available
 unalias             Unsets aliases
 
 Undocumented commands:

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1761,6 +1761,15 @@ def test_alias(base_app, capsys):
     out = run_cmd(base_app, 'alias fake')
     assert out == normalize('alias fake pyscript')
 
+def test_alias_with_quotes(base_app, capsys):
+    # Create the alias
+    out = run_cmd(base_app, 'alias fake help ">" "out file.txt"')
+    assert out == normalize("Alias 'fake' created")
+
+    # Lookup the new alias (Only the redirector should be unquoted)
+    out = run_cmd(base_app, 'alias fake')
+    assert out == normalize('alias fake help > "out file.txt"')
+
 def test_alias_lookup_invalid_alias(base_app, capsys):
     # Lookup invalid alias
     out = run_cmd(base_app, 'alias invalid')

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -32,11 +32,40 @@ def default_parser():
     parser = StatementParser()
     return parser
 
-def test_parse_empty_string_default(default_parser):
-    statement = default_parser.parse('')
-    assert statement.command == ''
+
+def test_parse_empty_string(parser):
+    line = ''
+    statement = parser.parse(line)
     assert statement == ''
-    assert statement.raw == ''
+    assert statement.args == statement
+    assert statement.raw == line
+    assert statement.command == ''
+    assert statement.arg_list == []
+    assert statement.multiline_command == ''
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == []
+    assert statement.output == ''
+    assert statement.output_to == ''
+    assert statement.command_and_args == line
+    assert statement.argv == statement.arg_list
+
+def test_parse_empty_string_default(default_parser):
+    line = ''
+    statement = default_parser.parse(line)
+    assert statement == ''
+    assert statement.args == statement
+    assert statement.raw == line
+    assert statement.command == ''
+    assert statement.arg_list == []
+    assert statement.multiline_command == ''
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == []
+    assert statement.output == ''
+    assert statement.output_to == ''
+    assert statement.command_and_args == line
+    assert statement.argv == statement.arg_list
 
 @pytest.mark.parametrize('line,tokens', [
     ('command', ['command']),
@@ -51,12 +80,6 @@ def test_parse_empty_string_default(default_parser):
 def test_tokenize_default(default_parser, line, tokens):
     tokens_to_test = default_parser.tokenize(line)
     assert tokens_to_test == tokens
-
-def test_parse_empty_string(parser):
-    statement = parser.parse('')
-    assert statement.command == ''
-    assert statement == ''
-    assert statement.raw == ''
 
 @pytest.mark.parametrize('line,tokens', [
     ('command', ['command']),
@@ -100,6 +123,15 @@ def test_parse_single_word(parser, line):
     assert statement == ''
     assert statement.argv == [utils.strip_quotes(line)]
     assert not statement.arg_list
+    assert statement.args == statement
+    assert statement.raw == line
+    assert statement.multiline_command == ''
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == []
+    assert statement.output == ''
+    assert statement.output_to == ''
+    assert statement.command_and_args == line
 
 @pytest.mark.parametrize('line,terminator', [
     ('termbare;', ';'),
@@ -550,10 +582,18 @@ def test_parse_alias_terminator_no_whitespace(parser, line):
 def test_parse_command_only_command_and_args(parser):
     line = 'help history'
     statement = parser.parse_command_only(line)
-    assert statement.command == 'help'
     assert statement == 'history'
     assert statement.args == statement
+    assert statement.raw == line
+    assert statement.command == 'help'
     assert statement.command_and_args == line
+    assert statement.arg_list == []
+    assert statement.multiline_command == ''
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == []
+    assert statement.output == ''
+    assert statement.output_to == ''
 
 def test_parse_command_only_emptyline(parser):
     line = ''

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -124,6 +124,7 @@ def test_parse_suffix_after_terminator(parser, line, terminator):
     statement = parser.parse(line)
     assert statement.command == 'termbare'
     assert statement == ''
+    assert statement.args == statement
     assert statement.argv == ['termbare']
     assert not statement.arg_list
     assert statement.terminator == terminator
@@ -134,6 +135,7 @@ def test_parse_command_with_args(parser):
     statement = parser.parse(line)
     assert statement.command == 'command'
     assert statement == 'with args'
+    assert statement.args == statement
     assert statement.argv == ['command', 'with', 'args']
     assert statement.arg_list == statement.argv[1:]
 
@@ -142,6 +144,7 @@ def test_parse_command_with_quoted_args(parser):
     statement = parser.parse(line)
     assert statement.command == 'command'
     assert statement == 'with "quoted args" and "some not"'
+    assert statement.args == statement
     assert statement.argv == ['command', 'with', 'quoted args', 'and', 'some not']
     assert statement.arg_list == ['with', '"quoted args"', 'and', '"some not"']
 
@@ -150,6 +153,7 @@ def test_parse_command_with_args_terminator_and_suffix(parser):
     statement = parser.parse(line)
     assert statement.command == 'command'
     assert statement == "with args and terminator"
+    assert statement.args == statement
     assert statement.argv == ['command', 'with', 'args', 'and', 'terminator']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
@@ -159,20 +163,23 @@ def test_parse_hashcomment(parser):
     statement = parser.parse('hi # this is all a comment')
     assert statement.command == 'hi'
     assert statement == ''
+    assert statement.args == statement
     assert statement.argv == ['hi']
     assert not statement.arg_list
 
 def test_parse_c_comment(parser):
     statement = parser.parse('hi /* this is | all a comment */')
     assert statement.command == 'hi'
+    assert statement == ''
+    assert statement.args == statement
     assert statement.argv == ['hi']
     assert not statement.arg_list
-    assert statement == ''
     assert not statement.pipe_to
 
 def test_parse_c_comment_empty(parser):
     statement = parser.parse('/* this is | all a comment */')
     assert statement.command == ''
+    assert statement.args == statement
     assert not statement.pipe_to
     assert not statement.argv
     assert not statement.arg_list
@@ -182,6 +189,7 @@ def test_parse_c_comment_no_closing(parser):
     statement = parser.parse('cat /tmp/*.txt')
     assert statement.command == 'cat'
     assert statement == '/tmp/*.txt'
+    assert statement.args == statement
     assert not statement.pipe_to
     assert statement.argv == ['cat', '/tmp/*.txt']
     assert statement.arg_list == statement.argv[1:]
@@ -190,6 +198,7 @@ def test_parse_c_comment_multiple_opening(parser):
     statement = parser.parse('cat /tmp/*.txt /tmp/*.cfg')
     assert statement.command == 'cat'
     assert statement == '/tmp/*.txt /tmp/*.cfg'
+    assert statement.args == statement
     assert not statement.pipe_to
     assert statement.argv == ['cat', '/tmp/*.txt', '/tmp/*.cfg']
     assert statement.arg_list == statement.argv[1:]
@@ -198,6 +207,7 @@ def test_parse_what_if_quoted_strings_seem_to_start_comments(parser):
     statement = parser.parse('what if "quoted strings /* seem to " start comments?')
     assert statement.command == 'what'
     assert statement == 'if "quoted strings /* seem to " start comments?'
+    assert statement.args == statement
     assert statement.argv == ['what', 'if', 'quoted strings /* seem to ', 'start', 'comments?']
     assert statement.arg_list == ['if', '"quoted strings /* seem to "', 'start', 'comments?']
     assert not statement.pipe_to
@@ -210,6 +220,7 @@ def test_parse_simple_pipe(parser, line):
     statement = parser.parse(line)
     assert statement.command == 'simple'
     assert statement == ''
+    assert statement.args == statement
     assert statement.argv == ['simple']
     assert not statement.arg_list
     assert statement.pipe_to == ['piped']
@@ -219,6 +230,7 @@ def test_parse_double_pipe_is_not_a_pipe(parser):
     statement = parser.parse(line)
     assert statement.command == 'double-pipe'
     assert statement == '|| is not a pipe'
+    assert statement.args == statement
     assert statement.argv == ['double-pipe', '||', 'is', 'not', 'a', 'pipe']
     assert statement.arg_list == statement.argv[1:]
     assert not statement.pipe_to
@@ -228,6 +240,7 @@ def test_parse_complex_pipe(parser):
     statement = parser.parse(line)
     assert statement.command == 'command'
     assert statement == "with args, terminator"
+    assert statement.args == statement
     assert statement.argv == ['command', 'with', 'args,', 'terminator']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == '&'
@@ -244,6 +257,7 @@ def test_parse_redirect(parser,line, output):
     statement = parser.parse(line)
     assert statement.command == 'help'
     assert statement == ''
+    assert statement.args == statement
     assert statement.output == output
     assert statement.output_to == 'out.txt'
 
@@ -252,6 +266,7 @@ def test_parse_redirect_with_args(parser):
     statement = parser.parse(line)
     assert statement.command == 'output'
     assert statement == 'into'
+    assert statement.args == statement
     assert statement.argv == ['output', 'into']
     assert statement.arg_list == statement.argv[1:]
     assert statement.output == '>'
@@ -262,6 +277,7 @@ def test_parse_redirect_with_dash_in_path(parser):
     statement = parser.parse(line)
     assert statement.command == 'output'
     assert statement == 'into'
+    assert statement.args == statement
     assert statement.argv == ['output', 'into']
     assert statement.arg_list == statement.argv[1:]
     assert statement.output == '>'
@@ -272,6 +288,7 @@ def test_parse_redirect_append(parser):
     statement = parser.parse(line)
     assert statement.command == 'output'
     assert statement == 'appended to'
+    assert statement.args == statement
     assert statement.argv == ['output', 'appended', 'to']
     assert statement.arg_list == statement.argv[1:]
     assert statement.output == '>>'
@@ -282,6 +299,7 @@ def test_parse_pipe_and_redirect(parser):
     statement = parser.parse(line)
     assert statement.command == 'output'
     assert statement == 'into'
+    assert statement.args == statement
     assert statement.argv == ['output', 'into']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
@@ -295,6 +313,7 @@ def test_parse_output_to_paste_buffer(parser):
     statement = parser.parse(line)
     assert statement.command == 'output'
     assert statement == 'to paste buffer'
+    assert statement.args == statement
     assert statement.argv == ['output', 'to', 'paste', 'buffer']
     assert statement.arg_list == statement.argv[1:]
     assert statement.output == '>>'
@@ -307,6 +326,7 @@ def test_parse_redirect_inside_terminator(parser):
     statement = parser.parse(line)
     assert statement.command == 'has'
     assert statement == '> inside'
+    assert statement.args == statement
     assert statement.argv == ['has', '>', 'inside']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
@@ -325,6 +345,7 @@ def test_parse_multiple_terminators(parser, line, terminator):
     statement = parser.parse(line)
     assert statement.multiline_command == 'multiline'
     assert statement == 'with | inside'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'with', '|', 'inside']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == terminator
@@ -335,6 +356,7 @@ def test_parse_unfinished_multiliine_command(parser):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'has > inside an unfinished command'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'has', '>', 'inside', 'an', 'unfinished', 'command']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ''
@@ -350,6 +372,7 @@ def test_parse_multiline_command_ignores_redirectors_within_it(parser, line, ter
     statement = parser.parse(line)
     assert statement.multiline_command == 'multiline'
     assert statement == 'has > inside'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'has', '>', 'inside']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == terminator
@@ -362,6 +385,7 @@ def test_parse_multiline_with_incomplete_comment(parser):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'command /* with unclosed comment'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'command', '/*', 'with', 'unclosed', 'comment']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
@@ -372,6 +396,7 @@ def test_parse_multiline_with_complete_comment(parser):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'command is done'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'command', 'is', 'done']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
@@ -382,6 +407,7 @@ def test_parse_multiline_terminated_by_empty_line(parser):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'command ends'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'command', 'ends']
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == '\n'
@@ -399,6 +425,7 @@ def test_parse_multiline_with_embedded_newline(parser, line, terminator):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'command "with\nembedded newline"'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'command', 'with\nembedded newline']
     assert statement.arg_list == ['command', '"with\nembedded newline"']
     assert statement.terminator == terminator
@@ -409,6 +436,7 @@ def test_parse_multiline_ignores_terminators_in_comments(parser):
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
     assert statement == 'command "with term; ends" now'
+    assert statement.args == statement
     assert statement.argv == ['multiline', 'command', 'with term; ends', 'now']
     assert statement.arg_list == ['command', '"with term; ends"', 'now']
     assert statement.terminator == '\n'
@@ -418,6 +446,7 @@ def test_parse_command_with_unicode_args(parser):
     statement = parser.parse(line)
     assert statement.command == 'drink'
     assert statement == 'café'
+    assert statement.args == statement
     assert statement.argv == ['drink', 'café']
     assert statement.arg_list == statement.argv[1:]
 
@@ -426,6 +455,7 @@ def test_parse_unicode_command(parser):
     statement = parser.parse(line)
     assert statement.command == 'café'
     assert statement == 'au lait'
+    assert statement.args == statement
     assert statement.argv == ['café', 'au', 'lait']
     assert statement.arg_list == statement.argv[1:]
 
@@ -434,6 +464,7 @@ def test_parse_redirect_to_unicode_filename(parser):
     statement = parser.parse(line)
     assert statement.command == 'dir'
     assert statement == 'home'
+    assert statement.args == statement
     assert statement.argv == ['dir', 'home']
     assert statement.arg_list == statement.argv[1:]
     assert statement.output == '>'
@@ -464,12 +495,14 @@ def test_parse_alias_and_shortcut_expansion(parser, line, command, args):
     statement = parser.parse(line)
     assert statement.command == command
     assert statement == args
+    assert statement.args == statement
 
 def test_parse_alias_on_multiline_command(parser):
     line = 'anothermultiline has > inside an unfinished command'
     statement = parser.parse(line)
     assert statement.multiline_command == 'multiline'
     assert statement.command == 'multiline'
+    assert statement.args == statement
     assert statement == 'has > inside an unfinished command'
     assert statement.terminator == ''
 
@@ -483,6 +516,7 @@ def test_parse_alias_redirection(parser, line, output):
     statement = parser.parse(line)
     assert statement.command == 'help'
     assert statement == ''
+    assert statement.args == statement
     assert statement.output == output
     assert statement.output_to == 'out.txt'
 
@@ -494,6 +528,7 @@ def test_parse_alias_pipe(parser, line):
     statement = parser.parse(line)
     assert statement.command == 'help'
     assert statement == ''
+    assert statement.args == statement
     assert statement.pipe_to == ['less']
 
 @pytest.mark.parametrize('line', [
@@ -508,6 +543,7 @@ def test_parse_alias_terminator_no_whitespace(parser, line):
     statement = parser.parse(line)
     assert statement.command == 'help'
     assert statement == ''
+    assert statement.args == statement
     assert statement.terminator == ';'
 
 def test_parse_command_only_command_and_args(parser):
@@ -515,6 +551,7 @@ def test_parse_command_only_command_and_args(parser):
     statement = parser.parse_command_only(line)
     assert statement.command == 'help'
     assert statement == 'history'
+    assert statement.args == statement
     assert statement.command_and_args == line
 
 def test_parse_command_only_emptyline(parser):
@@ -525,6 +562,7 @@ def test_parse_command_only_emptyline(parser):
     # the cmd in the standard library
     assert statement.command == ''
     assert statement == ''
+    assert statement.args == statement
     assert not statement.argv
     assert not statement.arg_list
     assert statement.command_and_args == ''
@@ -534,6 +572,7 @@ def test_parse_command_only_strips_line(parser):
     statement = parser.parse_command_only(line)
     assert statement.command == 'help'
     assert statement == 'history'
+    assert statement.args == statement
     assert statement.command_and_args == line.strip()
 
 def test_parse_command_only_expands_alias(parser):
@@ -541,12 +580,14 @@ def test_parse_command_only_expands_alias(parser):
     statement = parser.parse_command_only(line)
     assert statement.command == 'pyscript'
     assert statement == 'foobar.py'
+    assert statement.args == statement
 
 def test_parse_command_only_expands_shortcuts(parser):
     line = '!cat foobar.txt'
     statement = parser.parse_command_only(line)
     assert statement.command == 'shell'
     assert statement == 'cat foobar.txt'
+    assert statement.args == statement
     assert statement.command_and_args == 'shell cat foobar.txt'
 
 def test_parse_command_only_quoted_args(parser):
@@ -554,6 +595,7 @@ def test_parse_command_only_quoted_args(parser):
     statement = parser.parse_command_only(line)
     assert statement.command == 'shell'
     assert statement == 'ls -al "/tmp/directory with spaces/doit.sh"'
+    assert statement.args == statement
     assert statement.command_and_args == line.replace('l', 'shell ls -al')
 
 @pytest.mark.parametrize('line', [
@@ -569,6 +611,7 @@ def test_parse_command_only_quoted_args(parser):
 def test_parse_command_only_specialchars(parser, line):
     statement = parser.parse_command_only(line)
     assert statement.command == 'help'
+    assert statement.args == statement
 
 @pytest.mark.parametrize('line', [
     ';',
@@ -594,7 +637,7 @@ def test_parse_command_only_multiline(parser):
     assert statement.multiline_command == 'multiline'
     assert statement == 'with partially "open quotes and no terminator'
     assert statement.command_and_args == line
-
+    assert statement.args == statement
 
 def test_statement_initialization(parser):
     string = 'alias'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,6 +5,7 @@ Test the parsing logic in parsing.py
 Copyright 2017 Todd Leonhardt <todd.leonhardt@gmail.com>
 Released under MIT license, see LICENSE file
 """
+import attr
 import pytest
 
 import cmd2
@@ -639,7 +640,8 @@ def test_parse_command_only_multiline(parser):
     assert statement.command_and_args == line
     assert statement.args == statement
 
-def test_statement_initialization(parser):
+
+def test_statement_initialization():
     string = 'alias'
     statement = cmd2.Statement(string)
     assert string == statement
@@ -657,3 +659,15 @@ def test_statement_initialization(parser):
     assert not statement.pipe_to
     assert statement.output == ''
     assert statement.output_to == ''
+
+
+def test_statement_is_immutable():
+    string = 'foo'
+    statement = cmd2.Statement(string)
+    assert string == statement
+    assert statement.args == statement
+    assert statement.raw == ''
+    with pytest.raises(attr.exceptions.FrozenInstanceError):
+        statement.args = 'bar'
+    with pytest.raises(attr.exceptions.FrozenInstanceError):
+        statement.raw = 'baz'


### PR DESCRIPTION
Fixes #504 

[kotfu] I think we need to do the following before merging in this PR:

- [x]  as suggested by @tleonhardt, use attrs on Statement object to do immutability
- [x]  make `Statement.arg_list` include the command as the first list element, so it mirrors `Statement.argv` !wontfix. @kmvanbrunt made a convincing argument that `Statement.arg_list` should me more like `Statement.args`, not `Statement.argv`. Documentation updated appropriately.
- [x] Fix documentation and unit tests for `StatementParser.parse_command_only()`. Our changes in this PR infer that `parse_command_only` sets more attributes on the `Statement` object than the documentation says it does, and the unit tests do not check for what is and is not set by that method.

[kotfu] I'll work on all three of these items and get them completed.