### PR TITLE
Help now writes to stderr when no help information is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
     * Added ability to include command name placeholders in the message printed when trying to run a disabled command.
         * See docstring for ``disable_command()`` or ``disable_category()`` for more details.
 * Potentially breaking changes
-    * The following commands now write to stderr instead of stdout when printing an error. This will making catching
+    * The following commands now write to stderr instead of stdout when printing an error. This will make catching
     errors easier in pyscript.
         * ``do_help()`` - when no help information can be found
         * ``default()`` - in all cases since this is called when an invalid command name is run
         * ``_report_disabled_command_usage()`` - in all cases since this is called when a disabled command is run
+    * Removed *** from beginning of error messages printed by `do_help()` and `default()`.
 
 ## 0.9.11 (March 13, 2019)
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 * Enhancements
     * Added ability to include command name placeholders in the message printed when trying to run a disabled command.
         * See docstring for ``disable_command()`` or ``disable_category()`` for more details.
+* Potentially breaking changes
+    * The following commands now write to stderr instead of stdout when printing an error. This will making catching
+    errors easier in pyscript.
+        * ``do_help()`` - when no help information can be found
+        * ``default()`` - in all cases since this is called when an invalid command name is run
+        * ``_report_disabled_command_usage()`` - in all cases since this is called when a disabled command is run
 
 ## 0.9.11 (March 13, 2019)
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * Enhancements
     * Added ability to include command name placeholders in the message printed when trying to run a disabled command.
         * See docstring for ``disable_command()`` or ``disable_category()`` for more details.
+    * Added instance attributes to customize error messages without having to override methods. Theses messages can
+    also be colored.
+        * `help_error` - the error that prints when no help information can be found
+        * `default_error` - the error that prints when a non-existent command is run
 * Potentially breaking changes
     * The following commands now write to stderr instead of stdout when printing an error. This will make catching
     errors easier in pyscript.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -338,6 +338,9 @@ class Cmd(cmd.Cmd):
                 'quiet': "Don't print nonessential feedback",
                 'timing': 'Report execution times'}
 
+    # Override cmd's nohelp
+    nohelp = "No help on {}"
+
     def __init__(self, completekey: str = 'tab', stdin=None, stdout=None, persistent_history_file: str = '',
                  persistent_history_length: int = 1000, startup_script: Optional[str] = None, use_ipython: bool = False,
                  transcript_files: Optional[List[str]] = None) -> None:
@@ -2057,8 +2060,7 @@ class Cmd(cmd.Cmd):
 
             return self.do_shell(statement.command_and_args)
         else:
-            self.perror('{} is not a recognized command, alias, or macro'.format(statement.command),
-                        traceback_war=False, err_color=Fore.RESET)
+            sys.stderr.write('{} is not a recognized command, alias, or macro\n'.format(statement.command))
 
     def pseudo_raw_input(self, prompt: str) -> str:
         """Began life as a copy of cmd's cmdloop; like raw_input but
@@ -2596,7 +2598,8 @@ class Cmd(cmd.Cmd):
 
             # If there is no help information then print an error
             elif help_func is None and (func is None or not func.__doc__):
-                self.perror("No help on {}".format(args.command), traceback_war=False, err_color=Fore.RESET)
+                err_msg = Cmd.nohelp.format(args.command)
+                self.decolorized_write(sys.stderr, "{}\n".format(err_msg))
 
             # Otherwise delegate to cmd base class do_help()
             else:
@@ -3727,7 +3730,7 @@ class Cmd(cmd.Cmd):
         :param message_to_print: the message reporting that the command is disabled
         :param kwargs: not used
         """
-        self.perror(message_to_print, traceback_war=False, err_color=Fore.RESET)
+        self.decolorized_write(sys.stderr, "{}\n".format(message_to_print))
 
     def cmdloop(self, intro: Optional[str] = None) -> None:
         """This is an outer wrapper around _cmdloop() which deals with extra features provided by cmd2.

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -952,10 +952,10 @@ undoc
 """)
     assert out == expected
 
-def test_help_undocumented(help_app):
-    out = run_cmd(help_app, 'help undoc')
-    expected = normalize('*** No help on undoc')
-    assert out == expected
+def test_help_undocumented(help_app, capsys):
+    run_cmd(help_app, 'help undoc')
+    out, err = capsys.readouterr()
+    assert err.startswith("No help on undoc")
 
 def test_help_overridden_method(help_app):
     out = run_cmd(help_app, 'help edit')
@@ -1787,8 +1787,9 @@ def test_macro_create_with_escaped_args(base_app, capsys):
     assert out == normalize("Macro 'fake' created")
 
     # Run the macro
-    out = run_cmd(base_app, 'fake')
-    assert 'No help on {1}' in out[0]
+    run_cmd(base_app, 'fake')
+    out, err = capsys.readouterr()
+    assert err.startswith('No help on {1}')
 
 def test_macro_usage_with_missing_args(base_app, capsys):
     # Create the macro


### PR DESCRIPTION
Since ``StdSim.stderr`` is used to detect errors in a pyscript, it makes sense for us to be writing error strings to stderr,

I also removed '***' from the beginning of `help()` and `default()` error messages.