### PR TITLE
Deprecate Python 3.4 and add support and testing for Python 3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,9 @@ environment:
   PYTHONUNBUFFERED: 1
   MINICONDA: C:\\Miniconda3-x64
   matrix:
-  - PYTHON: "C:\\Python35"
-    TOX_ENV: "py35"
+# Disable Python 3.5 testing on AppVeyor for now until we fix issue with mock module install for python < 3.6
+#  - PYTHON: "C:\\Python35"
+#    TOX_ENV: "py35"
 
   - PYTHON: "C:\\Python36"
     TOX_ENV: "py36"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,9 +4,8 @@ environment:
   PYTHONUNBUFFERED: 1
   MINICONDA: C:\\Miniconda3-x64
   matrix:
-# Disable Python 3.5 testing on AppVeyor for now until we fix issue with mock module install for python < 3.6
-#  - PYTHON: "C:\\Python35"
-#    TOX_ENV: "py35"
+  - PYTHON: "C:\\Python35"
+    TOX_ENV: "py35"
 
   - PYTHON: "C:\\Python36"
     TOX_ENV: "py36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-sudo: false  # false enables container-based build for fast boot times on Linux
-
 matrix:
     include:
         - os: linux
@@ -13,11 +11,11 @@ matrix:
         - os: linux
           python: 3.7
           dist: xenial
-          sudo: true  # Travis CI doesn't yet support official (non-development) Python 3.7 on container-based builds
           env: TOXENV=py37
         - os: linux
-            python: 3.8-dev
-            env: TOXENV=py38
+          python: 3.8-dev
+          dist: xenial
+          env: TOXENV=py38
         - os: linux
           python: 3.5
           env: TOXENV=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: false  # false enables container-based build for fast boot times on Linux
 matrix:
     include:
         - os: linux
-          python: 3.4
-          env: TOXENV=py34
-        - os: linux
           python: 3.5
           env: TOXENV=py35
         - os: linux
@@ -18,6 +15,9 @@ matrix:
           dist: xenial
           sudo: true  # Travis CI doesn't yet support official (non-development) Python 3.7 on container-based builds
           env: TOXENV=py37
