### PR TITLE
Remove tabs as indentation

### DIFF
--- a/tests/test_autocompletion.py
+++ b/tests/test_autocompletion.py
@@ -31,8 +31,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -d, --duration DURATION{1..2}
                         Duration constraint in minutes.
-                        	single value - maximum duration
-                        	[a, b] - duration range'''
+                                single value - maximum duration
+                                [a, b] - duration range'''
 
 MEDIA_MOVIES_ADD_HELP = '''Usage: media movies add -d DIRECTOR{1..2}
                         [-h]
@@ -99,8 +99,8 @@ def test_autcomp_hint(cmd2_app, capsys):
     assert out == '''
 Hint:
   -d, --duration DURATION    Duration constraint in minutes.
-                             	single value - maximum duration
-                             	[a, b] - duration range
+                                single value - maximum duration
+                                [a, b] - duration range
 
 '''
 
@@ -140,8 +140,8 @@ def test_autcomp_hint_in_narg_range(cmd2_app, capsys):
     assert out == '''
 Hint:
   -d, --duration DURATION    Duration constraint in minutes.
-                             	single value - maximum duration
-                             	[a, b] - duration range
+                                single value - maximum duration
+                                [a, b] - duration range
 
 '''
 


### PR DESCRIPTION
Every instance of CPython comes with a builtin utility https://github.com/python/cpython/blob/master/Tools/scripts/reindent.py which replaces tab indentation with space indentation.  This PR uses that utility to fix the following 6 issues:

$ __flake8 . --select=E101__
```
./tests/test_autocompletion.py:34:25: E101 indentation contains mixed spaces and tabs
./tests/test_autocompletion.py:35:25: E101 indentation contains mixed spaces and tabs
./tests/test_autocompletion.py:102:30: E101 indentation contains mixed spaces and tabs
./tests/test_autocompletion.py:103:30: E101 indentation contains mixed spaces and tabs
./tests/test_autocompletion.py:143:30: E101 indentation contains mixed spaces and tabs
./tests/test_autocompletion.py:144:30: E101 indentation contains mixed spaces and tabs
```