### PR TITLE
Pipe chaining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   if [[ $TOXENV == py37 ]]; then
-    flake8 . --count --ignore=E252 --max-complexity=31 --max-line-length=127 --show-source --statistics ;
+    flake8 . --count --ignore=E252,W503 --max-complexity=31 --max-line-length=127 --show-source --statistics ;
   fi
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@
      scroll the actual error message off the screen.
     * Exceptions occurring in tab completion functions are now printed to stderr before returning control back to
     readline. This makes debugging a lot easier since readline suppresses these exceptions.
+    * Added capability to chain pipe commands and redirect their output (e.g. !ls -l | grep user | wc -l > out.txt)
 * Potentially breaking changes
     * Replaced `unquote_redirection_tokens()` with `unquote_specific_tokens()`. This was to support the fix
       that allows terminators in alias and macro values.
+    * Changed `Statement.pipe_to` to a string instead of a list 
 * **Python 3.4 EOL notice**
     * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019
     * This is the last release of `cmd2` which will support Python 3.4
@@ -87,7 +89,7 @@
     sorted the ``CompletionItem`` list. Otherwise it will be sorted using ``self.matches_sort_key``.
     * Removed support for bash completion since this feature had slow performance. Also it relied on
     ``AutoCompleter`` which has since developed a dependency on ``cmd2`` methods. 
-    * Removed ability to call commands in ``pyscript`` as if they were functions (e.g ``app.help()``) in favor
+    * Removed ability to call commands in ``pyscript`` as if they were functions (e.g. ``app.help()``) in favor
     of only supporting one ``pyscript`` interface. This simplifies future maintenance.
     * No longer supporting C-style comments. Hash (#) is the only valid comment marker.
     * No longer supporting comments embedded in a command. Only command line input where the first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     the behavior of aliases. Use the `expanded` or `verbose` arguments to `history` to see the resolved value for
     the macro.
 * Enhancements
+    * Added capability to chain pipe commands and redirect their output (e.g. !ls -l | grep user | wc -l > out.txt)
     * `pyscript` limits a command's stdout capture to the same period that redirection does.
       Therefore output from a command's postparsing and finalization hooks isn't saved in the StdSim object.
     * `StdSim.buffer.write()` now flushes when the wrapped stream uses line buffering and the bytes being written
@@ -15,7 +16,6 @@
      scroll the actual error message off the screen.
     * Exceptions occurring in tab completion functions are now printed to stderr before returning control back to
     readline. This makes debugging a lot easier since readline suppresses these exceptions.
-    * Added capability to chain pipe commands and redirect their output (e.g. !ls -l | grep user | wc -l > out.txt)
 * Potentially breaking changes
     * Replaced `unquote_redirection_tokens()` with `unquote_specific_tokens()`. This was to support the fix
       that allows terminators in alias and macro values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
     * History now shows what was typed for macros and not the resolved value by default. This is consistent with
     the behavior of aliases. Use the `expanded` or `verbose` arguments to `history` to see the resolved value for
     the macro.
+    * Fixed parsing issue in case where output redirection appears before a pipe. In that case, the pipe was given
+    precedence even though it appeared later in the command.
+    * Fixed issue where quotes around redirection file paths were being lost in `Statement.expanded_command_line()`
 * Enhancements
     * Added capability to chain pipe commands and redirect their output (e.g. !ls -l | grep user | wc -l > out.txt)
     * `pyscript` limits a command's stdout capture to the same period that redirection does.

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -999,9 +999,7 @@ class ACArgumentParser(argparse.ArgumentParser):
             linum += 1
 
         self.print_usage(sys.stderr)
-        sys.stderr.write(Fore.LIGHTRED_EX + '{}\n'.format(formatted_message) + Fore.RESET)
-
-        sys.exit(1)
+        self.exit(2, Fore.LIGHTRED_EX + '{}\n\n'.format(formatted_message) + Fore.RESET)
 
     def format_help(self) -> str:
         """Copy of format_help() from argparse.ArgumentParser with tweaks to separately display required parameters"""
@@ -1051,7 +1049,7 @@ class ACArgumentParser(argparse.ArgumentParser):
         formatter.add_text(self.epilog)
 
         # determine help from format above
-        return formatter.format_help()
+        return formatter.format_help() + '\n'
 
     def _get_nargs_pattern(self, action) -> str:
         # Override _get_nargs_pattern behavior to use the nargs ranges provided by AutoCompleter

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3331,18 +3331,21 @@ class Cmd(cmd.Cmd):
                                               help='output commands to a script file, implies -s'),
             ACTION_ARG_CHOICES, ('path_complete',))
     setattr(history_action_group.add_argument('-t', '--transcript',
-                                              help='output commands and results to a transcript file, implies -s'),
+                                              help='output commands and results to a transcript file,\n'
+                                                   'implies -s'),
             ACTION_ARG_CHOICES, ('path_complete',))
     history_action_group.add_argument('-c', '--clear', action='store_true', help='clear all history')
 
     history_format_group = history_parser.add_argument_group(title='formatting')
