### PR TITLE
Ruggedized registration of SIGINT signal handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.9.7 (TBD, 2018)
+* Enhancements
+    * **cmdloop** now only attempts to register a custom signal handler for SIGINT if running in the main thread
 * Deletions (potentially breaking changes)
     * Deleted ``Cmd.colorize()`` and ``Cmd._colorcodes`` which were deprecated in 0.9.5
     

--- a/docs/settingchanges.rst
+++ b/docs/settingchanges.rst
@@ -140,6 +140,10 @@ set to ``False``, then the current line will simply be cancelled.
   (Cmd) typing a comma^C
   (Cmd)
 
+.. warning::
+    The default SIGINT behavior will only function properly if **cmdloop** is running
+    in the main thread.
+
 
 Timing
 ======


### PR DESCRIPTION
cmdloop now checks to see if it is running in the main thread before attempting to register a signal handler for SIGINT

This closes #584 