### PR TITLE
Deleted Cmd.colorize() method and Cmd._colorcodes dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.7 (TBD, 2018)
+* Deletions (potentially breaking changes)
+    * Deleted ``Cmd.colorize()`` and ``Cmd._colorcodes`` which were deprecated in 0.9.5
+    
 ## 0.9.6 (October 13, 2018)
 * Bug Fixes
     * Fixed bug introduced in 0.9.5 caused by backing up and restoring `self.prompt` in `pseudo_raw_input`.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -436,15 +436,6 @@ class Cmd(cmd.Cmd):
         # Codes used for exit conditions
         self._STOP_AND_EXIT = True  # cmd convention
 
-        self._colorcodes = {'bold': {True: '\x1b[1m', False: '\x1b[22m'},
-                            'cyan': {True: Fore.CYAN, False: Fore.RESET},
-                            'blue': {True: Fore.BLUE, False: Fore.RESET},
-                            'red': {True: Fore.RED, False: Fore.RESET},
-                            'magenta': {True: Fore.MAGENTA, False: Fore.RESET},
-                            'green': {True: Fore.GREEN, False: Fore.RESET},
-                            'underline': {True: '\x1b[4m', False: Fore.RESET},
-                            'yellow': {True: Fore.YELLOW, False: Fore.RESET}}
-
         # Used load command to store the current script dir as a LIFO queue to support _relative_load command
         self._script_dir = []
 
@@ -713,17 +704,6 @@ class Cmd(cmd.Cmd):
                 # broken_pipe_warning attribute to the message you want printed.`
                 if self.broken_pipe_warning:
                     sys.stderr.write(self.broken_pipe_warning)
-
-    def colorize(self, val: str, color: str) -> str:
-        """Given a string (``val``), returns that string wrapped in UNIX-style
-           special characters that turn on (and then off) text color and style.
-           If the ``colors`` environment parameter is ``False``, or the application
-           is running on Windows, will return ``val`` unchanged.
-           ``color`` should be one of the supported strings (or styles):
-           red/blue/green/cyan/magenta, bold, underline"""
-        if self.colors.lower() != constants.COLORS_NEVER.lower() and (self.stdout == self.initial_stdout):
-            return self._colorcodes[color][True] + val + self._colorcodes[color][False]
-        return val
 
     # -----  Methods related to tab completion -----
 

--- a/docs/unfreefeatures.rst
+++ b/docs/unfreefeatures.rst
@@ -161,9 +161,6 @@ Always
     the output destination
 
 
-The previously recommended ``colorize`` method is now deprecated.
-
-
 .. _quiet:
 
 Suppressing non-essential output

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -855,16 +855,6 @@ now: True
     assert str(err).startswith('Traceback (most recent call last):')
 
 
-def test_base_colorize(base_app):
-    # If using base_app test fixture it won't get colorized because we replaced self.stdout
-    color_test = base_app.colorize('Test', 'red')
-    assert color_test == 'Test'
-
-    # But if we create a fresh Cmd() instance, it will
-    fresh_app = cmd2.Cmd()
-    color_test = fresh_app.colorize('Test', 'red')
-    assert color_test == '\x1b[31mTest\x1b[39m'
-
 def _expected_no_editor_error():
     expected_exception = 'OSError'
     # If PyPy, expect a different exception than with Python 3


### PR DESCRIPTION
This PR deletes a couple things that were deprecated in the 0.9.5 release and dealt with a built-in method for colorizing output.

``cmd2`` has for awhile had a dependency on ``colorama`` which provides much more full-featured and cross-platform support for colorizing output.  We strongly recommend that all end users use that or a similar colorizing library such as ``plumbum`` or ``colored``.

This closes #582 