-    history_script_help = 'output commands in script format, i.e. without command numbers'
-    history_format_group.add_argument('-s', '--script', action='store_true', help=history_script_help)
-    history_expand_help = 'output expanded commands instead of entered command'
-    history_format_group.add_argument('-x', '--expanded', action='store_true', help=history_expand_help)
+    history_format_group.add_argument('-s', '--script', action='store_true',
+                                      help='output commands in script format, i.e. without command\n'
+                                           'numbers')
+    history_format_group.add_argument('-x', '--expanded', action='store_true',
+                                      help='output fully parsed commands with any aliases and\n'
+                                           'macros expanded, instead of typed commands')
     history_format_group.add_argument('-v', '--verbose', action='store_true',
-                                      help='display history and include expanded commands if they'
-                                           ' differ from the typed command')
+                                      help='display history and include expanded commands if they\n'
+                                           'differ from the typed command')
 
     history_arg_help = ("empty               all history items\n"
                         "a                   one history item by number\n"

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1521,8 +1521,8 @@ class Cmd(cmd.Cmd):
 
                             # For delimited matches, we check for a space in what appears before the display
                             # matches (common_prefix) as well as in the display matches themselves.
-                            if (' ' in common_prefix) or (display_prefix and
-                                                          any(' ' in match for match in self.display_matches)):
+                            if ' ' in common_prefix or (display_prefix
+                                                        and any(' ' in match for match in self.display_matches)):
                                 add_quote = True
 
                         # If there is a tab completion and any match has a space, then add an opening quote

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2046,8 +2046,8 @@ class Cmd(cmd.Cmd):
                                     start_new_session=start_new_session,
                                     shell=True)
 
-            # Popen was called with shell=True so the user can do stuff like redirect the output of the pipe
-            # process (ex: !ls | grep foo > out.txt). But this makes it difficult to know if the pipe process
+            # Popen was called with shell=True so the user can chain pipe commands and redirect their output
+            # like: !ls -l | grep user | wc -l > out.txt. But this makes it difficult to know if the pipe process
             # started OK, since the shell itself always starts. Therefore, we will wait a short time and check
             # if the pipe process is still running.
             try:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2082,7 +2082,7 @@ class Cmd(cmd.Cmd):
                 if statement.output == constants.REDIRECTION_APPEND:
                     mode = 'a'
                 try:
-                    new_stdout = open(statement.output_to, mode)
+                    new_stdout = open(utils.strip_quotes(statement.output_to), mode)
                     saved_state.redirecting = True
                     sys.stdout = self.stdout = new_stdout
                 except OSError as ex:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1519,18 +1519,19 @@ class Cmd(cmd.Cmd):
                             # Check if any portion of the display matches appears in the tab completion
                             display_prefix = os.path.commonprefix(self.display_matches)
 
