### PR TITLE
Pyscript fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.9.12 (March TBD, 2019)
+* Bug Fixes
+    * Fixed a bug in how redirection and piping worked inside ``py`` or ``pyscript`` commands
 * Enhancements
     * Added ability to include command name placeholders in the message printed when trying to run a disabled command.
         * See docstring for ``disable_command()`` or ``disable_category()`` for more details.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1902,21 +1902,21 @@ class Cmd(cmd.Cmd):
             read_fd, write_fd = os.pipe()
 
             # Open each side of the pipe and set stdout accordingly
-            subproc_stdin = io.open(read_fd, 'r')
-            new_stdout = io.open(write_fd, 'w')
+            pipe_read = io.open(read_fd, 'r')
+            pipe_write = io.open(write_fd, 'w')
 
             # We want Popen to raise an exception if it fails to open the process.  Thus we don't set shell to True.
             try:
-                pipe_proc = subprocess.Popen(statement.pipe_to, stdin=subproc_stdin)
+                pipe_proc = subprocess.Popen(statement.pipe_to, stdin=pipe_read, stdout=self.stdout)
                 ret_val = RedirectionSavedState(self_stdout=self.stdout,
                                                 sys_stdout=None,
                                                 pipe_proc=self.pipe_proc)
-                self.stdout = new_stdout
+                self.stdout = pipe_write
                 self.pipe_proc = pipe_proc
             except Exception as ex:
                 self.perror('Not piping because - {}'.format(ex), traceback_war=False)
-                subproc_stdin.close()
-                new_stdout.close()
+                pipe_read.close()
+                pipe_write.close()
 
         elif statement.output:
             import tempfile

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -372,7 +372,7 @@ class StatementParser:
             line = self._expand(line)
 
         # check if this line is a comment
-        if line.strip().startswith(constants.COMMENT_CHAR):
+        if line.lstrip().startswith(constants.COMMENT_CHAR):
             return []
 
         # split on whitespace

--- a/cmd2/pyscript_bridge.py
+++ b/cmd2/pyscript_bridge.py
@@ -98,8 +98,7 @@ class PyscriptBridge(object):
             self._cmd2_app.stdout = copy_cmd_stdout
             with redirect_stdout(copy_cmd_stdout):
                 with redirect_stderr(copy_stderr):
-                    # Include a newline in case it's a multiline command
-                    self._cmd2_app.onecmd_plus_hooks(command + '\n')
+                    self._cmd2_app.onecmd_plus_hooks(command)
         finally:
             self._cmd2_app.stdout = copy_cmd_stdout.inner_stream
 


### PR DESCRIPTION
Fixes #613 

The root cause of #613 was `onecmd_plus_hooks()` calling `_restore_output()` if `self.redirecting` was **True**. While **pyscript** was redirecting its output to a file, the `PyscriptBridge` would call `onecmd_plus_hooks()` to handle `app('help')`. After the help command ended, `_restore_output()` would be called because  `self.redirecting` was **True** and therefore the file handle **pyscript** was using to redirect its output would be closed.

The new code keeps track of redirection for each command. Therefore `_restore_output()` only restores stuff if the current command set up redirection.

This also enhances our **pyscript** functionality quite a bit. We can now independently redirect each command running within the script. Therefore the outer **pyscript** call may be writing its output to a file while commands being run within the script can write anywhere they want, including piping to another process.

1. app("help > help.txt")
2. app("!cat file | grep string")

This PR also made a change to the piped process in redirection. We now set its **stdout** to be `self.stdout`.

Lastly, I no longer append a `\n` to commands in PyscriptBridge. This was originally done to assist in running multiline commands in a pyscript file. However, it had the unintended consequence of breaking redirection with non-multiline commands. From now on users are expected to include a terminator in multiline commands being run in a pyscript. This fits the expected syntax anyway since commands passed to `app()` should be the same as they would be typed on the command line.