### PR TITLE
Stdsim fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Enhancements
     * `pyscript` limits a command's stdout capture to the same period that redirection does.
       Therefore output from a command's postparsing and finalization hooks isn't saved in the StdSim object.
+    * `StdSim.buffer.write()` now flushes when the wrapped stream uses line buffering and the bytes being written
+      contain a newline or carriage return. This helps when `pyscript` is echoing the output of a shell command
+      since the output will print at the same frequency as when the command is run in a terminal.
     
 ## 0.9.12 (April 22, 2019)
 * Bug Fixes


### PR DESCRIPTION
Closes #654 
Removed support for wrapping binary streams in `ProcReader`.

These changes also improve the flushing behavior of when `pyscript` echos the output of a shell command. Since we obtain that output over binary pipes, we echo it using `StdSim.inner_stream.buffer.write()` which does not follow line buffering behavior by default. The new code will call `flush()` if the bytes being written contain a newline or carriage return and the inner stream has line buffering turned on.

This makes echoed shell command output print at the same frequency it would when run at the terminal. Commands like `ping` are a good test case for this. ex: `app('ping localhost')`