-                            # For delimited matches, we check what appears before the display
-                            # matches (common_prefix) as well as the display matches themselves.
-                            if (' ' in common_prefix) or (display_prefix and ' ' in ''.join(self.display_matches)):
+                            # For delimited matches, we check for a space in what appears before the display
+                            # matches (common_prefix) as well as in the display matches themselves.
+                            if (' ' in common_prefix) or (display_prefix and
+                                                          any(' ' in match for match in self.display_matches)):
                                 add_quote = True
 
                         # If there is a tab completion and any match has a space, then add an opening quote
-                        elif common_prefix and ' ' in ''.join(self.completion_matches):
+                        elif common_prefix and any(' ' in match for match in self.completion_matches):
                             add_quote = True
 
                         if add_quote:
                             # Figure out what kind of quote to add and save it as the unclosed_quote
-                            if '"' in ''.join(self.completion_matches):
+                            if any('"' in match for match in self.completion_matches):
                                 unclosed_quote = "'"
                             else:
                                 unclosed_quote = '"'
@@ -1540,7 +1541,7 @@ class Cmd(cmd.Cmd):
                     # Check if we need to remove text from the beginning of tab completions
                     elif text_to_remove:
                         self.completion_matches = \
-                            [m.replace(text_to_remove, '', 1) for m in self.completion_matches]
+                            [match.replace(text_to_remove, '', 1) for match in self.completion_matches]
 
                     # Check if we need to restore a shortcut in the tab completions
                     # so it doesn't get erased from the command line

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Statement parsing classes for cmd2"""
 
-import os
 import re
 import shlex
 from typing import Dict, Iterable, List, Optional, Tuple, Union
@@ -166,7 +165,7 @@ class Statement(str):
     # if output was redirected, the redirection token, i.e. '>>'
     output = attr.ib(default='', validator=attr.validators.instance_of(str))
 
-    # if output was redirected, the destination file
+    # if output was redirected, the destination file token (quotes preserved)
     output_to = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     def __new__(cls, value: object, *pos_args, **kw_args):
@@ -213,7 +212,7 @@ class Statement(str):
         if self.output:
             rtn += ' ' + self.output
             if self.output_to:
-                rtn += ' ' + utils.quote_string_if_needed(self.output_to)
+                rtn += ' ' + self.output_to
 
         return rtn
 
@@ -495,9 +494,11 @@ class StatementParser:
                 output = constants.REDIRECTION_APPEND
                 output_index = append_index
 
+            # Check if we are redirecting to a file
             if len(tokens) > output_index + 1:
                 unquoted_path = utils.strip_quotes(tokens[output_index + 1])
-                output_to = os.path.expanduser(unquoted_path)
+                if unquoted_path:
+                    output_to = utils.expand_user(tokens[output_index + 1])
 
             # remove all the tokens after the output redirect
             tokens = tokens[:output_index]

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -275,25 +275,34 @@ def unquote_specific_tokens(args: List[str], tokens_to_unquote: List[str]) -> No
             args[i] = unquoted_arg
 
 
+def expand_user(token: str) -> str:
+    """
+    Wrap os.expanduser() to support expanding ~ in quoted strings
+    :param token: the string to expand
+    """
+    if token:
+        if is_quoted(token):
+            quote_char = token[0]
+            token = strip_quotes(token)
+        else:
+            quote_char = ''
+
+        token = os.path.expanduser(token)
+
+        # Restore the quotes even if not needed to preserve what the user typed
+        if quote_char:
+            token = quote_char + token + quote_char
+
+    return token
+
+
 def expand_user_in_tokens(tokens: List[str]) -> None:
     """
