### PR TITLE
Azure Pipelines build for macOS now runs tox instead of pytest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,6 @@ jobs:
     # Install dependencies - install specific PyPI packages with pip, including cmd2 dependencies
   - script: |
       python -m pip install --upgrade pip && pip3 install --upgrade setuptools gnureadline tox
-      pip install -e .
     displayName: 'Upgrade pip and setuptools'
     continueOnError: false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Install dependencies - install specific PyPI packages with pip, including cmd2 dependencies
   - script: |
-      python -m pip install --upgrade pip && pip3 install --upgrade setuptools gnureadline tox
+      python -m pip install --upgrade pip && pip3 install --upgrade setuptools tox
     displayName: 'Upgrade pip and setuptools'
     continueOnError: false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,12 +16,16 @@ jobs:
     matrix:
       Python34:
         python.version: '3.4'
+        TOXENV: 'py34'
       Python35:
         python.version: '3.5'
+        TOXENV: 'py35'
       Python36:
         python.version: '3.6'
+        TOXENV: 'py36'
       Python37:
         python.version: '3.7'
+        TOXENV: 'py37'
     # Increase the maxParallel value to simultaneously run the job for all versions in the matrix (max 10 for free open-source)
     maxParallel: 4
 
@@ -34,7 +38,7 @@ jobs:
 
     # Install dependencies - install specific PyPI packages with pip, including cmd2 dependencies
   - script: |
-      python -m pip install --upgrade pip && pip3 install --upgrade setuptools gnureadline
+      python -m pip install --upgrade pip && pip3 install --upgrade setuptools gnureadline tox
       pip install -e .
     displayName: 'Upgrade pip and setuptools'
     continueOnError: false
@@ -43,8 +47,7 @@ jobs:
 
     # Test - test with pytest, collect coverage metrics with pytest-cov, and publish these metrics to codecov.io
   - script: |
-      pip install pytest pytest-cov pytest-mock codecov mock
-      py.test tests --cov --junitxml=junit/test-results.xml && codecov
+      tox -e $(TOXENV)
     displayName: 'Run tests and code coverage'
     continueOnError: false
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ EXTRAS_REQUIRE = {
     ":python_version<'3.5'": ['contextlib2', 'typing'],
     # Extra dependencies for running unit tests
     'test': ["argcomplete ; sys_platform!='win32'",  # include argcomplete tests where available
+             "gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in tox env
              "mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
              'codecov', 'pytest', 'pytest-cov', 'pytest-mock'],
     # development only dependencies:  install with 'pip install -e .[dev]'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv = CI TRAVIS TRAVIS_* APPVEYOR*
 setenv = PYTHONPATH={toxinidir}
 extras = test
 commands =
-  py.test {posargs} --cov
+  py.test {posargs} --cov --junitxml=junit/test-results.xml
   codecov
 
 [testenv:docs]


### PR DESCRIPTION
For symmetry with the other CI services, our Azure Pipelines builds for macOS now runs ``tox`` instead of ``pytest``.

This closes #488 