### PR TITLE
Travis CI tests now run with official Python 3.7 instead of development version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - os: linux
           python: 3.7
           dist: xenial
+          sudo: true  # Travis CI doesn't yet support official (non-development) Python 3.7 on container-based builds
           env: TOXENV=py37
         - os: linux
           python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           python: 3.6
           env: TOXENV=py36
         - os: linux
-          python: 3.7-dev
+          python: 3.7
           env: TOXENV=py37
         - os: linux
           python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
           env: TOXENV=py36
         - os: linux
           python: 3.7
+          dist: xenial
           env: TOXENV=py37
         - os: linux
           python: 3.5


### PR DESCRIPTION
.travis.yml now tests against Python 3.7 instead of 3.7-dev

This closes #520 