### PR TITLE
Make name a required argument for the "invoke tag" command

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -176,7 +176,7 @@ def clean_all(context):
 namespace_clean.add_task(clean_all, 'all')
 
 @invoke.task
-def tag(context, name='', message=''):
+def tag(context, name, message=''):
     "Add a Git tag and push it to origin"
     # If a tag was provided on the command-line, then add a Git tag and push it to origin
     if name:


### PR DESCRIPTION
This causes the "invoke tag" command to function in an intuitive fashion as so:
    invoke tag tag_name

Previously when name was an optional argument, the name needed to be set using a flag like so:
    invoke tag -n tag_name

This has the side benefit of now making the recommended usage in the Contributor's Guide correct.