### PR TITLE
Macro refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
       since the output will print at the same frequency as when the command is run in a terminal.
     * **ACArgumentParser** no longer prints complete help text when a parsing error occurs since long help messages
      scroll the actual error message off the screen.
-     * Exceptions occurring in tab completion functions are now printed to stderr before returning control back to
+    * Exceptions occurring in tab completion functions are now printed to stderr before returning control back to
     readline. This makes debugging a lot easier since readline suppresses these exceptions.
 * Potentially breaking changes
     * Replaced `unquote_redirection_tokens()` with `unquote_specific_tokens()`. This was to support the fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 ## 0.9.13 (TBD, 2019)
+* Bug Fixes
+    * Fixed issue where aliases and macros could not contain terminator characters in their values
+    * History now shows what was typed for macros and not the resolved value by default. This is consistent with
+    the behavior of aliases. Use the `expanded` or `verbose` arguments to `history` to see the resolved value for
+    the macro.
 * Enhancements
     * `pyscript` limits a command's stdout capture to the same period that redirection does.
       Therefore output from a command's postparsing and finalization hooks isn't saved in the StdSim object.
     * `StdSim.buffer.write()` now flushes when the wrapped stream uses line buffering and the bytes being written
       contain a newline or carriage return. This helps when `pyscript` is echoing the output of a shell command
       since the output will print at the same frequency as when the command is run in a terminal.
+* Potentially breaking changes
+    * Replaced `unquote_redirection_tokens()` with `unquote_specific_tokens()`. This was to support the fix
+      that allows terminators in alias and macro values.
 * **Python 3.4 EOL notice**
     * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019
     * This is the last release of `cmd2` which will support Python 3.4
-    
+
 ## 0.9.12 (April 22, 2019)
 * Bug Fixes
     * Fixed a bug in how redirection and piping worked inside ``py`` or ``pyscript`` commands

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2410,10 +2410,6 @@ class Cmd(cmd.Cmd):
             self.perror("Invalid macro name: {}".format(errmsg), traceback_war=False)
             return
 
-        if args.name in self.get_all_commands():
-            self.perror("Macro cannot have the same name as a command", traceback_war=False)
-            return
-
         if args.name in self.aliases:
             self.perror("Macro cannot have the same name as an alias", traceback_war=False)
             return
@@ -2546,16 +2542,13 @@ class Cmd(cmd.Cmd):
                            "\n"
                            "    macro create backup !cp \"{1}\" \"{1}.orig\"\n"
                            "\n"
-                           "  Be careful! Since macros can resolve into commands, aliases, and macros,\n"
-                           "  it is possible to create a macro that results in infinite recursion.\n"
-                           "\n"
                            "  If you want to use redirection or pipes in the macro, then quote them as in\n"
                            "  this example to prevent the 'macro create' command from being redirected.\n"
                            "\n"
                            "    macro create show_results print_results -type {1} \"|\" less\n"
                            "\n"
