### PR TITLE
Improved tab completion error feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     * `StdSim.buffer.write()` now flushes when the wrapped stream uses line buffering and the bytes being written
       contain a newline or carriage return. This helps when `pyscript` is echoing the output of a shell command
       since the output will print at the same frequency as when the command is run in a terminal.
+    * Exceptions occurring in tab completion functions are now printed to stderr before returning control back to
+    readline. This makes debugging a lot easier since readline suppresses these exceptions.
 * **Python 3.4 EOL notice**
     * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019
     * This is the last release of `cmd2` which will support Python 3.4

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -667,7 +667,7 @@ class AutoCompleter(object):
 
                 if callable(arg_choices[0]):
                     completer = arg_choices[0]
-                elif isinstance(arg_choices[0], str) and callable(getattr(self._cmd2_app, arg_choices[0])):
+                else:
                     completer = getattr(self._cmd2_app, arg_choices[0])
 
                 # extract the positional and keyword arguments from the tuple
@@ -701,32 +701,17 @@ class AutoCompleter(object):
             # is the argument a string? If so, see if we can find an attribute in the
             # application matching the string.
             if isinstance(args, str):
-                try:
-                    args = getattr(self._cmd2_app, args)
-                except AttributeError:
-                    # Couldn't find anything matching the name
-                    return []
+                args = getattr(self._cmd2_app, args)
 
             # is the provided argument a callable. If so, call it
             if callable(args):
                 try:
-                    try:
-                        args = args(self._cmd2_app)
-                    except TypeError:
-                        args = args()
+                    args = args(self._cmd2_app)
                 except TypeError:
-                    return []
+                    args = args()
 
-            try:
-                iter(args)
-            except TypeError:
-                pass
-            else:
-                # filter out arguments we already used
-                args = [arg for arg in args if arg not in used_values]
-
-                if len(args) > 0:
-                    return args
+            # filter out arguments we already used
+            return [arg for arg in args if arg not in used_values]
 
         return []
 

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -678,19 +678,16 @@ class AutoCompleter(object):
                         list_args = arg_choices[index]
                     elif isinstance(arg_choices[index], dict):
                         kw_args = arg_choices[index]
-                try:
-                    # call the provided function differently depending on the provided positional and keyword arguments
-                    if list_args is not None and kw_args is not None:
-                        return completer(text, line, begidx, endidx, *list_args, **kw_args)
-                    elif list_args is not None:
-                        return completer(text, line, begidx, endidx, *list_args)
-                    elif kw_args is not None:
-                        return completer(text, line, begidx, endidx, **kw_args)
-                    else:
-                        return completer(text, line, begidx, endidx)
-                except TypeError:
-                    # assume this is due to an incorrect function signature, return nothing.
-                    return []
+
+                # call the provided function differently depending on the provided positional and keyword arguments
+                if list_args is not None and kw_args is not None:
+                    return completer(text, line, begidx, endidx, *list_args, **kw_args)
+                elif list_args is not None:
+                    return completer(text, line, begidx, endidx, *list_args)
+                elif kw_args is not None:
+                    return completer(text, line, begidx, endidx, **kw_args)
+                else:
+                    return completer(text, line, begidx, endidx)
             else:
                 return self._cmd2_app.basic_complete(text, line, begidx, endidx,
                                                      self._resolve_choices_for_arg(action, used_values))

--- a/examples/tab_autocomp_dynamic.py
+++ b/examples/tab_autocomp_dynamic.py
@@ -69,7 +69,7 @@ class TabCompleteExample(cmd2.Cmd):
         setattr(director_action, argparse_completer.ACTION_ARG_CHOICES, TabCompleteExample.static_list_directors)
         setattr(actor_action, argparse_completer.ACTION_ARG_CHOICES, 'instance_query_actors')
 