-    Call os.path.expanduser() on all tokens in an already parsed list of command-line arguments.
-    This also supports expanding user in quoted tokens.
+    Call expand_user() on all tokens in a list of strings
     :param tokens: tokens to expand
     """
     for index, _ in enumerate(tokens):
-        if tokens[index]:
-            # Check if the token is quoted. Since parsing already passed, there isn't
-            # an unclosed quote. So we only need to check the first character.
-            first_char = tokens[index][0]
-            if first_char in constants.QUOTES:
-                tokens[index] = strip_quotes(tokens[index])
-
-            tokens[index] = os.path.expanduser(tokens[index])
-
-            # Restore the quotes even if not needed to preserve what the user typed
-            if first_char in constants.QUOTES:
-                tokens[index] = first_char + tokens[index] + first_char
+        tokens[index] = expand_user(tokens[index])
 
 
 def find_editor() -> str:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -291,7 +291,7 @@ def expand_user_in_tokens(tokens: List[str]) -> None:
 
             tokens[index] = os.path.expanduser(tokens[index])
 
-            # Restore the quotes
+            # Restore the quotes even if not needed to preserve what the user typed
             if first_char in constants.QUOTES:
                 tokens[index] = first_char + tokens[index] + first_char
 

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -275,6 +275,27 @@ def unquote_specific_tokens(args: List[str], tokens_to_unquote: List[str]) -> No
             args[i] = unquoted_arg
 
 
+def expand_user_in_tokens(tokens: List[str]) -> None:
+    """
+    Call os.path.expanduser() on all tokens in an already parsed list of command-line arguments.
+    This also supports expanding user in quoted tokens.
+    :param tokens: tokens to expand
+    """
+    for index, _ in enumerate(tokens):
+        if tokens[index]:
+            # Check if the token is quoted. Since parsing already passed, there isn't
+            # an unclosed quote. So we only need to check the first character.
+            first_char = tokens[index][0]
+            if first_char in constants.QUOTES:
+                tokens[index] = strip_quotes(tokens[index])
+
+            tokens[index] = os.path.expanduser(tokens[index])
+
+            # Restore the quotes
+            if first_char in constants.QUOTES:
+                tokens[index] = first_char + tokens[index] + first_char
+
+
 def find_editor() -> str:
     """Find a reasonable editor to use by default for the system that the cmd2 application is running on."""
     editor = os.environ.get('EDITOR')

--- a/tasks.py
+++ b/tasks.py
@@ -233,5 +233,5 @@ namespace.add_task(pypi_test)
 @invoke.task
 def flake8(context):
     "Run flake8 linter and tool for style guide enforcement"
-    context.run("flake8 --ignore=E252 --max-complexity=31 --max-line-length=127 --show-source --statistics")
+    context.run("flake8 --ignore=E252,W503 --max-complexity=31 --max-line-length=127 --show-source --statistics")
 namespace.add_task(flake8)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,13 +77,17 @@ optional arguments:
   -o, --output-file FILE
                         output commands to a script file, implies -s
   -t, --transcript TRANSCRIPT
-                        output commands and results to a transcript file, implies -s
+                        output commands and results to a transcript file,
+                        implies -s
   -c, --clear           clear all history
 
 formatting:
-  -s, --script          output commands in script format, i.e. without command numbers
-  -x, --expanded        output expanded commands instead of entered command
-  -v, --verbose         display history and include expanded commands if they differ from the typed command
+  -s, --script          output commands in script format, i.e. without command
+                        numbers
+  -x, --expanded        output fully parsed commands with any aliases and
+                        macros expanded, instead of typed commands
+  -v, --verbose         display history and include expanded commands if they
+                        differ from the typed command
 
 """
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -580,7 +580,7 @@ def test_pipe_to_shell_error(base_app):
     # Try to pipe command output to a shell command that doesn't exist in order to produce an error
     out, err = run_cmd(base_app, 'help | foobarbaz.this_does_not_exist')
     assert not out
-    assert "Failed to open pipe because" in err[0]
+    assert "Pipe process exited with code" in err[0]
 
 @pytest.mark.skipif(not clipboard.can_clip,
                     reason="Pyperclip could not find a copy/paste mechanism for your system")

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -576,6 +576,21 @@ def test_pipe_to_shell(base_app):
     out, err = run_cmd(base_app, command)
     assert out and not err
 