-                           "  Because macros do not resolve until after parsing (hitting Enter), tab\n"
-                           "  completion will only complete paths.")
+                           "  Because macros do not resolve until after hitting Enter, tab completion\n"
+                           "  will only complete paths while entering a macro.")
 
     macro_create_parser = macro_subparsers.add_parser('create', help=macro_create_help,
                                                       description=macro_create_description,

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -262,15 +262,16 @@ def natural_sort(list_to_sort: Iterable[str]) -> List[str]:
     return sorted(list_to_sort, key=natural_keys)
 
 
-def unquote_redirection_tokens(args: List[str]) -> None:
+def unquote_specific_tokens(args: List[str], tokens_to_unquote: List[str]) -> None:
     """
-    Unquote redirection tokens in a list of command-line arguments
-    This is used when redirection tokens have to be passed to another command
+    Unquote a specific tokens in a list of command-line arguments
+    This is used when certain tokens have to be passed to another command
     :param args: the command line args
+    :param tokens_to_unquote: the tokens, which if present in args, to unquote
     """
     for i, arg in enumerate(args):
         unquoted_arg = strip_quotes(arg)
-        if unquoted_arg in constants.REDIRECTION_TOKENS:
+        if unquoted_arg in tokens_to_unquote:
             args[i] = unquoted_arg
 
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1712,11 +1712,6 @@ def test_macro_create_with_alias_name(base_app):
     out, err = run_cmd(base_app, 'macro create {} help'.format(macro))
     assert "Macro cannot have the same name as an alias" in err[0]
 
-def test_macro_create_with_command_name(base_app):
-    macro = "my_macro"
-    out, err = run_cmd(base_app, 'macro create help stuff')
-    assert "Macro cannot have the same name as a command" in err[0]
-
 def test_macro_create_with_args(base_app):
     # Create the macro
     out, err = run_cmd(base_app, 'macro create fake {1} {2}')

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1712,6 +1712,11 @@ def test_macro_create_with_alias_name(base_app):
     out, err = run_cmd(base_app, 'macro create {} help'.format(macro))
     assert "Macro cannot have the same name as an alias" in err[0]
 
+def test_macro_create_with_command_name(base_app):
+    macro = "my_macro"
+    out, err = run_cmd(base_app, 'macro create help stuff')
+    assert "Macro cannot have the same name as a command" in err[0]
+
 def test_macro_create_with_args(base_app):
     # Create the macro
     out, err = run_cmd(base_app, 'macro create fake {1} {2}')

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1830,7 +1830,7 @@ def test_nonexistent_macro(base_app):
     exception = None
 
     try:
-        base_app._run_macro(StatementParser().parse('fake'))
+        base_app._resolve_macro(StatementParser().parse('fake'))
     except KeyError as e:
         exception = e
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1601,15 +1601,15 @@ def test_alias_create(base_app):
     assert out == normalize('alias create fake pyscript')
 
 def test_alias_create_with_quoted_value(base_app):
-    """Demonstrate that quotes in alias value will be preserved (except for redirectors)"""
+    """Demonstrate that quotes in alias value will be preserved (except for redirectors and terminators)"""
 
     # Create the alias
-    out, err = run_cmd(base_app, 'alias create fake help ">" "out file.txt"')
+    out, err = run_cmd(base_app, 'alias create fake help ">" "out file.txt" ";"')
     assert out == normalize("Alias 'fake' created")
 
     # Look up the new alias (Only the redirector should be unquoted)
     out, err = run_cmd(base_app, 'alias list fake')
-    assert out == normalize('alias create fake help > "out file.txt"')
+    assert out == normalize('alias create fake help > "out file.txt" ;')
 
 @pytest.mark.parametrize('alias_name', invalid_command_name)
 def test_alias_create_invalid_name(base_app, alias_name, capsys):
@@ -1692,14 +1692,14 @@ def test_macro_create(base_app):
     assert out == normalize('macro create fake pyscript')
 
 def test_macro_create_with_quoted_value(base_app):
-    """Demonstrate that quotes in macro value will be preserved (except for redirectors)"""
+    """Demonstrate that quotes in macro value will be preserved (except for redirectors and terminators)"""
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake help ">" "out file.txt"')
+    out, err = run_cmd(base_app, 'macro create fake help ">" "out file.txt" ";"')
     assert out == normalize("Macro 'fake' created")
 
     # Look up the new macro (Only the redirector should be unquoted)
     out, err = run_cmd(base_app, 'macro list fake')
-    assert out == normalize('macro create fake help > "out file.txt"')
+    assert out == normalize('macro create fake help > "out file.txt" ;')
 
 @pytest.mark.parametrize('macro_name', invalid_command_name)
 def test_macro_create_invalid_name(base_app, macro_name):


### PR DESCRIPTION
* Fixed issue where aliases and macros could not contain terminator characters in their values
* History now shows what was typed for macros and not the resolved value by default. This is consistent with the behavior of aliases. Use the `expanded` or `verbose` arguments to `history` to see the resolved value for the macro.
* Added `_input_line_to_statement()` which wraps  `_complete_statement()` and resolves macros.
* Refactored alias resolution in parsing code