### PR TITLE
Added a tag invoke task for adding a Git tag and pushing it to origin

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -173,6 +173,15 @@ def clean_all(context):
     pass
 namespace_clean.add_task(clean_all, 'all')
 
+@invoke.task
+def tag(context, name='', message=''):
+    "Add a Git tag and push it to origin"
+    # If a tag was provided on the command-line, then add a Git tag and push it to origin
+    if name:
+        context.run('git tag -a {} -m {!r}'.format(name, message))
+        context.run('git push origin {}'.format(name))
+namespace.add_task(tag)
+
 @invoke.task(pre=[clean_all])
 def sdist(context):
     "Create a source distribution"


### PR DESCRIPTION
Added ``tag`` **invoke** task to add a new Git tag and push it to origin.

This is a pretty simple task, but provides a small amount of automation in case a developer doesn't remember the correct Git syntax offhand.

This closes #469 

Given that we now use a version based off of Git tag instead of a hard-coded version in the code, I decided not to make the tag creation part of the ``pypi`` task.  That way a developer can create the appropriate Git tag however she wishes prior to publishing a release to pypi and isn't limited to creating it via **invoke**.