### PR TITLE
Use README.md as the PyPI long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,49 +3,13 @@
 """
 Setuptools setup file, used to install or test 'cmd2'
 """
+import codecs
 from setuptools import setup
 
 DESCRIPTION = "cmd2 - a tool for building interactive command line applications in Python"
-LONG_DESCRIPTION = """cmd2 is a tool for building interactive command line applications in Python. Its goal is to make
-it quick and easy for developers to build feature-rich and user-friendly interactive command line applications.  It
-provides a simple API which is an extension of Python's built-in cmd module.  cmd2 provides a wealth of features on top
-of cmd to make your life easier and eliminates much of the boilerplate code which would be necessary when using cmd.
 
-The latest documentation for cmd2 can be read online here:
-https://cmd2.readthedocs.io/
-
-Main features:
-
-    - Searchable command history (`history` command and `<Ctrl>+r`) - optionally persistent
-    - Text file scripting of your application with `load` (`@`) and `_relative_load` (`@@`)
-    - Python scripting of your application with ``pyscript``
-    - Run shell commands with ``!``
-    - Pipe command output to shell commands with `|`
-    - Redirect command output to file with `>`, `>>`
-    - Bare `>`, `>>` with no filename send output to paste buffer (clipboard)
-    - `py` enters interactive Python console (opt-in `ipy` for IPython console)
-    - Option to display long output using a pager with ``cmd2.Cmd.ppaged()``
-    - Multi-line commands
-    - Special-character command shortcuts (beyond cmd's `?` and `!`)
-    - Command aliasing similar to bash `alias` command
-    - Macros, which are similar to aliases, but they can contain argument placeholders
-    - Ability to load commands at startup from an initialization script
-    - Settable environment parameters
-    - Parsing commands with arguments using `argparse`, including support for sub-commands
-    - Unicode character support
-    - Good tab-completion of commands, sub-commands, file system paths, and shell commands
-    - Automatic tab-completion of `argparse` flags when using one of the `cmd2` `argparse` decorators
-    - Support for Python 3.4+ on Windows, macOS, and Linux
-    - Trivial to provide built-in help for all commands
-    - Built-in regression testing framework for your applications (transcript-based testing)
-    - Transcripts for use with built-in regression can be automatically generated from `history -t`
-    - Alerts that seamlessly print while user enters text at prompt
-
-Usable without modification anywhere cmd is used; simply import cmd2.Cmd in place of cmd.Cmd.
-
-Version 0.9.0+ of cmd2 supports Python 3.4+ only. If you wish to use cmd2 with Python 2.7, then
-please install version 0.8.x.
-"""
+with codecs.open('README.md', encoding='utf8') as f:
+    LONG_DESCRIPTION = f.read()
 
 CLASSIFIERS = list(filter(None, map(str.strip,
 """
@@ -90,6 +54,7 @@ setup(
     use_scm_version=True,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     classifiers=CLASSIFIERS,
     author='Catherine Devlin',
     author_email='catherine.devlin@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Setuptools setup file, used to install or test 'cmd2'
 import codecs
 from setuptools import setup
 
-DESCRIPTION = "cmd2 - a tool for building interactive command line applications in Python"
+DESCRIPTION = "cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python"
 
 with codecs.open('README.md', encoding='utf8') as f:
     LONG_DESCRIPTION = f.read()


### PR DESCRIPTION
Removed redundant documentation from **setup.py** by having it read in the entire **README.md** and use that as the "long description" for PyPI.

I validated that it works on test.pypi.org

This closes #551 