### PR TITLE
Replace static image link with link to YouTube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ applications.  It provides a simple API which is an extension of Python's built-
 of cmd to make your life easier and eliminates much of the boilerplate code which would be necessary
 when using cmd.
 
-[![Screenshot](cmd2.png)](https://github.com/python-cmd2/cmd2/blob/master/cmd2.png)
+Click on image below to watch a short video demonstrating the capabilities of cmd2.
 
+[![Screenshot](cmd2.png)](https://youtu.be/DDU_JH6cFsA)
 
 Main Features
 -------------

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ applications.  It provides a simple API which is an extension of Python's built-
 of cmd to make your life easier and eliminates much of the boilerplate code which would be necessary
 when using cmd.
 
-Click on image below to watch a short video demonstrating the capabilities of cmd2.
-
+Click on image below to watch a short video demonstrating the capabilities of cmd2:
 [![Screenshot](cmd2.png)](https://youtu.be/DDU_JH6cFsA)
 
 Main Features


### PR DESCRIPTION
This partly addresses #484 

This PR leaves the same static image on the front-page README, but replaces the embedded link with a link to the YouTube video made by @MarkLalor.  Some text added above the image tells the user to click the image to watch a video. 