### PR TITLE
Added way of returning a non-zero exit code to the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.9.5 (TBD, 2018)
 * Bug Fixes
     * Fixed bug where ``get_all_commands`` could return non-callable attributes
+* Enhancements
+    * Added ``exit_code`` attribute of ``cmd2.Cmd`` class
+        * Enables applications to return a non-zero exit code when exiting from ``cmdloop``
     
 ## 0.9.4 (August 21, 2018)
 * Bug Fixes

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -523,6 +523,9 @@ class Cmd(cmd.Cmd):
         # This boolean flag determines whether or not the cmd2 application can interact with the clipboard
         self.can_clip = can_clip
 
+        # This determines if a non-zero exit code should be used when exiting the application
+        self.exit_code = None
+
     # -----  Methods related to presenting output to the user -----
 
     @property
@@ -3226,6 +3229,9 @@ Script should contain one command per line, just like command would be typed in 
         for func in self._postloop_hooks:
             func()
         self.postloop()
+
+        if self.exit_code is not None:
+            sys.exit(self.exit_code)
 
     ###
     #

--- a/docs/unfreefeatures.rst
+++ b/docs/unfreefeatures.rst
@@ -182,3 +182,10 @@ Presents numbered options to user, as bash ``select``.
         2. salty
     Sauce? 2
     wheaties with salty sauce, yum!
+
+
+Exit code to shell
+==================
+The ``self.exit_code`` attribute of your ``cmd2`` application controls
+what exit code is sent to the shell when your application exits from
+``cmdloop()``.

--- a/examples/exit_code.py
+++ b/examples/exit_code.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""A simple example demonstrating the following how to emit a non-zero exit code in your cmd2 application.
+"""
+import cmd2
+import sys
+from typing import List
+
+
+class ReplWithExitCode(cmd2.Cmd):
+    """ Example cmd2 application where we can specify an exit code when existing."""
+
+    def __init__(self):
+        super().__init__()
+
+    @cmd2.with_argument_list
+    def do_exit(self, arg_list: List[str]) -> bool:
+        """Exit the application with an optional exit code.
+
+Usage:  exit [exit_code]
+    Where:
+        * exit_code - integer exit code to return to the shell
+"""
+        # If an argument was provided
+        if arg_list:
+            try:
+                self.exit_code = int(arg_list[0])
+            except ValueError:
+                self.perror("{} isn't a valid integer exit code".format(arg_list[0]))
+                self.exit_code = -1
+
+        self._should_quit = True
+        return self._STOP_AND_EXIT
+
+    def postloop(self) -> None:
+        """Hook method executed once when the cmdloop() method is about to return.
+
+        """
+        code = self.exit_code if self.exit_code is not None else 0
+        print('{!r} exiting with code: {}'.format(sys.argv[0], code))
+
+
+if __name__ == '__main__':
+    app = ReplWithExitCode()
+    app.cmdloop()


### PR DESCRIPTION
Added ``exit_code`` attribute to ``cmd2.Cmd`` class which if set will return a non-zero exit code to the shell when exiting from ``cmdloop``.

There are many ways in which this could be done and I chose to implement pretty much the simplest possible way I could think of.

I'd appreciate feedback regarding if you think this will likely meet end users needs for this sort of feature.

This closes #358 