### PR TITLE
Added a shlex.split() wrapper to have a common way of calling it.

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -35,7 +35,6 @@ import glob
 import inspect
 import os
 import re
-import shlex
 import sys
 import threading
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union, IO

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -158,7 +158,7 @@ def with_category(category: str) -> Callable:
     return cat_decorator
 
 
-def _get_command_arg_list(to_parse: Union[str, Statement], preserve_quotes: bool) -> List[str]:
+def _get_command_arg_list(to_parse: Union[Statement, str], preserve_quotes: bool) -> List[str]:
     """
     Called by the argument_list and argparse wrappers to retrieve just the arguments being
     passed to their do_* methods as a list.
@@ -198,7 +198,7 @@ def with_argument_list(*args: List[Callable], preserve_quotes: bool = False) -> 
 
     def arg_decorator(func: Callable):
         @functools.wraps(func)
-        def cmd_wrapper(cmd2_instance, statement: Union[str, Statement]):
+        def cmd_wrapper(cmd2_instance, statement: Union[Statement, str]):
             parsed_arglist = _get_command_arg_list(statement, preserve_quotes)
             return func(cmd2_instance, parsed_arglist)
 
@@ -225,7 +225,7 @@ def with_argparser_and_unknown_args(argparser: argparse.ArgumentParser, preserve
     # noinspection PyProtectedMember
     def arg_decorator(func: Callable):
         @functools.wraps(func)
-        def cmd_wrapper(cmd2_instance, statement: Union[str, Statement]):
+        def cmd_wrapper(cmd2_instance, statement: Union[Statement, str]):
             parsed_arglist = _get_command_arg_list(statement, preserve_quotes)
 
             try:
@@ -268,7 +268,7 @@ def with_argparser(argparser: argparse.ArgumentParser,
     # noinspection PyProtectedMember
     def arg_decorator(func: Callable):
         @functools.wraps(func)
-        def cmd_wrapper(cmd2_instance, statement: Union[str, Statement]):
+        def cmd_wrapper(cmd2_instance, statement: Union[Statement, str]):
 
             parsed_arglist = _get_command_arg_list(statement, preserve_quotes)
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -47,8 +47,8 @@ from . import plugin
 from . import utils
 from .argparse_completer import AutoCompleter, ACArgumentParser, ACTION_ARG_CHOICES
 from .clipboard import can_clip, get_paste_buffer, write_to_paste_buffer
-from .parsing import StatementParser, Statement, Macro, MacroArg, shlex_split, get_command_arg_list
 from .history import History, HistoryItem
+from .parsing import StatementParser, Statement, Macro, MacroArg, shlex_split, get_command_arg_list
 
 # Set up readline
 from .rl_utils import rl_type, RlType, rl_get_point, rl_set_prompt, vt100_support, rl_make_safe_prompt

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -256,7 +256,7 @@ def get_command_arg_list(to_parse: Union[Statement, str], preserve_quotes: bool)
         else:
             return to_parse.argv[1:]
     else:
-        # We only have the argument string. Use the parser to split this string.
+        # We have the arguments in a string. Use shlex to split it.
         parsed_arglist = shlex_split(to_parse)
         if not preserve_quotes:
             parsed_arglist = [utils.strip_quotes(arg) for arg in parsed_arglist]

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -349,7 +349,7 @@ class StatementParser:
             return []
 
         # split on whitespace
-        tokens = shlex.split(line, comments=False, posix=False)
+        tokens = StatementParser.shlex_split(line)
 
         # custom lexing
         tokens = self._split_on_punctuation(tokens)
@@ -606,6 +606,16 @@ class StatementParser:
             args = ' '.join(tokens[1:])
 
         return command, args
+
+    @staticmethod
+    def shlex_split(str_to_split: str) -> List[str]:
+        """
+        A wrapper around shlex.split() that uses cmd2's preferred arguments
+        This allows other classes to easily call split() the same way StatementParser does
+        :param str_to_split: the string being split
+        :return: A list of tokens
+        """
+        return shlex.split(str_to_split, comments=False, posix=False)
 
     def _split_on_punctuation(self, tokens: List[str]) -> List[str]:
         """Further splits tokens from a command line using punctuation characters

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -5,12 +5,22 @@
 import os
 import re
 import shlex
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple, Union
 
 import attr
 
 from . import constants
 from . import utils
