### PR TITLE
Persistent history for #669

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ dmypy.json
 dmypy.sock
 
 # cmd2 history file used in hello_cmd2.py
-cmd2_history.txt
+cmd2_history.dat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,7 @@
     * Changed `Statement.pipe_to` to a string instead of a list
     * `preserve_quotes` is now a keyword-only argument in the argparse decorators
     * Refactored so that `cmd2.Cmd.cmdloop()` returns the `exit_code` instead of a call to `sys.exit()`
-        * It is now applicaiton developer's responsibility to treat the return value from `cmdloop()` accordingly
-      , and is in a binary format,
-      not a text format.
+      It is now application developer's responsibility to treat the return value from `cmdloop()` accordingly
     * Only valid commands are persistent in history between invocations of `cmd2` based apps. Previously
       all user input was persistent in history. If readline is installed, the history available with the up and
       down arrow keys (readline history) may not match that shown in the `history` command, because `history`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,25 @@
     * Added support for custom Namespaces in the argparse decorators. See description of `ns_provider` argument
     for more information.
     * Transcript testing now sets the `exit_code` returned from `cmdloop` based on Success/Failure
-* Potentially breaking changes
+    * The history of entered commands previously was saved using the readline persistence mechanism,
+      and only persisted if you had readline installed. Now history is persisted independent of readline; user
+      input from previous invocations of `cmd2` based apps now shows in the `history` command.
+
+* Breaking changes
     * Replaced `unquote_redirection_tokens()` with `unquote_specific_tokens()`. This was to support the fix
       that allows terminators in alias and macro values.
     * Changed `Statement.pipe_to` to a string instead of a list
     * `preserve_quotes` is now a keyword-only argument in the argparse decorators
     * Refactored so that `cmd2.Cmd.cmdloop()` returns the `exit_code` instead of a call to `sys.exit()`
         * It is now applicaiton developer's responsibility to treat the return value from `cmdloop()` accordingly
+      , and is in a binary format,
+      not a text format.
+    * Only valid commands are persistent in history between invocations of `cmd2` based apps. Previously
+      all user input was persistent in history. If readline is installed, the history available with the up and
+      down arrow keys (readline history) may not match that shown in the `history` command, because `history`
+      only tracks valid input, while readline history captures all input.
+    * History is now persisted in a binary format, not plain text format. Previous history files are destroyed
+      on first launch of a `cmd2` based app of version 0.9.13 or higher.
 * **Python 3.4 EOL notice**
     * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019
     * This is the last release of `cmd2` which will support Python 3.4
@@ -38,7 +50,7 @@
 * Bug Fixes
     * Fixed a bug in how redirection and piping worked inside ``py`` or ``pyscript`` commands
     * Fixed bug in `async_alert` where it didn't account for prompts that contained newline characters
-    * Fixed path completion case when CWD is just a slash. Relative path matches were incorrectly prepended with a slash. 
+    * Fixed path completion case when CWD is just a slash. Relative path matches were incorrectly prepended with a slash.
 * Enhancements
     * Added ability to include command name placeholders in the message printed when trying to run a disabled command.
         * See docstring for ``disable_command()`` or ``disable_category()`` for more details.
@@ -60,7 +72,7 @@
         * ``_report_disabled_command_usage()`` - in all cases since this is called when a disabled command is run
     * Removed *** from beginning of error messages printed by `do_help()` and `default()`
     * Significantly refactored ``cmd.Cmd`` class so that all class attributes got converted to instance attributes, also:
