### PR TITLE
Renamed cmd'2 parser to Cmd2ArgumentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     * Restored `cmd2.Cmd.statement_parser` to be a public attribute (no underscore) 
         * Since it can be useful for creating [post-parsing hooks](https://cmd2.readthedocs.io/en/latest/features/hooks.html#postparsing-hooks)
     * Completely overhauled the interface for adding tab completion to argparse arguments. See enhancements for more details.
-    * `ACArgumentParser` is now called `ArgParser`
+    * `ACArgumentParser` is now called `Cmd2ArgumentParser`
     * Moved `basic_complete` to utils.py
     * Made optional arguments on the following completer methods keyword-only:
     `delimiter_complete`, `flag_based_complete`, `index_based_complete`. `path_complete`, `shell_cmd_complete`

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Instructions for implementing each feature follow.
 
     See https://cmd2.readthedocs.io/en/latest/argument_processing.html for more details
     
-    NOTE: `cmd2` also provides the `cmd2.ArgParser` customization of `argparse.ArgumentParser` for prettier formatting
+    NOTE: `cmd2` also provides the `Cmd2ArgumentParser` customization of `argparse.ArgumentParser` for prettier formatting
     of help and error messages.
 
 - `cmd2` applications function like a full-featured shell in many ways (and are cross-platform)

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -11,7 +11,7 @@ except DistributionNotFound:
     pass
 
 from .ansi import style
-from .argparse_custom import ArgParser, CompletionItem
+from .argparse_custom import Cmd2ArgumentParser, CompletionItem
 from .cmd2 import Cmd, Statement, EmptyStatement, categorize
 from .cmd2 import with_argument_list, with_argparser, with_argparser_and_unknown_args, with_category
 from .constants import DEFAULT_SHORTCUTS

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1,14 +1,14 @@
 # coding=utf-8
 """
 This module adds capabilities to argparse by patching a few of its functions. It also defines a parser
-class called ArgParser which improves error and help output over normal argparse. All cmd2 code uses
+class called Cmd2ArgumentParser which improves error and help output over normal argparse. All cmd2 code uses
 this parser and it is recommended that developers of cmd2-based apps either use it or write their own parser
 that inherits from it. This will give a consistent look-and-feel between the help/error output of built-in
 cmd2 commands and the app-specific commands.
 
-Since the new capabilities are added by patching at the argparse API level, they are available whether or
-not ArgParser is used. However, the help and error output of ArgParser is customized to notate nargs ranges
-whereas any other parser class won't be as explicit in their output.
+Since the new capabilities are added by patching at the argparse API level, they are available whether or not
+Cmd2ArgumentParser is used. However, the help and error output of Cmd2ArgumentParser is customized to notate
+nargs ranges whereas any other parser class won't be as explicit in their output.
 
 ############################################################################################################
 # Added capabilities
@@ -634,7 +634,7 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
 
 
 # noinspection PyCompatibility
-class ArgParser(argparse.ArgumentParser):
+class Cmd2ArgumentParser(argparse.ArgumentParser):
     """Custom ArgumentParser class that improves error and help output"""
 
     def __init__(self, *args, **kwargs) -> None:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -42,7 +42,7 @@ from collections import namedtuple
 from contextlib import redirect_stdout
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Type, Union
 
-from . import ArgParser, CompletionItem
+from . import Cmd2ArgumentParser, CompletionItem
 from . import ansi
 from . import constants
 from . import plugin
@@ -2348,7 +2348,7 @@ class Cmd(cmd.Cmd):
                          "An alias is a command that enables replacement of a word by another string.")
     alias_epilog = ("See also:\n"
                     "  macro")
-    alias_parser = ArgParser(description=alias_description, epilog=alias_epilog, prog='alias')
+    alias_parser = Cmd2ArgumentParser(description=alias_description, epilog=alias_epilog, prog='alias')
 
     # Add sub-commands to alias
     alias_subparsers = alias_parser.add_subparsers()
@@ -2528,7 +2528,7 @@ class Cmd(cmd.Cmd):
                          "A macro is similar to an alias, but it can contain argument placeholders.")
     macro_epilog = ("See also:\n"
                     "  alias")
-    macro_parser = ArgParser(description=macro_description, epilog=macro_epilog, prog='macro')
+    macro_parser = Cmd2ArgumentParser(description=macro_description, epilog=macro_epilog, prog='macro')
 
     # Add sub-commands to macro
     macro_subparsers = macro_parser.add_subparsers()
@@ -2660,7 +2660,7 @@ class Cmd(cmd.Cmd):
 
         return matches
 
-    help_parser = ArgParser()
+    help_parser = Cmd2ArgumentParser()
     help_parser.add_argument('command', nargs=argparse.OPTIONAL, help="command to retrieve help for",
                              completer_method=complete_help_command)
     help_parser.add_argument('subcommand', nargs=argparse.REMAINDER, help="sub-command to retrieve help for",
@@ -2824,7 +2824,7 @@ class Cmd(cmd.Cmd):
                         command = ''
                 self.stdout.write("\n")
 
-    @with_argparser(ArgParser())
+    @with_argparser(Cmd2ArgumentParser())
     def do_shortcuts(self, _: argparse.Namespace) -> None:
         """List available shortcuts"""
         # Sort the shortcut tuples by name
@@ -2832,13 +2832,13 @@ class Cmd(cmd.Cmd):
         result = "\n".join('{}: {}'.format(sc[0], sc[1]) for sc in sorted_shortcuts)
         self.poutput("Shortcuts for other commands:\n{}".format(result))
 
-    @with_argparser(ArgParser(epilog=INTERNAL_COMMAND_EPILOG))
+    @with_argparser(Cmd2ArgumentParser(epilog=INTERNAL_COMMAND_EPILOG))
     def do_eof(self, _: argparse.Namespace) -> bool:
         """Called when <Ctrl>-D is pressed"""
         # Return True to stop the command loop
         return True
 
-    @with_argparser(ArgParser())
+    @with_argparser(Cmd2ArgumentParser())
     def do_quit(self, _: argparse.Namespace) -> bool:
         """Exit this application"""
         # Return True to stop the command loop
@@ -2933,7 +2933,7 @@ class Cmd(cmd.Cmd):
                        "Accepts abbreviated parameter names so long as there is no ambiguity.\n"
                        "Call without arguments for a list of settable parameters with their values.")
 
-    set_parser = ArgParser(description=set_description)
+    set_parser = Cmd2ArgumentParser(description=set_description)
     set_parser.add_argument('-a', '--all', action='store_true', help='display read-only settings as well')
     set_parser.add_argument('-l', '--long', action='store_true', help='describe function of parameter')
     set_parser.add_argument('param', nargs=argparse.OPTIONAL, help='parameter to set or view',
@@ -2978,7 +2978,7 @@ class Cmd(cmd.Cmd):
             if onchange_hook is not None:
                 onchange_hook(old=orig_value, new=new_value)  # pylint: disable=not-callable
 
-    shell_parser = ArgParser()
+    shell_parser = Cmd2ArgumentParser()
     shell_parser.add_argument('command', help='the command to run', completer_method=shell_cmd_complete)
     shell_parser.add_argument('command_args', nargs=argparse.REMAINDER, help='arguments to pass to command',
                               completer_method=path_complete)
@@ -3041,7 +3041,7 @@ class Cmd(cmd.Cmd):
                       "If you see strange parsing behavior, it's best to just open the Python shell\n"
                       "by providing no arguments to py and run more complex statements there.")
 
-    py_parser = ArgParser(description=py_description)
+    py_parser = Cmd2ArgumentParser(description=py_description)
     py_parser.add_argument('command', nargs=argparse.OPTIONAL, help="command to run")
     py_parser.add_argument('remainder', nargs=argparse.REMAINDER, help="remainder of command")
 
@@ -3227,7 +3227,7 @@ class Cmd(cmd.Cmd):
 
         return bridge.stop
 
-    run_pyscript_parser = ArgParser()
+    run_pyscript_parser = Cmd2ArgumentParser()
     run_pyscript_parser.add_argument('script_path', help='path to the script file', completer_method=path_complete)
     run_pyscript_parser.add_argument('script_arguments', nargs=argparse.REMAINDER,
                                      help='arguments to pass to script', completer_method=path_complete)
@@ -3260,7 +3260,7 @@ class Cmd(cmd.Cmd):
 
     # Only include the do_ipy() method if IPython is available on the system
     if ipython_available:  # pragma: no cover
-        @with_argparser(ArgParser())
+        @with_argparser(Cmd2ArgumentParser())
         def do_ipy(self, _: argparse.Namespace) -> None:
             """Enter an interactive IPython shell"""
             from .pyscript_bridge import PyscriptBridge
@@ -3283,7 +3283,7 @@ class Cmd(cmd.Cmd):
 
     history_description = "View, run, edit, save, or clear previously entered commands"
 
-    history_parser = ArgParser(description=history_description)
+    history_parser = Cmd2ArgumentParser(description=history_description)
     history_action_group = history_parser.add_mutually_exclusive_group()
     history_action_group.add_argument('-r', '--run', action='store_true', help='run selected history items')
     history_action_group.add_argument('-e', '--edit', action='store_true',
@@ -3582,7 +3582,7 @@ class Cmd(cmd.Cmd):
                         "\n"
                         "  set editor (program-name)")
 
-    edit_parser = ArgParser(description=edit_description)
+    edit_parser = Cmd2ArgumentParser(description=edit_description)
     edit_parser.add_argument('file_path', nargs=argparse.OPTIONAL,
                              help="path to a file to open in editor", completer_method=path_complete)
 
@@ -3614,7 +3614,7 @@ class Cmd(cmd.Cmd):
                               "If the -t/--transcript flag is used, this command instead records\n"
                               "the output of the script commands to a transcript for testing purposes.\n")
 
-    run_script_parser = ArgParser(description=run_script_description)
+    run_script_parser = Cmd2ArgumentParser(description=run_script_description)
     run_script_parser.add_argument('-t', '--transcript', metavar='TRANSCRIPT_FILE',
                                    help='record the output of the script as a transcript file',
                                    completer_method=path_complete)
@@ -3681,8 +3681,8 @@ class Cmd(cmd.Cmd):
     relative_run_script_epilog = ("Notes:\n"
                                   "  This command is intended to only be used within text file scripts.")
 
-    relative_run_script_parser = ArgParser(description=relative_run_script_description,
-                                           epilog=relative_run_script_epilog)
+    relative_run_script_parser = Cmd2ArgumentParser(description=relative_run_script_description,
+                                                    epilog=relative_run_script_epilog)
     relative_run_script_parser.add_argument('file_path', help='a file path pointing to a script')
 
     @with_argparser(relative_run_script_parser)

--- a/examples/tab_autocompletion.py
+++ b/examples/tab_autocompletion.py
@@ -8,7 +8,7 @@ import functools
 from typing import List
 
 import cmd2
-from cmd2 import utils, CompletionItem
+from cmd2 import utils, Cmd2ArgumentParser, CompletionItem
 
 actors = ['Mark Hamill', 'Harrison Ford', 'Carrie Fisher', 'Alec Guinness', 'Peter Mayhew',
           'Anthony Daniels', 'Adam Driver', 'Daisy Ridley', 'John Boyega', 'Oscar Isaac',
@@ -128,7 +128,7 @@ class TabCompleteExample(cmd2.Cmd):
 
     suggest_description = "Suggest command demonstrates argparse customizations.\n"
     suggest_description += "See hybrid_suggest and orig_suggest to compare the help output."
-    suggest_parser = cmd2.ArgParser(description=suggest_description)
+    suggest_parser = Cmd2ArgumentParser(description=suggest_description)
 
     suggest_parser.add_argument('-t', '--type', choices=['movie', 'show'], required=True)
     suggest_parser.add_argument('-d', '--duration', nargs=(1, 2), action='append',
@@ -204,7 +204,7 @@ class TabCompleteExample(cmd2.Cmd):
                                   '\n    '.join(ep_list)))
                 print()
 
-    video_parser = cmd2.ArgParser(prog='media')
+    video_parser = Cmd2ArgumentParser(prog='media')
 
     video_types_subparsers = video_parser.add_subparsers(title='Media Types', dest='type')
 

--- a/examples/table_display.py
+++ b/examples/table_display.py
@@ -14,8 +14,10 @@ and either the colored or colorama module
 """
 from typing import Tuple
 
-import cmd2
 import tableformatter as tf
+
+import cmd2
+from cmd2 import Cmd2ArgumentParser
 
 # Configure colors for when users chooses the "-c" flag to enable color in the table output
 try:
@@ -142,14 +144,14 @@ def high_density_objs(row_obj: CityInfo) -> dict:
     return opts
 
 
-def make_table_parser() -> cmd2.ArgParser:
+def make_table_parser() -> Cmd2ArgumentParser:
     """Create a unique instance of an argparse Argument parser for processing table arguments.
 
     NOTE: The two cmd2 argparse decorators require that each parser be unique, even if they are essentially a deep copy
     of each other.  For cases like that, you can create a function to return a unique instance of a parser, which is
     what is being done here.
     """
-    table_parser = cmd2.ArgParser()
+    table_parser = Cmd2ArgumentParser()
     table_item_group = table_parser.add_mutually_exclusive_group()
     table_item_group.add_argument('-c', '--color', action='store_true', help='Enable color')
     table_item_group.add_argument('-f', '--fancy', action='store_true', help='Fancy Grid')

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -9,7 +9,7 @@ from typing import List
 import pytest
 
 import cmd2
-from cmd2 import with_argparser, CompletionItem
+from cmd2 import with_argparser, Cmd2ArgumentParser, CompletionItem
 from cmd2.utils import StdSim, basic_complete
 from .conftest import run_cmd, complete_tester
 
@@ -63,7 +63,7 @@ class AutoCompleteTester(cmd2.Cmd):
         self.poutput('music create rock')
 
     # Top level parser for music command
-    music_parser = cmd2.ArgParser(description='Manage music', prog='music')
+    music_parser = Cmd2ArgumentParser(description='Manage music', prog='music')
 
     # Add sub-commands to music
     music_subparsers = music_parser.add_subparsers()
@@ -100,7 +100,7 @@ class AutoCompleteTester(cmd2.Cmd):
     ############################################################################################################
 
     # Uses default flag prefix value (-)
-    flag_parser = cmd2.ArgParser()
+    flag_parser = Cmd2ArgumentParser()
     flag_parser.add_argument('-n', '--normal_flag', help='A normal flag', action='store_true')
     flag_parser.add_argument('-a', '--append_flag', help='Append flag', action='append')
     flag_parser.add_argument('-o', '--append_const_flag', help='Append const flag', action='append_const', const=True)
@@ -113,7 +113,7 @@ class AutoCompleteTester(cmd2.Cmd):
         pass
 
     # Uses non-default flag prefix value (+)
-    plus_flag_parser = cmd2.ArgParser(prefix_chars='+')
+    plus_flag_parser = Cmd2ArgumentParser(prefix_chars='+')
     plus_flag_parser.add_argument('+n', '++normal_flag', help='A normal flag', action='store_true')
 
     @with_argparser(plus_flag_parser)
@@ -135,7 +135,7 @@ class AutoCompleteTester(cmd2.Cmd):
             items.append(CompletionItem(main_str, desc='blah blah'))
         return items
 
-    choices_parser = cmd2.ArgParser()
+    choices_parser = Cmd2ArgumentParser()
 
     # Flag args for choices command. Include string and non-string arg types.
     choices_parser.add_argument("-l", "--list", help="a flag populated with a choices list",
@@ -168,7 +168,7 @@ class AutoCompleteTester(cmd2.Cmd):
         """Tab completion method"""
         return basic_complete(text, line, begidx, endidx, completions_from_method)
 
-    completer_parser = cmd2.ArgParser()
+    completer_parser = Cmd2ArgumentParser()
 
     # Flag args for completer command
     completer_parser.add_argument("-f", "--function", help="a flag using a completer function",
@@ -189,7 +189,7 @@ class AutoCompleteTester(cmd2.Cmd):
     ############################################################################################################
     # Begin code related to nargs
     ############################################################################################################
-    nargs_parser = cmd2.ArgParser()
+    nargs_parser = Cmd2ArgumentParser()
 
     # Flag args for nargs command
     nargs_parser.add_argument("--set_value", help="a flag with a set value for nargs", nargs=2,
@@ -215,7 +215,7 @@ class AutoCompleteTester(cmd2.Cmd):
     ############################################################################################################
     # Begin code related to testing tab hints
     ############################################################################################################
-    hint_parser = cmd2.ArgParser()
+    hint_parser = Cmd2ArgumentParser()
     hint_parser.add_argument('-f', '--flag', help='a flag arg')
     hint_parser.add_argument('-s', '--suppressed_help', help=argparse.SUPPRESS)
     hint_parser.add_argument('-t', '--suppressed_hint', help='a flag arg', suppress_tab_hint=True)
@@ -711,7 +711,7 @@ Hint:
 
 def test_single_prefix_char():
     from cmd2.argparse_completer import _single_prefix_char
-    parser = cmd2.ArgParser(prefix_chars='-+')
+    parser = Cmd2ArgumentParser(prefix_chars='-+')
 
     # Invalid
     assert not _single_prefix_char('', parser)
@@ -727,7 +727,7 @@ def test_single_prefix_char():
 
 def test_looks_like_flag():
     from cmd2.argparse_completer import _looks_like_flag
-    parser = cmd2.ArgParser()
+    parser = Cmd2ArgumentParser()
 
     # Does not start like a flag
     assert not _looks_like_flag('', parser)
@@ -745,7 +745,7 @@ def test_looks_like_flag():
 def test_complete_command_no_tokens(ac_app):
     from cmd2.argparse_completer import AutoCompleter
 
-    parser = cmd2.ArgParser()
+    parser = Cmd2ArgumentParser()
     ac = AutoCompleter(parser, ac_app)
 
     completions = ac.complete_command(tokens=[], text='', line='', begidx=0, endidx=0)
@@ -755,7 +755,7 @@ def test_complete_command_no_tokens(ac_app):
 def test_complete_command_help_no_tokens(ac_app):
     from cmd2.argparse_completer import AutoCompleter
 
-    parser = cmd2.ArgParser()
+    parser = Cmd2ArgumentParser()
     ac = AutoCompleter(parser, ac_app)
 
     completions = ac.complete_command_help(tokens=[], text='', line='', begidx=0, endidx=0)

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -7,6 +7,7 @@ import argparse
 import pytest
 
 import cmd2
+from cmd2 import Cmd2ArgumentParser
 from cmd2.argparse_custom import generate_range_error, INFINITY
 from .conftest import run_cmd
 
@@ -16,7 +17,7 @@ class ApCustomTestApp(cmd2.Cmd):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    range_parser = cmd2.ArgParser()
+    range_parser = Cmd2ArgumentParser()
     range_parser.add_argument('--arg0', nargs=1)
     range_parser.add_argument('--arg1', nargs=2)
     range_parser.add_argument('--arg2', nargs=(3,))
@@ -50,7 +51,7 @@ def fake_func():
     ({'choices_method': fake_func, 'completer_method': fake_func}, False),
 ])
 def test_apcustom_invalid_args(args, is_valid):
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     try:
         parser.add_argument('name', **args)
         assert is_valid
@@ -61,7 +62,7 @@ def test_apcustom_invalid_args(args, is_valid):
 
 def test_apcustom_usage():
     usage = "A custom usage statement"
-    parser = cmd2.ArgParser(usage=usage)
+    parser = Cmd2ArgumentParser(usage=usage)
     assert usage in parser.format_help()
 
 
@@ -101,40 +102,40 @@ def test_apcustom_nargs_range_validation(cust_app):
 ])
 def test_apcustom_narg_invalid_tuples(nargs_tuple):
     with pytest.raises(ValueError) as excinfo:
-        parser = cmd2.ArgParser(prog='test')
+        parser = Cmd2ArgumentParser(prog='test')
         parser.add_argument('invalid_tuple', nargs=nargs_tuple)
     assert 'Ranged values for nargs must be a tuple of 1 or 2 integers' in str(excinfo.value)
 
 
 def test_apcustom_narg_tuple_order():
     with pytest.raises(ValueError) as excinfo:
-        parser = cmd2.ArgParser(prog='test')
+        parser = Cmd2ArgumentParser(prog='test')
         parser.add_argument('invalid_tuple', nargs=(2, 1))
     assert 'Invalid nargs range. The first value must be less than the second' in str(excinfo.value)
 
 
 def test_apcustom_narg_tuple_negative():
     with pytest.raises(ValueError) as excinfo:
-        parser = cmd2.ArgParser(prog='test')
+        parser = Cmd2ArgumentParser(prog='test')
         parser.add_argument('invalid_tuple', nargs=(-1, 1))
     assert 'Negative numbers are invalid for nargs range' in str(excinfo.value)
 
 
 # noinspection PyUnresolvedReferences
 def test_apcustom_narg_tuple_zero_base():
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(0,))
     assert arg.nargs == argparse.ZERO_OR_MORE
     assert arg.nargs_range is None
     assert "[arg [...]]" in parser.format_help()
 
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(0, 1))
     assert arg.nargs == argparse.OPTIONAL
     assert arg.nargs_range is None
     assert "[arg]" in parser.format_help()
 
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(0, 3))
     assert arg.nargs == argparse.ZERO_OR_MORE
     assert arg.nargs_range == (0, 3)