+
+
+def shlex_split(str_to_split: str) -> List[str]:
+    """A wrapper around shlex.split() that uses cmd2's preferred arguments.
+
+    This allows other classes to easily call split() the same way StatementParser does
+    :param str_to_split: the string being split
+    :return: A list of tokens
+    """
+    return shlex.split(str_to_split, comments=False, posix=False)
 
 
 @attr.s(frozen=True)
@@ -226,6 +236,34 @@ class Statement(str):
         return rtn
 
 
+def get_command_arg_list(to_parse: Union[Statement, str], preserve_quotes: bool) -> List[str]:
+    """
+    Called by the argument_list and argparse wrappers to retrieve just the arguments being
+    passed to their do_* methods as a list.
+
+    :param to_parse: what is being passed to the do_* method. It can be one of two types:
+                     1. An already parsed Statement
+                     2. An argument string in cases where a do_* method is explicitly called
+                        e.g.: Calling do_help('alias create') would cause to_parse to be 'alias create'
+
+    :param preserve_quotes: if True, then quotes will not be stripped from the arguments
+    :return: the arguments in a list
+    """
+    if isinstance(to_parse, Statement):
+        # In the case of a Statement, we already have what we need
+        if preserve_quotes:
+            return to_parse.arg_list
+        else:
+            return to_parse.argv[1:]
+    else:
+        # We only have the argument string. Use the parser to split this string.
+        parsed_arglist = shlex_split(to_parse)
+        if not preserve_quotes:
+            parsed_arglist = [utils.strip_quotes(arg) for arg in parsed_arglist]
+
+        return parsed_arglist
+
+
 class StatementParser:
     """Parse raw text into command components.
 
@@ -349,7 +387,7 @@ class StatementParser:
             return []
 
         # split on whitespace
-        tokens = StatementParser.shlex_split(line)
+        tokens = shlex_split(line)
 
         # custom lexing
         tokens = self._split_on_punctuation(tokens)
@@ -606,16 +644,6 @@ class StatementParser:
             args = ' '.join(tokens[1:])
 
         return command, args
-
-    @staticmethod
-    def shlex_split(str_to_split: str) -> List[str]:
-        """
-        A wrapper around shlex.split() that uses cmd2's preferred arguments
-        This allows other classes to easily call split() the same way StatementParser does
-        :param str_to_split: the string being split
-        :return: A list of tokens
-        """
-        return shlex.split(str_to_split, comments=False, posix=False)
 
     def _split_on_punctuation(self, tokens: List[str]) -> List[str]:
         """Further splits tokens from a command line using punctuation characters

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -72,14 +72,6 @@ class ArgparseApp(cmd2.Cmd):
     def do_preservelist(self, arglist):
         self.stdout.write('{}'.format(arglist))
 
-    @cmd2.with_argument_list
-    @cmd2.with_argument_list
-    def do_arglisttwice(self, arglist):
-        if isinstance(arglist, list):
-            self.stdout.write(' '.join(arglist))
-        else:
-            self.stdout.write('False')
-
     known_parser = argparse.ArgumentParser()
     known_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     known_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
@@ -177,10 +169,6 @@ def test_arglist(argparse_app):
 def test_preservelist(argparse_app):
     out = run_cmd(argparse_app, 'preservelist foo "bar baz"')
     assert out[0] == "['foo', '\"bar baz\"']"
-
-def test_arglist_decorator_twice(argparse_app):
-    out = run_cmd(argparse_app, 'arglisttwice "we  should" get these')
-    assert out[0] == 'we  should get these'
 
 
 class SubcommandApp(cmd2.Cmd):


### PR DESCRIPTION
This is pretty much a refactor that provides a common way of calling `shlex.split()` to ensure the same arguments are always used for consistent parsing.

I also replaced `parse_quoted_string()` with `_get_command_arg_list()`. I believe the name and documentation of this function better communicates its purpose. This function also doesn't bother calling `shlex.split()` on an already parsed `Statement` object.

@kotfu I removed a unit test called `test_arglist_decorator_twice`. Is that an OK change? I wasn't sure the use case of having two `with_argument_list` decorators on one method. Let me know if I need to put it back and make the new code work with it. It would be a trivial fix for me.