+def test_pipe_to_shell_and_redirect(base_app):
+    filename = 'out.txt'
+    if sys.platform == "win32":
+        # Windows
+        command = 'help | sort > {}'.format(filename)
+    else:
+        # Mac and Linux
+        # Get help on help and pipe it's output to the input of the word count shell command
+        command = 'help help | wc > {}'.format(filename)
+
+    out, err = run_cmd(base_app, command)
+    assert not out and not err
+    assert os.path.exists(filename)
+    os.remove(filename)
+
 def test_pipe_to_shell_error(base_app):
     # Try to pipe command output to a shell command that doesn't exist in order to produce an error
     out, err = run_cmd(base_app, 'help | foobarbaz.this_does_not_exist')

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1713,7 +1713,6 @@ def test_macro_create_with_alias_name(base_app):
     assert "Macro cannot have the same name as an alias" in err[0]
 
 def test_macro_create_with_command_name(base_app):
-    macro = "my_macro"
     out, err = run_cmd(base_app, 'macro create help stuff')
     assert "Macro cannot have the same name as a command" in err[0]
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -394,8 +394,36 @@ def test_redirect_to_quoted_string(parser):
     assert statement.output == '>'
     assert statement.output_to == '"file.txt"'
 
+def test_redirect_to_single_quoted_string(parser):
+    line = "help alias > 'file.txt'"
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
+    assert statement.output_to == "'file.txt'"
+
 def test_redirect_to_empty_quoted_string(parser):
     line = 'help alias > ""'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
+    assert statement.output_to == ''
+
+def test_redirect_to_empty_single_quoted_string(parser):
+    line = "help alias > ''"
     statement = parser.parse(line)
     assert statement.command == 'help'
     assert statement == 'alias'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -296,7 +296,7 @@ def test_parse_redirect_append(parser):
     assert statement.output == '>>'
     assert statement.output_to == '/tmp/afile.txt'
 
-def test_parse_pipe_and_redirect(parser):
+def test_parse_pipe_then_redirect(parser):
     line = 'output into;sufx | pipethrume plz > afile.txt'
     statement = parser.parse(line)
     assert statement.command == 'output'
@@ -308,6 +308,104 @@ def test_parse_pipe_and_redirect(parser):
     assert statement.suffix == 'sufx'
     assert statement.pipe_to == 'pipethrume plz > afile.txt'
     assert statement.output == ''
+    assert statement.output_to == ''
+
+def test_parse_multiple_pipes(parser):
+    line = 'output into;sufx | pipethrume plz | grep blah'
+    statement = parser.parse(line)
+    assert statement.command == 'output'
+    assert statement == 'into'
+    assert statement.args == statement
+    assert statement.argv == ['output', 'into']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ';'
+    assert statement.suffix == 'sufx'
+    assert statement.pipe_to == 'pipethrume plz | grep blah'
+    assert statement.output == ''
+    assert statement.output_to == ''
+
+def test_redirect_then_pipe(parser):
+    line = 'help alias > file.txt | grep blah'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
+    assert statement.output_to == 'file.txt'
+
+def test_append_then_pipe(parser):
+    line = 'help alias >> file.txt | grep blah'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>>'
+    assert statement.output_to == 'file.txt'
+
+def test_append_then_redirect(parser):
+    line = 'help alias >> file.txt > file2.txt'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>>'
+    assert statement.output_to == 'file.txt'
+
+def test_redirect_then_append(parser):
+    line = 'help alias > file.txt >> file2.txt'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
+    assert statement.output_to == 'file.txt'
+
+def test_redirect_to_quoted_string(parser):
+    line = 'help alias > "file.txt"'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
+    assert statement.output_to == '"file.txt"'
+
+def test_redirect_to_empty_quoted_string(parser):
+    line = 'help alias > ""'
+    statement = parser.parse(line)
+    assert statement.command == 'help'
+    assert statement == 'alias'
+    assert statement.args == statement
+    assert statement.argv == ['help', 'alias']
+    assert statement.arg_list == statement.argv[1:]
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == '>'
     assert statement.output_to == ''
 
 def test_parse_output_to_paste_buffer(parser):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -11,7 +11,6 @@ import pytest
 
 import cmd2
 from cmd2 import constants, utils
-from cmd2.constants import MULTILINE_TERMINATOR
 from cmd2.parsing import StatementParser, shlex_split
 
 @pytest.fixture
@@ -46,7 +45,7 @@ def test_parse_empty_string(parser):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
     assert statement.command_and_args == line
@@ -63,7 +62,7 @@ def test_parse_empty_string_default(default_parser):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
     assert statement.command_and_args == line
@@ -130,7 +129,7 @@ def test_parse_single_word(parser, line):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
     assert statement.command_and_args == line
@@ -224,8 +223,8 @@ def test_parse_simple_pipe(parser, line):
     assert statement.args == statement
     assert statement.argv == ['simple']
     assert not statement.arg_list
-    assert statement.pipe_to == ['piped']
-    assert statement.expanded_command_line == statement.command + ' | ' + ' '.join(statement.pipe_to)
+    assert statement.pipe_to == 'piped'
+    assert statement.expanded_command_line == statement.command + ' | ' + statement.pipe_to
 
 def test_parse_double_pipe_is_not_a_pipe(parser):
     line = 'double-pipe || is not a pipe'
@@ -247,7 +246,7 @@ def test_parse_complex_pipe(parser):
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == '&'
     assert statement.suffix == 'sufx'
-    assert statement.pipe_to == ['piped']
+    assert statement.pipe_to == 'piped'
 
 @pytest.mark.parametrize('line,output', [
     ('help > out.txt', '>'),
@@ -307,7 +306,7 @@ def test_parse_pipe_and_redirect(parser):
     assert statement.arg_list == statement.argv[1:]
     assert statement.terminator == ';'
     assert statement.suffix == 'sufx'
-    assert statement.pipe_to == ['pipethrume', 'plz', '>', 'afile.txt']
+    assert statement.pipe_to == 'pipethrume plz > afile.txt'
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -516,7 +515,7 @@ def test_parse_alias_pipe(parser, line):
     assert statement.command == 'help'
     assert statement == ''
     assert statement.args == statement
-    assert statement.pipe_to == ['less']
+    assert statement.pipe_to == 'less'
 
 @pytest.mark.parametrize('line', [
     'helpalias;',
@@ -545,7 +544,7 @@ def test_parse_command_only_command_and_args(parser):
     assert statement.raw == line
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -561,7 +560,7 @@ def test_parse_command_only_strips_line(parser):
     assert statement.raw == line
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -577,7 +576,7 @@ def test_parse_command_only_expands_alias(parser):
     assert statement.raw == line
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -594,7 +593,7 @@ def test_parse_command_only_expands_shortcuts(parser):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -611,7 +610,7 @@ def test_parse_command_only_quoted_args(parser):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -635,7 +634,7 @@ def test_parse_command_only_specialchars(parser, line, args):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -664,7 +663,7 @@ def test_parse_command_only_empty(parser, line):
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert statement.pipe_to == []
+    assert statement.pipe_to == ''
     assert statement.output == ''
     assert statement.output_to == ''
 
@@ -692,7 +691,7 @@ def test_statement_initialization():
     assert statement.multiline_command == ''
     assert statement.terminator == ''
     assert statement.suffix == ''
-    assert isinstance(statement.pipe_to, list)
+    assert isinstance(statement.pipe_to, str)
     assert not statement.pipe_to
     assert statement.output == ''
     assert statement.output_to == ''


### PR DESCRIPTION
- Added capability to redirect pipe commands and chain them together. This involved changing `Statement.pipe_to` from a list to a string.
- Fixed parsing issue in case where output redirection (e.g. > file) appears before a pipe. In that case, the pipe was given precedence even though it appeared later in the command.
- Preserving originally typed quotes of `Statement.output_to` for use in `Statement.post_command()`