### PR TITLE
Travis CI: Use flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   if [[ $TOXENV == py37 ]]; then
-    flake8 . --count --exclude=./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
-    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
+    flake8 . --count --exclude=./.,./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
+    flake8 . --count --exclude=./. --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
   fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   if [[ $TOXENV == py37 ]]; then
-    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics ;
+    flake8 . --count --exclude=./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   if [[ $TOXENV == py37 ]]; then
-    flake8 . --count --exclude=./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
-    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
+    flake8 . --count --exclude=./.*,./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
+    flake8 . --count --exclude=./.* --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
   fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   if [[ $TOXENV == py37 ]]; then
-    flake8 . --count --exclude=./.,./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
-    flake8 . --count --exclude=./. --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
+    flake8 . --count --exclude=./examples,./tests --select=E901,E999,F821,F822,F823 --show-source --statistics ;
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
   fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 #            - BREW_INSTALL=python3
 
 install:
-  - pip install tox
+  - pip install flake8 tox
 #  - |
 #    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 #      if [[ -n "$BREW_INSTALL" ]]; then
@@ -41,7 +41,14 @@ install:
 #        brew install "$BREW_INSTALL"
 #      fi
 #    fi
-#    pip install tox
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  if [[ $TOXENV == py37 ]]; then
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics ;
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics ;
+  fi
 
 script:
   - tox


### PR DESCRIPTION
Currently __app__ and __self__ are _undefined names_.  Is there a way to use __global__ or __import__ or __# noqa__ to resolve this?

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree