### PR TITLE
Reduce redundant definition of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ EXTRAS_REQUIRE = {
     # Python 3.4 and earlier require contextlib2 for temporarily redirecting stderr and stdout
     ":python_version<'3.5'": ['contextlib2', 'typing'],
     # Extra dependencies for running unit tests
-    'test': ["argcomplete ; sys_platform!='win32",  # include argcomplete tests where available
+    'test': ["argcomplete ; sys_platform!='win32'",  # include argcomplete tests where available
              "mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
              'codecov', 'pytest', 'pytest-cov', 'pytest-mock'],
     # development only dependencies:  install with 'pip install -e .[dev]'

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,14 @@ EXTRAS_REQUIRE = {
     ":sys_platform!='win32'": ['wcwidth'],
     # Python 3.4 and earlier require contextlib2 for temporarily redirecting stderr and stdout
     ":python_version<'3.5'": ['contextlib2', 'typing'],
-    # development only dependencies
-    # install with 'pip install -e .[dev]'
-    'dev': [
-        # for python 3.5 and earlier we need the third party mock module
-        "mock ; python_version<'3.6'",
-        'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'pylint',
-        'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'invoke', 'twine>=1.11',
+    # Extra dependencies for running unit tests
+    'test': ["argcomplete ; sys_platform!='win32",  # include argcomplete tests where available
+             "mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
+             'codecov', 'pytest', 'pytest-cov', 'pytest-mock'],
+    # development only dependencies:  install with 'pip install -e .[dev]'
+    'dev': ["mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
+            'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'pylint',
+            'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'invoke', 'twine>=1.11',
     ]
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ testpaths = tests
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
-setenv =
-    PYTHONPATH={toxinidir}
+setenv = PYTHONPATH={toxinidir}
+extras = test
 
 [testenv:docs]
 basepython = python3.5
@@ -18,76 +18,30 @@ changedir = docs
 commands = sphinx-build -a -W -T -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:py34]
-deps =
-  codecov
-  pyperclip
-  pytest
-  pytest-cov
-  pytest-mock
-  argcomplete
-  wcwidth
 commands =
   py.test {posargs} --cov
   codecov
 
 [testenv:py35]
-deps =
-  mock
-  pyperclip
-  pytest
-  pytest-mock
-  argcomplete
-  wcwidth
 commands = py.test -v
 
 [testenv:py35-win]
-deps =
-  mock
-  pyperclip
-  pyreadline
-  pytest
 commands = py.test -v
 
 [testenv:py36]
-deps =
-  codecov
-  pyperclip
-  pytest
-  pytest-cov
-  pytest-mock
-  argcomplete
-  wcwidth
 commands =
   py.test {posargs} --cov
   codecov
 
 [testenv:py36-win]
-deps =
-  codecov
-  pyperclip
-  pyreadline
-  pytest
-  pytest-cov
 commands =
   py.test {posargs} --cov
   codecov
 
 [testenv:py37]
-deps =
-  pyperclip
-  pytest
-  pytest-mock
-  argcomplete
-  wcwidth
 commands = py.test -v
 
 [testenv:py37-win]
-deps =
-  codecov
-  pyperclip
-  pyreadline
-  pytest
-  pytest-cov
 commands =
   py.test {posargs} --cov
   codecov

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ testpaths = tests
 passenv = CI TRAVIS TRAVIS_* APPVEYOR*
 setenv = PYTHONPATH={toxinidir}
 extras = test
+commands =
+  py.test {posargs} --cov
+  codecov
 
 [testenv:docs]
 basepython = python3.5
@@ -16,32 +19,3 @@ deps =
   sphinx-rtd-theme
 changedir = docs
 commands = sphinx-build -a -W -T -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-[testenv:py34]
-commands =
-  py.test {posargs} --cov
-  codecov
-
-[testenv:py35]
-commands = py.test -v
-
-[testenv:py35-win]
-commands = py.test -v
-
-[testenv:py36]
-commands =
-  py.test {posargs} --cov
-  codecov
-
-[testenv:py36-win]
-commands =
-  py.test {posargs} --cov
-  codecov
-
-[testenv:py37]
-commands = py.test -v
-
-[testenv:py37-win]
-commands =
-  py.test {posargs} --cov
-  codecov


### PR DESCRIPTION
Modified **setup.py** to include a definition of the extra dependencies required for running unit tests.
This allowed a significant simplification of **tox.ini**.

This closes #486 