### PR TITLE
Appveyor fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,10 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py35"
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py36"
+#    - PYTHON: "C:\\Python36-x64"
+#      PYTHON_VERSION: "3.6.x"
+#      PYTHON_ARCH: "64"
+#      TOXENV: "py36"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,4 +22,4 @@ install:
 - "%PYTHON%/Scripts/pip install -U --user setuptools tox wheel"
 
 test_script:
-- "%PYTHON%/python -m tox -e %TOX_ENV%"
+- "%PYTHON%/python -m tox -e %TOXENV%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,9 @@ environment:
   PYTHONUNBUFFERED: 1
   MINICONDA: C:\\Miniconda3-x64
   matrix:
-  - PYTHON: "C:\\Python35"
-    TOX_ENV: "py35"
+# Disable Python 3.5 testing on AppVeyor for now until we fix issue with mock module install for python < 3.6
+#  - PYTHON: "C:\\Python35"
+#    TOX_ENV: "py35"
 
   - PYTHON: "C:\\Python36"
     TOX_ENV: "py36"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,25 @@
 build: off
 
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py35"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py36"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py37"
+
 install:
   - python -m pip install -U pip
   - python -m pip install -U wheel setuptools tox
 
 test_script:
-  - python -m tox -e py35,py36,py37
+  - python -m tox -e %TOX_ENV%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,4 +22,4 @@ install:
   - python -m pip install -U wheel setuptools tox
 
 test_script:
-  - python -m tox -e %TOX_ENV%
+  - python -m tox -e %TOXENV%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ environment:
       TOXENV: "py37"
 
 install:
-  - python3 -m pip install -U pip
-  - python3 -m pip install -U wheel setuptools tox
+  - %PYTHON% -m pip install -U pip
+  - %PYTHON% -m pip install -U wheel setuptools tox
 
 test_script:
-  - python3 -m tox -e %TOXENV%
+  - %PYTHON% -m tox -e %TOXENV%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
-install:
-  - python -m pip install tox
-
 build: off
+
+install:
+  - python -m pip install -U pip
+  - python -m pip install -U wheel setuptools tox
 
 test_script:
   - python -m tox -e py35,py36,py37

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ environment:
       TOXENV: "py37"
 
 install:
-  - %PYTHON% -m pip install -U pip
-  - %PYTHON% -m pip install -U wheel setuptools tox
+- "%PYTHON%/Scripts/pip install -U --user pip"
+- "%PYTHON%/Scripts/pip install -U --user setuptools tox wheel"
 
 test_script:
-  - %PYTHON% -m tox -e %TOXENV%
+- "%PYTHON%/python -m tox -e %TOX_ENV%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,25 +1,26 @@
 build: off
 
 environment:
+  PYTHONUNBUFFERED: 1
+  MINICONDA: C:\\Miniconda3-x64
   matrix:
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py35"
+  - PYTHON: "C:\\Python35"
+    TOX_ENV: "py35"
 
-#    - PYTHON: "C:\\Python36-x64"
-#      PYTHON_VERSION: "3.6.x"
-#      PYTHON_ARCH: "64"
-#      TOXENV: "py36"
+  - PYTHON: "C:\\Python36"
+    TOX_ENV: "py36"
 
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py37"
+  - PYTHON: "C:\\Python37"
+    TOX_ENV: "py37"
+
+init:
+- "%PYTHON%/python -V"
+- mkdir C:\Users\appveyor\.conda
+- call %MINICONDA%\Scripts\activate.bat
 
 install:
 - "%PYTHON%/Scripts/pip install -U --user pip"
 - "%PYTHON%/Scripts/pip install -U --user setuptools tox wheel"
 
 test_script:
-- "%PYTHON%/python -m tox -e %TOXENV%"
+- "%PYTHON%/python -m tox -e %TOX_ENV%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ environment:
       TOXENV: "py37"
 
 install:
-  - python -m pip install -U pip
-  - python -m pip install -U wheel setuptools tox
+  - python3 -m pip install -U pip
+  - python3 -m pip install -U wheel setuptools tox
 
 test_script:
-  - python -m tox -e %TOXENV%
+  - python3 -m tox -e %TOXENV%


### PR DESCRIPTION
Switched to a Miniconda matrix-based build on AppVeyor and temporarily disabled Python 3.5 to get around some issues.

Fixes #678 