### PR TITLE
Path fix

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1141,7 +1141,11 @@ class Cmd(cmd.Cmd):
 
         # Remove cwd if it was added to match the text readline expects
         if cwd_added:
-            matches = [cur_path.replace(cwd + os.path.sep, '', 1) for cur_path in matches]
+            if cwd == os.path.sep:
+                to_replace = cwd
+            else:
+                to_replace = cwd + os.path.sep
+            matches = [cur_path.replace(to_replace, '', 1) for cur_path in matches]
 
         # Restore the tilde string if we expanded one to match the text readline expects
         if expanded_tilde_path:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -400,6 +400,25 @@ def test_path_completion_no_path(cmd2_app):
     assert completions_no_text == completions_cwd
     assert completions_cwd
 
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="this only applies on systems where the root directory is a slash")
+def test_path_completion_cwd_is_root_dir(cmd2_app):
+    # Change our CWD to root dir
+    cwd = os.getcwd()
+    os.chdir(os.path.sep)
+
+    text = ''
+    line = 'shell ls {}'.format(text)
+    endidx = len(line)
+    begidx = endidx - len(text)
+    completions = cmd2_app.path_complete(text, line, begidx, endidx)
+
+    # No match should start with a slash
+    assert not any(match.startswith(os.path.sep) for match in completions)
+
+    # Restore CWD
+    os.chdir(cwd)
+
 def test_path_completion_doesnt_match_wildcards(cmd2_app, request):
     test_dir = os.path.dirname(request.module.__file__)
 


### PR DESCRIPTION
Fixed issue when cmd2's CWD is / and relative path completion is done. Matches were being returned that began with a slash. Since these paths were relative, they should not have begun with the slash.