### PR TITLE
Fixed bug where  was sometimes showing raw and expanded commands when they weren't different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.15 (July TBD, 2019)
 * Bug Fixes
     * Fixed exception caused by tab completing after an invalid subcommand was entered
+    * Fixed bug where `history -v` was sometimes showing raw and expanded commands when they weren't different
 * Enhancements
     * Greatly simplified using argparse-based tab completion. The new interface is a complete overhaul that breaks
     the previous way of specifying completion and choices functions. See header of [argparse_custom.py](https://github.com/python-cmd2/cmd2/blob/master/cmd2/argparse_custom.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 * Bug Fixes
     * Fixed exception caused by tab completing after an invalid subcommand was entered
     * Fixed bug where `history -v` was sometimes showing raw and expanded commands when they weren't different
+    * Fixed bug where multiline commands were having leading and ending spaces stripped. This would mess up quoted
+    strings that crossed multiple lines.
 * Enhancements
     * Greatly simplified using argparse-based tab completion. The new interface is a complete overhaul that breaks
     the previous way of specifying completion and choices functions. See header of [argparse_custom.py](https://github.com/python-cmd2/cmd2/blob/master/cmd2/argparse_custom.py)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2204,7 +2204,7 @@ class Cmd(cmd.Cmd):
                 else:
                     line = 'eof'
 
-        return line.strip()
+        return line.rstrip('\r\n')
 
     def _cmdloop(self) -> None:
         """Repeatedly issue a prompt, accept input, parse an initial prefix

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -44,9 +44,12 @@ class HistoryItem():
         :return: pretty print string version of a HistoryItem
         """
         if verbose:
-            ret_str = self._listformat.format(self.idx, self.raw.rstrip())
-            if self.raw != self.expanded.rstrip():
-                ret_str += '\n' + self._ex_listformat.format(self.idx, self.expanded.rstrip())
+            raw = self.raw.rstrip()
+            expanded = self.expanded.rstrip()
+
+            ret_str = self._listformat.format(self.idx, raw)
+            if raw != expanded:
+                ret_str += '\n' + self._ex_listformat.format(self.idx, expanded)
         else:
             if expanded:
                 ret_str = self.expanded.rstrip()


### PR DESCRIPTION
* Fixed bug where `history -v` was sometimes showing raw and expanded commands when they weren't different
 * Fixed bug where multiline commands were having leading and ending spaces stripped. This would mess up quoted strings that crossed multiple lines.

Fixes #727 