### PR TITLE
Undefined names: from colorama import Fore, Back

### DIFF
--- a/examples/plumbum_colors.py
+++ b/examples/plumbum_colors.py
@@ -31,6 +31,7 @@ import random
 import argparse
 
 import cmd2
+from colorama import Fore, Back
 from plumbum.colors import fg, bg, reset
 
 FG_COLORS = {


### PR DESCRIPTION
__Fore__ and __Back__ are used on line 128 but they are never defined or imported.  That means that they are _undefined names_  which have the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/python-cmd2/cmd2 on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/plumbum_colors.py:127:21: F821 undefined name 'Fore'
        color_off = Fore.RESET + Back.RESET
                    ^
./examples/plumbum_colors.py:127:34: F821 undefined name 'Back'
        color_off = Fore.RESET + Back.RESET
                                 ^
```