+        - os: linux
+            python: 3.8-dev
+            env: TOXENV=py38
         - os: linux
           python: 3.5
           env: TOXENV=docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.14 (TBD, 2019
+* Enhancements
+    * Added support for and testing with Python 3.8, starting with 3.8 beta
+* Breaking Changes
+    * Python 3.4 reached its [end of life](https://www.python.org/dev/peps/pep-0429/) on March 18, 2019 and is no longer supported by `cmd2`
+
 ## 0.9.13 (June 14, 2019)
 * Bug Fixes
     * Fixed issue where the wrong terminator was being appended by `Statement.expanded_command_line()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The tables below list all prerequisites along with the minimum required version 
 
 | Prerequisite                                        | Minimum Version |
 | --------------------------------------------------- | --------------- |
-| [python](https://www.python.org/downloads/)         | `3.4`           |
+| [python](https://www.python.org/downloads/)         | `3.5`           |
 | [attrs](https://github.com/python-attrs/attrs)      | `16.3`          |
 | [colorama](https://github.com/tartley/colorama)     | `0.3.7`         |
 | [pyperclip](https://github.com/asweigart/pyperclip) | `1.5.27`        |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Main Features
 - Unicode character support
 - Good tab-completion of commands, sub-commands, file system paths, and shell commands
 - Automatic tab-completion of `argparse` flags when using one of the `cmd2` `argparse` decorators
-- Support for Python 3.4+ on Windows, macOS, and Linux
+- Support for Python 3.5+ on Windows, macOS, and Linux
 - Trivial to provide built-in help for all commands
 - Built-in regression testing framework for your applications (transcript-based testing)
 - Transcripts for use with built-in regression can be automatically generated from `history -t` or `load -t`
@@ -59,7 +59,7 @@ On all operating systems, the latest stable version of `cmd2` can be installed u
 pip install -U cmd2
 ```
 
-cmd2 works with Python 3.4+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
+cmd2 works with Python 3.5+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
 
 For information on other installation options, see
 [Installation Instructions](https://cmd2.readthedocs.io/en/latest/install.html) in the cmd2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,6 @@ jobs:
   # Run the pipeline with multiple Python versions
   strategy:
     matrix:
-      Python34:
-        python.version: '3.4'
-        TOXENV: 'py34'
       Python35:
         python.version: '3.5'
         TOXENV: 'py35'

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -39,6 +39,7 @@ import re
 import sys
 import threading
 from collections import namedtuple
+from contextlib import redirect_stdout
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union, IO
 
 import colorama
@@ -103,12 +104,6 @@ except ImportError:
                     return True
             return NotImplemented
 
-# Python 3.4 require contextlib2 for temporarily redirecting stderr and stdout
-if sys.version_info < (3, 5):
-    # noinspection PyUnresolvedReferences
-    from contextlib2 import redirect_stdout
-else:
-    from contextlib import redirect_stdout
 
 # Detect whether IPython is installed to determine if the built-in "ipy" command should be included
 ipython_available = True

--- a/cmd2/pyscript_bridge.py
+++ b/cmd2/pyscript_bridge.py
@@ -5,16 +5,10 @@ degree of isolation between the two
 """
 
 import sys
+from contextlib import redirect_stdout, redirect_stderr
 from typing import Optional
 
 from .utils import namedtuple_with_defaults, StdSim
-
-# Python 3.4 require contextlib2 for temporarily redirecting stderr and stdout
-if sys.version_info < (3, 5):
-    # noinspection PyUnresolvedReferences
-    from contextlib2 import redirect_stdout, redirect_stderr
-else:
-    from contextlib import redirect_stdout, redirect_stderr
 
 
 class CommandResult(namedtuple_with_defaults('CommandResult', ['stdout', 'stderr', 'stop', 'data'])):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ Contents:
 Compatibility
 =============
 
-Tested and working with Python 3.4+ on Windows, macOS, and Linux.
+Tested and working with Python 3.5+ on Windows, macOS, and Linux.
 
 Index
 =====

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ This section covers the basics of how to install, upgrade, and uninstall ``cmd2`
 
 Installing
 ----------
-First you need to make sure you have Python 3.4+, pip_, and setuptools_.  Then you can just use pip to
+First you need to make sure you have Python 3.5+, pip_, and setuptools_.  Then you can just use pip to
 install from PyPI_.
 
 .. _pip: https://pypi.python.org/pypi/pip
@@ -25,7 +25,7 @@ install from PyPI_.
 
 Requirements for Installing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* If you have Python 3 >=3.4 installed from `python.org
+* If you have Python 3 >=3.5 installed from `python.org
   <https://www.python.org>`_, you will already have pip_ and
   setuptools_, but may need to upgrade to the latest versions:
 
@@ -124,10 +124,6 @@ If you wish to permanently uninstall ``cmd2``, this can also easily be done with
 
     pip uninstall cmd2
 
-Extra requirements for Python 3.4
----------------------------------
-``cmd2`` requires the ``contextlib2`` module for Python 3.4.  This is used to temporarily redirect
-stdout and stderr.  Also when using Python 3.4, ``cmd2`` requires the ``typing`` module backport.
 
 Extra requirement for macOS
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ Intended Audience :: System Administrators
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines())))  # noqa: E128
@@ -36,14 +36,12 @@ INSTALL_REQUIRES = ['pyperclip >= 1.5.27', 'colorama', 'attrs >= 16.3.0', 'wcwid
 EXTRAS_REQUIRE = {
     # Windows also requires pyreadline to ensure tab completion works
     ":sys_platform=='win32'": ['pyreadline'],
-    # Python 3.4 and earlier require contextlib2 for temporarily redirecting stderr and stdout
-    ":python_version<'3.5'": ['contextlib2', 'typing'],
     # Extra dependencies for running unit tests
     'test': ["gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in tox env
-             "mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
+             "mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
              'codecov', 'pytest', 'pytest-cov', 'pytest-mock'],
     # development only dependencies:  install with 'pip install -e .[dev]'
-    'dev': ["mock ; python_version<'3.6'",  # for python 3.5 and earlier we need the third party mock module
+    'dev': ["mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
             'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'pylint',
             'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'invoke', 'twine>=1.11',
             ]
@@ -63,7 +61,7 @@ setup(
     platforms=['any'],
     packages=['cmd2'],
     keywords='command prompt console cmd',
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     setup_requires=SETUP_REQUIRES,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 Cmd2 unit/functional testing
 """
 import sys
+from contextlib import redirect_stdout, redirect_stderr
 from typing import Optional
 from unittest import mock
 
@@ -11,12 +12,6 @@ from pytest import fixture
 import cmd2
 from cmd2.utils import StdSim
 
-# Python 3.4 require contextlib2 for temporarily redirecting stderr and stdout
-if sys.version_info < (3, 5):
-    # noinspection PyUnresolvedReferences
-    from contextlib2 import redirect_stdout, redirect_stderr
-else:
-    from contextlib import redirect_stdout, redirect_stderr
 
 # Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,py34,py35,py36,py37
+envlist = docs,py35,py36,py37,py38
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
Removed extra dependencies and imports required by Python 3.4 as well as unit testing on Python 3.4 from all platform.s

Added support for Python 3.8 in setup.py and unit testing for python 3.8beta on Travis CI.

Now that we support Python 3.5+, this opens up the possibility for beginning to use libraries like [pathlib](https://docs.python.org/3/library/pathlib.html).

Closes #661 
Closes #693 

TODO:
* [x] Updated CHANGELOG