-        * Added ``allow_redirection``, ``terminators``, ``multiline_commands``, and ``shortcuts`` as optional arguments 
+        * Added ``allow_redirection``, ``terminators``, ``multiline_commands``, and ``shortcuts`` as optional arguments
         to ``cmd.Cmd.__init__()`
         * A few instance attributes were moved inside ``StatementParser`` and properties were created for accessing them
     * ``self.pipe_proc`` is now called ``self.cur_pipe_proc_reader`` and is a ``ProcReader`` class.
@@ -98,7 +110,7 @@
     ``cmd2`` convention of setting ``self.matches_sorted`` to True before returning the results if you have already
     sorted the ``CompletionItem`` list. Otherwise it will be sorted using ``self.matches_sort_key``.
     * Removed support for bash completion since this feature had slow performance. Also it relied on
-    ``AutoCompleter`` which has since developed a dependency on ``cmd2`` methods. 
+    ``AutoCompleter`` which has since developed a dependency on ``cmd2`` methods.
     * Removed ability to call commands in ``pyscript`` as if they were functions (e.g. ``app.help()``) in favor
     of only supporting one ``pyscript`` interface. This simplifies future maintenance.
     * No longer supporting C-style comments. Hash (#) is the only valid comment marker.
@@ -118,7 +130,7 @@
     * Fixed bug where the ``set`` command was not tab completing from the current ``settable`` dictionary.
 * Enhancements
     * Changed edit command to use do_shell() instead of calling os.system()
-    
+
 ## 0.9.8 (February 06, 2019)
 * Bug Fixes
     * Fixed issue with echoing strings in StdSim. Because they were being sent to a binary buffer, line buffering
@@ -139,9 +151,9 @@
 * Deletions (potentially breaking changes)
     * Deleted ``Cmd.colorize()`` and ``Cmd._colorcodes`` which were deprecated in 0.9.5
     * Replaced ``dir_exe_only`` and  ``dir_only`` flags in ``path_complete`` with optional ``path_filter`` function
-    that is used to filter paths out of completion results. 
+    that is used to filter paths out of completion results.
     * ``perror()`` no longer prepends "ERROR: " to the error message being printed
-    
+
 ## 0.9.6 (October 13, 2018)
 * Bug Fixes
     * Fixed bug introduced in 0.9.5 caused by backing up and restoring `self.prompt` in `pseudo_raw_input`.
@@ -167,8 +179,8 @@
     the argparse object. Also, single-character tokens that happen to be a
     prefix char are not treated as flags by argparse and AutoCompleter now
     matches that behavior.
-    * Fixed bug where AutoCompleter was not distinguishing between a negative number and a flag 
-    * Fixed bug where AutoCompleter did not handle -- the same way argparse does (all args after -- are non-options)  
+    * Fixed bug where AutoCompleter was not distinguishing between a negative number and a flag
+    * Fixed bug where AutoCompleter did not handle -- the same way argparse does (all args after -- are non-options)
 * Enhancements
     * Added ``exit_code`` attribute of ``cmd2.Cmd`` class
         * Enables applications to return a non-zero exit code when exiting from ``cmdloop``
@@ -180,10 +192,10 @@
         * These allow you to provide feedback to the user in an asychronous fashion, meaning alerts can
         display when the user is still entering text at the prompt. See [async_printing.py](https://github.com/python-cmd2/cmd2/blob/master/examples/async_printing.py)
         for an example.
-    * Cross-platform colored output support 
+    * Cross-platform colored output support
         * ``colorama`` gets initialized properly in ``Cmd.__init()``
         * The ``Cmd.colors`` setting is no longer platform dependent and now has three values:
-            * Terminal (default) - output methods do not strip any ANSI escape sequences when output is a terminal, but 
+            * Terminal (default) - output methods do not strip any ANSI escape sequences when output is a terminal, but
             if the output is a pipe or a file the escape sequences are stripped
             * Always - output methods **never** strip ANSI escape sequences, regardless of the output destination
             * Never - output methods strip all ANSI escape sequences
@@ -193,18 +205,18 @@
 * Deprecations
     * Deprecated the built-in ``cmd2`` support for colors including ``Cmd.colorize()`` and ``Cmd._colorcodes``
 * Deletions (potentially breaking changes)
-    * The ``preparse``, ``postparsing_precmd``, and ``postparsing_postcmd`` methods *deprecated* in the previous release 
+    * The ``preparse``, ``postparsing_precmd``, and ``postparsing_postcmd`` methods *deprecated* in the previous release
     have been deleted
         * The new application lifecycle hook system allows for registration of callbacks to be called at various points
         in the lifecycle and is more powerful and flexible than the previous system
     * ``alias`` is now a command with sub-commands to create, list, and delete aliases. Therefore its syntax
       has changed. All current alias commands in startup scripts or transcripts will break with this release.
     * `unalias` was deleted since ``alias delete`` replaced it
-    
+
 ## 0.9.4 (August 21, 2018)
 * Bug Fixes
     * Fixed bug where ``preparse`` was not getting called
-    * Fixed bug in parsing of multiline commands where matching quote is on another line 
+    * Fixed bug in parsing of multiline commands where matching quote is on another line
 * Enhancements
     * Improved implementation of lifecycle hooks to support a plugin
       framework, see ``docs/hooks.rst`` for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
       only tracks valid input, while readline history captures all input.
     * History is now persisted in a binary format, not plain text format. Previous history files are destroyed
       on first launch of a `cmd2` based app of version 0.9.13 or higher.
+    * HistoryItem class is no longer a subclass of `str`. If you are directly accessing the `.history` attribute
+      of a `cmd2` based app, you will need to update your code to use `.history.get(1).statement.raw` instead.
 * **Python 3.4 EOL notice**
     * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019
     * This is the last release of `cmd2` which will support Python 3.4

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3409,9 +3409,9 @@ class Cmd(cmd.Cmd):
                             traceback_war=False)
             else:
                 for runme in history:
-                    self.pfeedback(runme.statement.raw)
+                    self.pfeedback(runme.raw)
                     if runme:
-                        self.onecmd_plus_hooks(runme.statement.raw)
+                        self.onecmd_plus_hooks(runme.raw)
         elif args.edit:
             import tempfile
             fd, fname = tempfile.mkstemp(suffix='.txt', text=True)
@@ -3420,7 +3420,7 @@ class Cmd(cmd.Cmd):
                     if command.statement.multiline_command:
                         fobj.write('{}\n'.format(command.expanded.rstrip()))
                     else:
-                        fobj.write('{}\n'.format(command))
+                        fobj.write('{}\n'.format(command.raw))
             try:
                 self.do_edit(fname)
                 self.do_load(fname)
@@ -3433,9 +3433,9 @@ class Cmd(cmd.Cmd):
                 with open(os.path.expanduser(args.output_file), 'w') as fobj:
                     for item in history:
                         if item.statement.multiline_command:
-                            fobj.write('{}\n'.format(item.statement.expanded_command_line.rstrip()))
+                            fobj.write('{}\n'.format(item.expanded.rstrip()))
                         else:
-                            fobj.write('{}\n'.format(item.statement.raw))
+                            fobj.write('{}\n'.format(item.raw))
                 plural = 's' if len(history) > 1 else ''
                 self.pfeedback('{} command{} saved to {}'.format(len(history), plural, args.output_file))
             except Exception as e:
@@ -3492,9 +3492,9 @@ class Cmd(cmd.Cmd):
             for item in history:
                 # readline only adds a single entry for multiple sequential identical commands
                 # so we emulate that behavior here
-                if item.statement.raw != last:
-                    readline.add_history(item.statement.raw)
-                    last = item.statement.raw
+                if item.raw != last:
+                    readline.add_history(item.raw)
+                    last = item.raw
 
         # register a function to write history at save
         # if the history file is in plain text format from 0.9.12 or lower
@@ -3549,7 +3549,7 @@ class Cmd(cmd.Cmd):
                 first = True
                 command = ''
                 if isinstance(history_item, HistoryItem):
-                    history_item = history_item.statement.raw
+                    history_item = history_item.raw
                 for line in history_item.splitlines():
                     if first:
                         command += '{}{}\n'.format(self.prompt, line)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3469,15 +3469,18 @@ class Cmd(cmd.Cmd):
 
         # first we try and unpickle the history file
         history = History()
+        # on Windows, trying to open a directory throws a permission
+        # error, not a `IsADirectoryError`. So we'll check it ourselves.
+        if os.path.isdir(hist_file):
+            msg = "persistent history file '{}' is a directory"
+            self.perror(msg.format(hist_file))
+            return
+
         try:
             with open(hist_file, 'rb') as fobj:
                 history = pickle.load(fobj)
         except (FileNotFoundError, KeyError, EOFError):
             pass
-        except IsADirectoryError:
-            msg = "persistent history file '{}' is a directory"
-            self.perror(msg.format(hist_file))
-            return
         except OSError as ex:
             msg = "can not read persistent history file '{}': {}"
             self.perror(msg.format(hist_file, ex), traceback_war=False)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3479,7 +3479,8 @@ class Cmd(cmd.Cmd):
         try:
             with open(hist_file, 'rb') as fobj:
                 history = pickle.load(fobj)
-        except (FileNotFoundError, KeyError, EOFError):
+        except (AttributeError, EOFError, FileNotFoundError, ImportError, IndexError, KeyError, pickle.UnpicklingError):
+            # If any non-operating system error occurs when attempting to unpickle, just use an empty history
             pass
         except OSError as ex:
             msg = "can not read persistent history file '{}': {}"

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -34,6 +34,7 @@ import cmd
 import glob
 import inspect
 import os
+import pathlib
 import pickle
 import re
 import sys
@@ -3465,29 +3466,29 @@ class Cmd(cmd.Cmd):
             self.persistent_history_file = hist_file
             return
 
-        hist_file = os.path.expanduser(hist_file)
+        histpath = pathlib.Path(hist_file).expanduser().resolve()
 
         # first we try and unpickle the history file
         history = History()
         # on Windows, trying to open a directory throws a permission
         # error, not a `IsADirectoryError`. So we'll check it ourselves.
-        if os.path.isdir(hist_file):
+        if histpath.is_dir():
             msg = "persistent history file '{}' is a directory"
-            self.perror(msg.format(hist_file))
+            self.perror(msg.format(histpath))
             return
 
         try:
-            with open(hist_file, 'rb') as fobj:
+            with open(str(histpath), 'rb') as fobj:
                 history = pickle.load(fobj)
         except (FileNotFoundError, KeyError, EOFError):
             pass
         except OSError as ex:
             msg = "can not read persistent history file '{}': {}"
-            self.perror(msg.format(hist_file, ex), traceback_war=False)
+            self.perror(msg.format(histpath, ex), traceback_war=False)
             return
 
         self.history = history
-        self.persistent_history_file = hist_file
+        self.persistent_history_file = str(histpath)
 
         # populate readline history
         if rl_type != RlType.NONE:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -468,7 +468,7 @@ class Cmd(cmd.Cmd):
 
         # If a startup script is provided, then add it in the queue to load
         if startup_script is not None:
-            startup_script = os.path.expanduser(startup_script)
+            startup_script = os.path.abspath(os.path.expanduser(startup_script))
             if os.path.exists(startup_script) and os.path.getsize(startup_script) > 0:
                 self.cmdqueue.append("load '{}'".format(startup_script))
 
@@ -3371,10 +3371,11 @@ class Cmd(cmd.Cmd):
             # Clear command and readline history
             self.history.clear()
 
+            if self.persistent_history_file:
+                os.remove(self.persistent_history_file)
+
             if rl_type != RlType.NONE:
                 readline.clear_history()
-                if self.persistent_history_file:
-                    os.remove(self.persistent_history_file)
             return
 
         # If an argument was supplied, then retrieve partial contents of the history
@@ -3468,7 +3469,7 @@ class Cmd(cmd.Cmd):
             self.persistent_history_file = hist_file
             return
 
-        hist_file = os.path.expanduser(hist_file)
+        hist_file = os.path.abspath(os.path.expanduser(hist_file))
 
         # first we try and unpickle the history file
         history = History()
@@ -3690,7 +3691,7 @@ class Cmd(cmd.Cmd):
             return
 
         if args.transcript:
-            self._generate_transcript(script_commands, os.path.expanduser(args.transcript))
+            self._generate_transcript(script_commands, args.transcript)
             return
 
         self.cmdqueue = script_commands + ['eos'] + self.cmdqueue

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3338,7 +3338,8 @@ class Cmd(cmd.Cmd):
                                       help='display history and include expanded commands if they\n'
                                            'differ from the typed command')
     history_format_group.add_argument('-a', '--all', action='store_true',
-                                      help='display all commands, including ones persisted from previous sessions')
+                                      help='display all commands, including ones persisted from\n'
+                                           'previous sessions')
 
     history_arg_help = ("empty               all history items\n"
                         "a                   one history item by number\n"

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2389,8 +2389,8 @@ class Cmd(cmd.Cmd):
                            "  If you want to use redirection, pipes, or terminators like ';' in the value\n"
                            "  of the alias, then quote them.\n"
                            "\n"
-                           "  Since aliases are resolved during parsing, tab completion will function as it\n"
-                           "  would for the actual command the alias resolves to.\n"
+                           "  Since aliases are resolved during parsing, tab completion will function as\n"
+                           "  it would for the actual command the alias resolves to.\n"
                            "\n"
                            "Examples:\n"
                            "  alias create ls !ls -lF\n"
@@ -2420,8 +2420,8 @@ class Cmd(cmd.Cmd):
 
     # alias -> list
     alias_list_help = "list aliases"
-    alias_list_description = ("List specified aliases in a reusable form that can be saved to a startup script\n"
-                              "to preserve aliases across sessions\n"
+    alias_list_description = ("List specified aliases in a reusable form that can be saved to a startup\n"
+                              "script to preserve aliases across sessions\n"
                               "\n"
                               "Without arguments, all aliases will be listed.")
 
@@ -2572,17 +2572,17 @@ class Cmd(cmd.Cmd):
                            "\n"
                            "The following creates a macro called my_macro that expects two arguments:\n"
                            "\n"
-                           "  macro create my_macro make_dinner -meat {1} -veggie {2}\n"
+                           "  macro create my_macro make_dinner --meat {1} --veggie {2}\n"
                            "\n"
-                           "When the macro is called, the provided arguments are resolved and the assembled\n"
-                           "command is run. For example:\n"
+                           "When the macro is called, the provided arguments are resolved and the\n"
+                           "assembled command is run. For example:\n"
                            "\n"
-                           "  my_macro beef broccoli ---> make_dinner -meat beef -veggie broccoli\n"
+                           "  my_macro beef broccoli ---> make_dinner --meat beef --veggie broccoli\n"
                            "\n"
                            "Notes:\n"
                            "  To use the literal string {1} in your command, escape it this way: {{1}}.\n"
                            "\n"
-                           "  Extra arguments passed when calling a macro are tacked onto resolved command.\n"
+                           "  Extra arguments passed to a macro are appended to resolved command.\n"
                            "\n"
                            "  An argument number can be repeated in a macro. In the following example the\n"
                            "  first argument will populate both {1} instances.\n"
@@ -3068,8 +3068,8 @@ class Cmd(cmd.Cmd):
                       "has limited ability to parse Python statements into tokens. In particular,\n"
                       "there may be problems with whitespace and quotes depending on their placement.\n"
                       "\n"
-                      "If you see strange parsing behavior, it's best to just open the Python shell by\n"
-                      "providing no arguments to py and run more complex statements there.")
+                      "If you see strange parsing behavior, it's best to just open the Python shell\n"
+                      "by providing no arguments to py and run more complex statements there.")
 
     py_parser = ACArgumentParser(description=py_description)
     py_parser.add_argument('command', help="command to run", nargs='?')

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -34,7 +34,6 @@ import cmd
 import glob
 import inspect
 import os
-import pathlib
 import pickle
 import re
 import sys
@@ -3466,29 +3465,29 @@ class Cmd(cmd.Cmd):
             self.persistent_history_file = hist_file
             return
 
-        histpath = pathlib.Path(hist_file).expanduser().resolve()
+        hist_file = os.path.expanduser(hist_file)
 
         # first we try and unpickle the history file
         history = History()
         # on Windows, trying to open a directory throws a permission
         # error, not a `IsADirectoryError`. So we'll check it ourselves.
-        if histpath.is_dir():
+        if os.path.isdir(hist_file):
             msg = "persistent history file '{}' is a directory"
-            self.perror(msg.format(histpath))
+            self.perror(msg.format(hist_file))
             return
 
         try:
-            with open(str(histpath), 'rb') as fobj:
+            with open(hist_file, 'rb') as fobj:
                 history = pickle.load(fobj)
         except (FileNotFoundError, KeyError, EOFError):
             pass
         except OSError as ex:
             msg = "can not read persistent history file '{}': {}"
-            self.perror(msg.format(histpath, ex), traceback_war=False)
+            self.perror(msg.format(hist_file, ex), traceback_war=False)
             return
 
         self.history = history
-        self.persistent_history_file = str(histpath)
+        self.persistent_history_file = hist_file
 
         # populate readline history
         if rl_type != RlType.NONE:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3410,9 +3410,9 @@ class Cmd(cmd.Cmd):
                             traceback_war=False)
             else:
                 for runme in history:
-                    self.pfeedback(runme)
+                    self.pfeedback(runme.statement.raw)
                     if runme:
-                        self.onecmd_plus_hooks(runme)
+                        self.onecmd_plus_hooks(runme.statement.raw)
         elif args.edit:
             import tempfile
             fd, fname = tempfile.mkstemp(suffix='.txt', text=True)
@@ -3432,11 +3432,11 @@ class Cmd(cmd.Cmd):
         elif args.output_file:
             try:
                 with open(os.path.expanduser(args.output_file), 'w') as fobj:
-                    for command in history:
-                        if command.statement.multiline_command:
-                            fobj.write('{}\n'.format(command.expanded.rstrip()))
+                    for item in history:
+                        if item.statement.multiline_command:
+                            fobj.write('{}\n'.format(item.statement.expanded_command_line.rstrip()))
                         else:
-                            fobj.write('{}\n'.format(command))
+                            fobj.write('{}\n'.format(item.statement.raw))
                 plural = 's' if len(history) > 1 else ''
                 self.pfeedback('{} command{} saved to {}'.format(len(history), plural, args.output_file))
             except Exception as e:
@@ -3547,6 +3547,8 @@ class Cmd(cmd.Cmd):
                 # the command from the output
                 first = True
                 command = ''
+                if isinstance(history_item, HistoryItem):
+                    history_item = history_item.statement.raw
                 for line in history_item.splitlines():
                     if first:
                         command += '{}{}\n'.format(self.prompt, line)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3503,9 +3503,9 @@ class Cmd(cmd.Cmd):
         # if the history file is in plain text format from 0.9.12 or lower
         # this will fail, and the history in the plain text file will be lost
         import atexit
-        atexit.register(self._persist_history_on_exit)
+        atexit.register(self._persist_history)
 
-    def _persist_history_on_exit(self):
+    def _persist_history(self):
         """write history out to the history file"""
         if not self.persistent_history_file:
             return

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -222,7 +222,7 @@ class History(list):
         """Find history items which contain a given string
 
         :param search: the string to search for
-        :param include_persisted: (optional) if True, then search full history including from persisted history
+        :param include_persisted: (optional) if True, then search full history including persisted history
         :return: a list of history items, or an empty list if the string was not found
         """
         def isin(history_item):
@@ -239,7 +239,7 @@ class History(list):
         """Find history items which match a given regular expression
 
         :param regex: the regular expression to search for.
-        :param include_persisted: (optional) if True, then search full history including from persisted history
+        :param include_persisted: (optional) if True, then search full history including persisted history
         :return: a list of history items, or an empty list if the string was not found
         """
         regex = regex.strip()

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -90,7 +90,7 @@ class History(list):
 
         :param new: command line to convert to HistoryItem and add to the end of the History list
         """
-        history_item = HistoryItem(new, len(self)+1)
+        history_item = HistoryItem(new, len(self) + 1)
         list.append(self, history_item)
 
     def get(self, index: Union[int, str]) -> HistoryItem:
@@ -210,7 +210,9 @@ class History(list):
         def isin(history_item):
             """filter function for string search of history"""
             sloppy = utils.norm_fold(search)
-            return sloppy in utils.norm_fold(history_item.statement.raw) or sloppy in utils.norm_fold(history_item.statement.expanded_command_line)
+            inraw = sloppy in utils.norm_fold(history_item.statement.raw)
+            inexpanded = sloppy in utils.norm_fold(history_item.statement.expanded_command_line)
+            return inraw or inexpanded
         return [item for item in self if isin(item)]
 
     def regex_search(self, regex: str) -> List[HistoryItem]:
@@ -229,7 +231,7 @@ class History(list):
             return finder.search(hi.statement.raw) or finder.search(hi.statement.expanded_command_line)
         return [itm for itm in self if isin(itm)]
 
-    def truncate(self, max_length:int) -> None:
+    def truncate(self, max_length: int) -> None:
         """Truncate the length of the history, dropping the oldest items if necessary
 
         :param max_length: the maximum length of the history, if negative, all history

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -24,10 +24,7 @@ class HistoryItem():
 
     def __str__(self):
         """A convenient human readable representation of the history item"""
-        if self.statement:
-            return self.statement.raw
-        else:
-            return ''
+        return self.statement.raw
 
     @property
     def raw(self) -> str:

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -224,3 +224,17 @@ class History(list):
             """filter function for doing a regular expression search of history"""
             return finder.search(hi) or finder.search(hi.expanded)
         return [itm for itm in self if isin(itm)]
+
+    def truncate(self, max_length:int) -> None:
+        """Truncate the length of the history, dropping the oldest items if necessary
+
+        :param max_length: the maximum length of the history, if negative, all history
+                           items will be deleted
+        :return: nothing
+        """
+        if max_length <= 0:
+            # remove all history
+            del self[:]
+        elif len(self) > max_length:
+            last_element = len(self) - max_length
+            del self[0:last_element]

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -12,6 +12,7 @@ import attr
 from . import utils
 from .parsing import Statement
 
+
 @attr.s(frozen=True)
 class HistoryItem():
     """Class used to represent one command in the History list"""

--- a/docs/freefeatures.rst
+++ b/docs/freefeatures.rst
@@ -258,7 +258,7 @@ All cmd_-based applications on systems with the ``readline`` module
 also provide `Readline Emacs editing mode`_.  With this you can, for example, use **Ctrl-r** to search backward through
 the readline history.
 
-``cmd2`` adds the option of making this readline history persistent via optional arguments to ``cmd2.Cmd.__init__()``:
+``cmd2`` adds the option of making this history persistent via optional arguments to ``cmd2.Cmd.__init__()``:
 
 .. automethod:: cmd2.cmd2.Cmd.__init__
 

--- a/examples/hello_cmd2.py
+++ b/examples/hello_cmd2.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
 
     # Set "use_ipython" to True to include the ipy command if IPython is installed, which supports advanced interactive
     # debugging of your application via introspection on self.
-    app = cmd2.Cmd(use_ipython=True, persistent_history_file='cmd2_history.txt')
+    app = cmd2.Cmd(use_ipython=True, persistent_history_file='cmd2_history.dat')
     app.locals_in_py = True     # Enable access to "self" within the py command
     app.debug = True            # Show traceback if/when an exception occurs
     sys.exit(app.cmdloop())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,8 @@ formatting:
                         macros expanded, instead of typed commands
   -v, --verbose         display history and include expanded commands if they
                         differ from the typed command
-  -a, --all             display all commands, including ones persisted from previous sessions
+  -a, --all             display all commands, including ones persisted from
+                        previous sessions
 """
 
 # Output from the shortcuts command with default built-in shortcuts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ shortcuts           List available shortcuts
 
 # Help text for the history command
 HELP_HISTORY = """Usage: history [-h] [-r | -e | -o FILE | -t TRANSCRIPT | -c] [-s] [-x] [-v]
+               [-a]
                [arg]
 
 View, run, edit, save, or clear previously entered commands
@@ -88,7 +89,7 @@ formatting:
                         macros expanded, instead of typed commands
   -v, --verbose         display history and include expanded commands if they
                         differ from the typed command
-
+  -a, --all             display all commands, including ones persisted from previous sessions
 """
 
 # Output from the shortcuts command with default built-in shortcuts

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -459,16 +459,18 @@ def hist_file():
         pass
 
 def test_bad_history_file_path(capsys, request):
-    with tempfile.TemporaryDirectory() as test_dir:
-        # For appveyor, create a directory in our temp dir
-        # for some reason it seems that appveyor won't let us read
-        # the directory we created
-        safe_dir = os.path.join(test_dir, 'somedir')
-        os.mkdir(safe_dir)
-        # Create a new cmd2 app
-        cmd2.Cmd(persistent_history_file=safe_dir)
-        _, err = capsys.readouterr()
-        assert 'is a directory' in err
+    # can't use tempfile.TemporaryDirectory() as a context on Appveyor
+    # on windows. it causes a file locking issue which is reflected as
+    # a permission exception
+    test_dir = tempfile.mkdtemp()
+    # Create a new cmd2 app
+    cmd2.Cmd(persistent_history_file=test_dir)
+    _, err = capsys.readouterr()
+    assert 'is a directory' in err
+    try:
+        os.rmdir(test_dir)
+    except OSError:
+        pass
 
 def test_history_file_conversion_no_truncate_on_init(hist_file, capsys):
     # test the code that converts a plain text history file to a pickle binary

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -398,8 +398,6 @@ def hist_file():
         pass
 
 def test_existing_history_file(hist_file, capsys):
-    import atexit
-    import readline
 
     # Create the history file before making cmd2 app
     with open(hist_file, 'w'):
@@ -416,11 +414,9 @@ def test_existing_history_file(hist_file, capsys):
     ## TODO atexit.unregister(readline.write_history_file)
 
     # Remove created history file
-    os.remove(hist_file)
+    #os.remove(hist_file)
 
 def test_new_history_file(hist_file, capsys):
-    import atexit
-    import readline
 
     # Remove any existing history file
     try:
@@ -439,7 +435,7 @@ def test_new_history_file(hist_file, capsys):
     ### TODO atexit.unregister(readline.write_history_file)
 
     # Remove created history file
-    os.remove(hist_file)
+    #os.remove(hist_file)
 
 def test_bad_history_file_path(capsys, request):
     # Use a directory path as the history file
@@ -449,7 +445,7 @@ def test_bad_history_file_path(capsys, request):
     cmd2.Cmd(persistent_history_file=test_dir)
     _, err = capsys.readouterr()
 
-    assert 'can not write' in err
+    assert 'is a directory' in err
 
 def test_history_file_conversion_no_truncate_on_init(hist_file, capsys):
     # test the code that converts a plain text history file to a pickle binary

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -459,18 +459,11 @@ def hist_file():
         pass
 
 def test_bad_history_file_path(capsys, request):
-    # can't use tempfile.TemporaryDirectory() as a context on Appveyor
-    # on windows. it causes a file locking issue which is reflected as
-    # a permission exception
-    test_dir = tempfile.mkdtemp()
-    # Create a new cmd2 app
-    cmd2.Cmd(persistent_history_file=test_dir)
-    _, err = capsys.readouterr()
-    assert 'is a directory' in err
-    try:
-        os.rmdir(test_dir)
-    except OSError:
-        pass
+    with tempfile.TemporaryDirectory() as test_dir:
+        # Create a new cmd2 app
+        cmd2.Cmd(persistent_history_file=test_dir)
+        _, err = capsys.readouterr()
+        assert 'is a directory' in err
 
 def test_history_file_conversion_no_truncate_on_init(hist_file, capsys):
     # test the code that converts a plain text history file to a pickle binary

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -459,14 +459,11 @@ def hist_file():
         pass
 
 def test_bad_history_file_path(capsys, request):
-    # Use a directory path as the history file
-    test_dir = os.path.dirname(request.module.__file__)
-
-    # Create a new cmd2 app
-    cmd2.Cmd(persistent_history_file=test_dir)
-    _, err = capsys.readouterr()
-
-    assert 'is a directory' in err
+    with tempfile.TemporaryDirectory() as test_dir:
+        # Create a new cmd2 app
+        cmd2.Cmd(persistent_history_file=test_dir)
+        _, err = capsys.readouterr()
+        assert 'is a directory' in err
 
 def test_history_file_conversion_no_truncate_on_init(hist_file, capsys):
     # test the code that converts a plain text history file to a pickle binary

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -460,8 +460,13 @@ def hist_file():
 
 def test_bad_history_file_path(capsys, request):
     with tempfile.TemporaryDirectory() as test_dir:
+        # For appveyor, create a directory in our temp dir
+        # for some reason it seems that appveyor won't let us read
+        # the directory we created
+        safe_dir = os.path.join(test_dir, 'somedir')
+        os.mkdir(safe_dir)
         # Create a new cmd2 app
-        cmd2.Cmd(persistent_history_file=test_dir)
+        cmd2.Cmd(persistent_history_file=safe_dir)
         _, err = capsys.readouterr()
         assert 'is a directory' in err
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -5,8 +5,6 @@ Test history functions of cmd2
 """
 import tempfile
 import os
-import pickle
-import sys
 
 import pytest
 
@@ -18,6 +16,8 @@ except ImportError:
 
 import cmd2
 from .conftest import run_cmd, normalize, HELP_HISTORY
+from cmd2.parsing import Statement
+from cmd2.history import HistoryItem
 
 
 def test_base_help_history(base_app):
@@ -50,16 +50,25 @@ def test_exclude_from_history(base_app, monkeypatch):
     expected = normalize("""    1  help""")
     assert out == expected
 
-
 @pytest.fixture
 def hist():
-    from cmd2.parsing import Statement
-    from cmd2.cmd2 import History, HistoryItem
+    from cmd2.history import History
     h = History([HistoryItem(Statement('', raw='first'), 1),
                  HistoryItem(Statement('', raw='second'), 2),
                  HistoryItem(Statement('', raw='third'), 3),
-                 HistoryItem(Statement('', raw='fourth'),4)])
+                 HistoryItem(Statement('', raw='fourth'), 4)])
     return h
+
+def test_history_item():
+    raw = 'help'
+    stmt = Statement('', raw=raw)
+    index = 1
+    hi = HistoryItem(stmt, index)
+    assert hi.statement == stmt
+    assert hi.idx == index
+    assert hi.statement.raw == raw
+    assert str(hi) == raw
+
 
 def test_history_class_span(hist):
     for tryit in ['*', ':', '-', 'all', 'ALL']:


### PR DESCRIPTION
Fixes #669.

We have a readline history and a native in-memory history. Previous to this PR, only readline history was persistent between invocations of a `cmd2` based app. Now both readline and native history are persistent. Plaintext history files are ignored, and do not cause read errors. All new history files written after this PR sill be in binary pickle format.

This includes several breaking changes noted in the changelog, including:

- Change persistent history format to pickle instead of plain text
- refactoring HistoryItem to not subclass string (it wouldn't unpickle)