-        # tag the file property with a custom completion function 'delimeter_complete' provided by cmd2.
+        # tag the file property with a custom completion function 'delimiter_complete' provided by cmd2.
         setattr(vid_movie_file_action, argparse_completer.ACTION_ARG_CHOICES,
                 ('delimiter_complete',
                  {'delimiter': '/',

--- a/examples/tab_autocompletion.py
+++ b/examples/tab_autocompletion.py
@@ -255,7 +255,7 @@ class TabCompleteExample(cmd2.Cmd):
     setattr(director_action, argparse_completer.ACTION_ARG_CHOICES, static_list_directors)
     setattr(actor_action, argparse_completer.ACTION_ARG_CHOICES, 'instance_query_actors')
 
-    # tag the file property with a custom completion function 'delimeter_complete' provided by cmd2.
+    # tag the file property with a custom completion function 'delimiter_complete' provided by cmd2.
     setattr(vid_movie_file_action, argparse_completer.ACTION_ARG_CHOICES,
             ('delimiter_complete',
              {'delimiter': '/',

--- a/tests/test_autocompletion.py
+++ b/tests/test_autocompletion.py
@@ -229,7 +229,7 @@ def test_autocomp_subcmd_flag_comp_list_attr(cmd2_app):
     assert first_match is not None and first_match == '"Gareth Edwards'
 
 
-def test_autcomp_pos_consumed(cmd2_app):
+def test_autocomp_pos_consumed(cmd2_app):
     text = ''
     line = 'library movie add SW_EP01 {}'.format(text)
     endidx = len(line)
@@ -239,7 +239,7 @@ def test_autcomp_pos_consumed(cmd2_app):
     assert first_match is None
 
 
-def test_autcomp_pos_after_flag(cmd2_app):
+def test_autocomp_pos_after_flag(cmd2_app):
     text = 'Joh'
     line = 'video movies add -d "George Lucas" -- "Han Solo" PG "Emilia Clarke" "{}'.format(text)
     endidx = len(line)
@@ -250,7 +250,7 @@ def test_autcomp_pos_after_flag(cmd2_app):
            cmd2_app.completion_matches == ['John Boyega" ']
 
 
-def test_autcomp_custom_func_list_arg(cmd2_app):
+def test_autocomp_custom_func_list_arg(cmd2_app):
     text = 'SW_'
     line = 'library show add {}'.format(text)
     endidx = len(line)
@@ -261,7 +261,7 @@ def test_autcomp_custom_func_list_arg(cmd2_app):
            cmd2_app.completion_matches == ['SW_CW', 'SW_REB', 'SW_TCW']
 
 
-def test_autcomp_custom_func_list_and_dict_arg(cmd2_app):
+def test_autocomp_custom_func_list_and_dict_arg(cmd2_app):
     text = ''
     line = 'library show add SW_REB {}'.format(text)
     endidx = len(line)
@@ -270,6 +270,17 @@ def test_autcomp_custom_func_list_and_dict_arg(cmd2_app):
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
     assert first_match is not None and \
            cmd2_app.completion_matches == ['S01E02', 'S01E03', 'S02E01', 'S02E03']
+
+
+def test_autocomp_custom_func_dict_arg(cmd2_app):
+    text = '/home/user/'
+    line = 'video movies load {}'.format(text)
+    endidx = len(line)
+    begidx = endidx - len(text)
+
+    first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
+    assert first_match is not None and \
+           cmd2_app.completion_matches == ['/home/user/another.db', '/home/user/file space.db', '/home/user/file.db']
 
 
 def test_argparse_remainder_flag_completion(cmd2_app):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -77,6 +77,12 @@ class CompletionsExample(cmd2.Cmd):
         num_strs = ['2', '11', '1']
         return self.basic_complete(text, line, begidx, endidx, num_strs)
 
+    def do_test_raise_exception(self, args):
+        pass
+
+    def complete_test_raise_exception(self, text, line, begidx, endidx):
+        raise IndexError("You are out of bounds!!")
+
 
 @pytest.fixture
 def cmd2_app():
@@ -119,6 +125,18 @@ def test_complete_bogus_command(cmd2_app):
 
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
     assert first_match is None
+
+def test_complete_exception(cmd2_app, capsys):
+    text = ''
+    line = 'test_raise_exception {}'.format(text)
+    endidx = len(line)
+    begidx = endidx - len(text)
+
+    first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
+    out, err = capsys.readouterr()
+
+    assert first_match is None
+    assert "IndexError" in err
 
 def test_complete_macro(base_app, request):
     # Create the macro


### PR DESCRIPTION
Fixes #668 
Exceptions occurring in tab completion functions are now printed to stderr before returning control back to readline.

No changes have been made to the argparse completion code yet. We need to figure out the best approach. Do we just remove the try/except statements? Or do we keep them and just call raise?