@@ -143,13 +144,13 @@ def test_apcustom_narg_tuple_zero_base():
 
 # noinspection PyUnresolvedReferences
 def test_apcustom_narg_tuple_one_base():
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(1,))
     assert arg.nargs == argparse.ONE_OR_MORE
     assert arg.nargs_range is None
     assert "arg [...]" in parser.format_help()
 
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(1, 5))
     assert arg.nargs == argparse.ONE_OR_MORE
     assert arg.nargs_range == (1, 5)
@@ -160,13 +161,13 @@ def test_apcustom_narg_tuple_one_base():
 def test_apcustom_narg_tuple_other_ranges():
 
     # Test range with no upper bound on max
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(2,))
     assert arg.nargs == argparse.ONE_OR_MORE
     assert arg.nargs_range == (2, INFINITY)
 
     # Test finite range
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     arg = parser.add_argument('arg', nargs=(2, 5))
     assert arg.nargs == argparse.ONE_OR_MORE
     assert arg.nargs_range == (2, 5)
@@ -177,13 +178,13 @@ def test_apcustom_print_message(capsys):
     test_message = 'The test message'
 
     # Specify the file
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     parser._print_message(test_message, file=sys.stdout)
     out, err = capsys.readouterr()
     assert test_message in out
 
     # Make sure file defaults to sys.stderr
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     parser._print_message(test_message)
     out, err = capsys.readouterr()
     assert test_message in err
@@ -214,6 +215,6 @@ def test_generate_range_error():
 
 def test_apcustom_required_options():
     # Make sure a 'required arguments' section shows when a flag is marked required
-    parser = cmd2.ArgParser(prog='test')
+    parser = Cmd2ArgumentParser(prog='test')
     parser.add_argument('--required_flag', required=True)
     assert 'required arguments' in parser.format_help()


### PR DESCRIPTION
After speaking with a number of devs, I decided to name cmd2's custom parser `Cmd2ArgumentParser`.
It is a long name, but actually only 2 characters longer than its previous name, `ACArgumentParser`.

The previous name was clear in it being a derived class of `argparse.ArgumentParser`, but it was misleading in that `AC` implied it was needed for auto-completion of argparse commands to work.

One suggestion given was `cmd2.ArgumentParser`. While that name takes advantage of namespace separation, I was worried that developers reading **cmd2.py** for examples would think we are using normal `argparse.ArgumentParser` objects. They'd have to read the imports to know otherwise.

 `Cmd2ArgumentParser` makes it obvious that we have a derived class of  `argparse.ArgumentParser`.