### PR TITLE
Add Env setup documentation in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,23 +180,20 @@ $ git push origin [name_of_your_new_branch]
 
 
 ### Setting up for cmd2 development
-For doing cmd2 development, you actually do NOT want to have cmd2 installed as a Python package.
-So if you have previously installed cmd2, make sure to uninstall it:
+For doing cmd2 development, it is recommended you create a virutal environment and install the package from the source.
 ```sh
-$ pip uninstall cmd2
+# Create a new environment for cmd2
+$ conda create -n cmd2 python=3.6
+
+# Activate cmd virtual environment
+$ source activate cmd2
 ```
 
-Assuming you cloned the repository to `~/src/cmd2`:
-```sh
-$ cd ~/src/cmd2
-$ pip install -e .
-```
-will install cmd2 in [editable mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs).
+Assuming you cloned the repository to `~/src/cmd2` you can install cmd2 in 
+[editable mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs).
 Changes to the source code are immediately available when the python interpreter
 imports `cmd2`, there is no need to re-install the module after every change. This
-command will also install all of the runtime dependencies for `cmd2`.
-
-Next you should install all the modules used for development of `cmd2`:
+command will also install all of the runtime dependencies for `cmd2` and modules used for development of `cmd2`:
 ```sh
 $ cd ~/src/cmd2
 $ pip install -e .[dev]
@@ -229,11 +226,17 @@ have a look at `tasks.py`.
 Now you can check if everything is installed and working:
 ```sh
 $ cd ~src/cmd2
+$ invoke pytest
+```
+
+If the tests are executed it means that dependencies and project are installed succesfully.
+
+You can also run the example app and see a prompt that says "(Cmd)" running the command:
+```sh
 $ python examples/example.py
 ```
 
-If the example app loads, you should see a prompt that says "(Cmd)".  You can
-type `help` to get help or `quit` to quit. If you see that, then congratulations
+You can type `help` to get help or `quit` to quit. If you see that, then congratulations
 – you're all set. Otherwise, refer to the cmd2 [installation instructions](https://cmd2.readthedocs.io/en/latest/install.html#installing).
 There also might be an error in the console of your Bash / terminal / command line
 that will help identify the problem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,13 +180,30 @@ $ git push origin [name_of_your_new_branch]
 
 
 ### Setting up for cmd2 development
-For doing cmd2 development, it is recommended you create a virutal environment and install the package from the source.
-```sh
-# Create a new environment for cmd2
-$ conda create -n cmd2 python=3.6
+For doing cmd2 development, it is recommended you create a virutal environment using Conda or Virtualenv and install the package from the source.
 
-# Activate cmd virtual environment
+#### Create a new environment for cmd2 using Conda
+```sh
+$ conda create -n cmd2_py36 python=3.6
 $ source activate cmd2
+```
+
+#### Create a new environment for cmd using Virtualenv
+We recommend that you use [pyenv](https://github.com/pyenv/pyenv) to manage your installed python versions.
+
+```sh
+# Check pyenv versions installed
+pyenv versions
+
+# Install python version defined
+pyenv install 3.6.3
+```
+With the Python version installed, you can set the virutalenv properly. 
+
+```sh
+$ cd ~/src/cmd2
+$ virtualenv -p $(pyenv root)/versions/3.6.3/ cmd_py36 
+$ source ~/src/cmd2/bin/activate
 ```
 
 Assuming you cloned the repository to `~/src/cmd2` you can install cmd2 in 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ For doing cmd2 development, it is recommended you create a virutal environment u
 #### Create a new environment for cmd2 using Conda
 ```sh
 $ conda create -n cmd2_py36 python=3.6
-$ source activate cmd2
+$ conda activate cmd2
 ```
 
 #### Create a new environment for cmd using Virtualenv


### PR DESCRIPTION
Hi guys, this PR is related with issue #471. It is a proposal to improve the CONTRIBUTING doc.

I add some steps to configure an environment using conda, helping current and new devs.

I want to add description for virtualenv too.

Please, give me a feedback to go further.

This closes #471