### PR TITLE
Changed all uses of sub-command to subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@
     have been deleted
         * The new application lifecycle hook system allows for registration of callbacks to be called at various points
         in the lifecycle and is more powerful and flexible than the previous system
-    * ``alias`` is now a command with sub-commands to create, list, and delete aliases. Therefore its syntax
+    * ``alias`` is now a command with subcommands to create, list, and delete aliases. Therefore its syntax
       has changed. All current alias commands in startup scripts or transcripts will break with this release.
     * `unalias` was deleted since ``alias delete`` replaced it
 
@@ -519,9 +519,9 @@
     *  See the [Argument Processing](http://cmd2.readthedocs.io/en/latest/argument_processing.html) section of the documentation for more information on these decorators
         * Alternatively, see the [argparse_example.py](https://github.com/python-cmd2/cmd2/blob/master/examples/argparse_example.py)
         and [arg_print.py](https://github.com/python-cmd2/cmd2/blob/master/examples/arg_print.py) examples
-    * Added support for Argparse sub-commands when using the **with_argument_parser** or **with_argparser_and_unknown_args** decorators
+    * Added support for Argparse subcommands when using the **with_argument_parser** or **with_argparser_and_unknown_args** decorators
         * See [subcommands.py](https://github.com/python-cmd2/cmd2/blob/master/examples/subcommands.py) for an example of how to use subcommands
-        * Tab-completion of sub-command names is automatically supported
+        * Tab-completion of subcommand names is automatically supported
     * The **__relative_load** command is now hidden from the help menu by default
         * This command is not intended to be called from the command line, only from within scripts
     * The **set** command now has an additional **-a/--all** option to also display read-only settings

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Main Features
 - Macros, which are similar to aliases, but they can contain argument placeholders
 - Ability to run commands at startup from an initialization script
 - Settable environment parameters
-- Parsing commands with arguments using `argparse`, including support for sub-commands
+- Parsing commands with arguments using `argparse`, including support for subcommands
 - Unicode character support
-- Good tab-completion of commands, sub-commands, file system paths, and shell commands
+- Good tab-completion of commands, subcommands, file system paths, and shell commands
 - Automatic tab-completion of `argparse` flags when using one of the `cmd2` `argparse` decorators
 - Support for Python 3.5+ on Windows, macOS, and Linux
 - Trivial to provide built-in help for all commands

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -108,7 +108,7 @@ class AutoCompleter(object):
         self._flag_to_action = {}  # maps flags to the argparse action object
         self._positional_actions = []  # actions for positional arguments (by position index)
 
-        # maps action to sub-command autocompleter:
+        # maps action to subcommand autocompleter:
         #   action -> dict(sub_command -> completer)
         self._positional_completers = {}
 
@@ -264,7 +264,7 @@ class AutoCompleter(object):
                     if pos_index < len(self._positional_actions):
                         action = self._positional_actions[pos_index]
 
-                        # Are we at a sub-command? If so, forward to the matching completer
+                        # Are we at a subcommand? If so, forward to the matching completer
                         if isinstance(action, argparse._SubParsersAction):
                             sub_completers = self._positional_completers[action]
                             if token in sub_completers:
@@ -412,7 +412,7 @@ class AutoCompleter(object):
 
     def complete_command_help(self, tokens: List[str], text: str, line: str, begidx: int, endidx: int) -> List[str]:
         """
-        Supports cmd2's help command in the completion of sub-command names
+        Supports cmd2's help command in the completion of subcommand names
         :param tokens: command line tokens
         :param text: the string prefix we are attempting to match (all matches must begin with it)
         :param line: the current input line with leading whitespace removed
@@ -422,7 +422,7 @@ class AutoCompleter(object):
         """
         for token in tokens[self._token_start_index:]:
             if self._positional_completers:
-                # For now argparse only allows 1 sub-command group per level
+                # For now argparse only allows 1 subcommand group per level
                 # so this will only loop once.
                 for completers in self._positional_completers.values():
                     if token in completers:
@@ -439,7 +439,7 @@ class AutoCompleter(object):
         """
         for token in tokens[self._token_start_index:]:
             if self._positional_completers:
-                # For now argparse only allows 1 sub-command group per level
+                # For now argparse only allows 1 subcommand group per level
                 # so this will only loop once.
                 for completers in self._positional_completers.values():
                     if token in completers:

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -26,7 +26,7 @@ value with no upper bound, use a 1-item tuple (min,)
 
 Tab Completion:
     cmd2 uses its AutoCompleter class to enable argparse-based tab completion on all commands that use the
-    @with_argparse wrappers. Out of the box you get tab completion of commands, sub-commands, and flag names,
+    @with_argparse wrappers. Out of the box you get tab completion of commands, subcommands, and flag names,
     as well as instructive hints about the current argument that print when tab is pressed. In addition,
     you can add tab completion for each argument's values using parameters passed to add_argument().
 
@@ -646,7 +646,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
     def add_subparsers(self, **kwargs):
         """Custom override. Sets a default title if one was not given."""
         if 'title' not in kwargs:
-            kwargs['title'] = 'sub-commands'
+            kwargs['title'] = 'subcommands'
 
         return super().add_subparsers(**kwargs)
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2327,7 +2327,7 @@ class Cmd(cmd.Cmd):
                 if saved_readline_settings is not None:
                     self._restore_readline(saved_readline_settings)
 
-    # -----  Alias sub-command functions -----
+    # -----  Alias subcommand functions -----
 
     def _alias_create(self, args: argparse.Namespace) -> None:
         """Create or overwrite an alias"""
@@ -2392,7 +2392,7 @@ class Cmd(cmd.Cmd):
                     "  macro")
     alias_parser = Cmd2ArgumentParser(description=alias_description, epilog=alias_epilog, prog='alias')
 
-    # Add sub-commands to alias
+    # Add subcommands to alias
     alias_subparsers = alias_parser.add_subparsers()
 
     # alias -> create
@@ -2450,13 +2450,13 @@ class Cmd(cmd.Cmd):
         """Manage aliases"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('alias')
 
-    # -----  Macro sub-command functions -----
+    # -----  Macro subcommand functions -----
 
     def _macro_create(self, args: argparse.Namespace) -> None:
         """Create or overwrite a macro"""
@@ -2572,7 +2572,7 @@ class Cmd(cmd.Cmd):
                     "  alias")
     macro_parser = Cmd2ArgumentParser(description=macro_description, epilog=macro_epilog, prog='macro')
 
-    # Add sub-commands to macro
+    # Add subcommands to macro
     macro_subparsers = macro_parser.add_subparsers()
 
     # macro -> create
@@ -2652,10 +2652,10 @@ class Cmd(cmd.Cmd):
         """Manage macros"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('macro')
 
     def complete_help_command(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
@@ -2676,7 +2676,7 @@ class Cmd(cmd.Cmd):
         if not tokens:
             return []
 
-        # Must have at least 3 args for 'help command sub-command'
+        # Must have at least 3 args for 'help command subcommand'
         if len(tokens) < 3:
             return []
 
@@ -2705,7 +2705,7 @@ class Cmd(cmd.Cmd):
     help_parser = Cmd2ArgumentParser()
     help_parser.add_argument('command', nargs=argparse.OPTIONAL, help="command to retrieve help for",
                              completer_method=complete_help_command)
-    help_parser.add_argument('subcommand', nargs=argparse.REMAINDER, help="sub-command to retrieve help for",
+    help_parser.add_argument('subcommand', nargs=argparse.REMAINDER, help="subcommand to retrieve help for",
                              completer_method=complete_help_subcommand)
     help_parser.add_argument('-v', '--verbose', action='store_true',
                              help="print a list of all commands with descriptions of each")

--- a/docs/features/argument_processing.rst
+++ b/docs/features/argument_processing.rst
@@ -326,19 +326,19 @@ The Namespace is passed by the decorators to the ``argparse`` parsing functions
 which gives your custom code access to the state data it needs for its parsing
 logic.
 
-Sub-commands
+Subcommands
 ------------
 
-Sub-commands are supported for commands using either the ``@with_argparser`` or
+Subcommands are supported for commands using either the ``@with_argparser`` or
 ``@with_argparser_and_unknown_args`` decorator.  The syntax for supporting them
 is based on argparse sub-parsers.
 
-You may add multiple layers of sub-commands for your command. Cmd2 will
-automatically traverse and tab-complete sub-commands for all commands using
+You may add multiple layers of subcommands for your command. Cmd2 will
+automatically traverse and tab-complete subcommands for all commands using
 argparse.
 
 See the subcommands_ and tab_autocompletion_ example to learn more about how to
-use sub-commands in your ``cmd2`` application.
+use subcommands in your ``cmd2`` application.
 
 .. _subcommands: https://github.com/python-cmd2/cmd2/blob/master/examples/subcommands.py
 .. _tab_autocompletion: https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocompletion.py

--- a/examples/scripts/save_help_text.py
+++ b/examples/scripts/save_help_text.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # flake8: noqa F821
 """
-A cmd2 script that saves the help text for every command, sub-command, and topic to a file.
+A cmd2 script that saves the help text for every command, subcommand, and topic to a file.
 This is meant to be run within a cmd2 session using run_pyscript.
 """
 
@@ -14,19 +14,19 @@ ASTERISKS = "********************************************************"
 
 
 def get_sub_commands(parser: argparse.ArgumentParser) -> List[str]:
-    """Get a list of sub-commands for an ArgumentParser"""
+    """Get a list of subcommands for an ArgumentParser"""
     sub_cmds = []
 
-    # Check if this is parser has sub-commands
+    # Check if this is parser has subcommands
     if parser is not None and parser._subparsers is not None:
 
-        # Find the _SubParsersAction for the sub-commands of this parser
+        # Find the _SubParsersAction for the subcommands of this parser
         for action in parser._subparsers._actions:
             if isinstance(action, argparse._SubParsersAction):
                 for sub_cmd, sub_cmd_parser in action.choices.items():
                     sub_cmds.append(sub_cmd)
 
-                    # Look for nested sub-commands
+                    # Look for nested subcommands
                     for nested_sub_cmd in get_sub_commands(sub_cmd_parser):
                         sub_cmds.append('{} {}'.format(sub_cmd, nested_sub_cmd))
 
@@ -94,7 +94,7 @@ def main() -> None:
         add_help_to_file(item, outfile, is_command)
 
         if is_command:
-            # Add any sub-commands
+            # Add any subcommands
             for subcmd in get_sub_commands(getattr(self.cmd_func(item), 'argparser', None)):
                 full_cmd = '{} {}'.format(item, subcmd)
                 add_help_to_file(full_cmd, outfile, is_command)

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # coding=utf-8
-"""A simple example demonstrating how to use Argparse to support sub-commands.
+"""A simple example demonstrating how to use Argparse to support subcommands.
 
 
-This example shows an easy way for a single command to have many sub-commands, each of which takes different arguments
+This example shows an easy way for a single command to have many subcommands, each of which takes different arguments
 and provides separate contextual help.
 """
 import argparse
@@ -13,15 +13,15 @@ sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
 # create the top-level parser for the base command
 base_parser = argparse.ArgumentParser(prog='base')
-base_subparsers = base_parser.add_subparsers(title='sub-commands', help='sub-command help')
+base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
-# create the parser for the "foo" sub-command
+# create the parser for the "foo" subcommand
 parser_foo = base_subparsers.add_parser('foo', help='foo help')
 parser_foo.add_argument('-x', type=int, default=1, help='integer')
 parser_foo.add_argument('y', type=float, help='float')
 parser_foo.add_argument('input_file', type=str, help='Input File')
 
-# create the parser for the "bar" sub-command
+# create the parser for the "bar" subcommand
 parser_bar = base_subparsers.add_parser('bar', help='bar help')
 
 bar_subparsers = parser_bar.add_subparsers(title='layer3', help='help for 3rd layer of commands')
@@ -31,7 +31,7 @@ bar_subparsers.add_parser('apple', help='apple help')
 bar_subparsers.add_parser('artichoke', help='artichoke help')
 bar_subparsers.add_parser('cranberries', help='cranberries help')
 
-# create the parser for the "sport" sub-command
+# create the parser for the "sport" subcommand
 parser_sport = base_subparsers.add_parser('sport', help='sport help')
 sport_arg = parser_sport.add_argument('sport', help='Enter name of a sport', choices=sport_item_strs)
 
@@ -39,15 +39,15 @@ sport_arg = parser_sport.add_argument('sport', help='Enter name of a sport', cho
 # create the top-level parser for the alternate command
 # The alternate command doesn't provide its own help flag
 base2_parser = argparse.ArgumentParser(prog='alternate', add_help=False)
-base2_subparsers = base2_parser.add_subparsers(title='sub-commands', help='sub-command help')
+base2_subparsers = base2_parser.add_subparsers(title='subcommands', help='subcommand help')
 
-# create the parser for the "foo" sub-command
+# create the parser for the "foo" subcommand
 parser_foo2 = base2_subparsers.add_parser('foo', help='foo help')
 parser_foo2.add_argument('-x', type=int, default=1, help='integer')
 parser_foo2.add_argument('y', type=float, help='float')
 parser_foo2.add_argument('input_file', type=str, help='Input File')
 
-# create the parser for the "bar" sub-command
+# create the parser for the "bar" subcommand
 parser_bar2 = base2_subparsers.add_parser('bar', help='bar help')
 
 bar2_subparsers = parser_bar2.add_subparsers(title='layer3', help='help for 3rd layer of commands')
@@ -57,33 +57,33 @@ bar2_subparsers.add_parser('apple', help='apple help')
 bar2_subparsers.add_parser('artichoke', help='artichoke help')
 bar2_subparsers.add_parser('cranberries', help='cranberries help')
 
-# create the parser for the "sport" sub-command
+# create the parser for the "sport" subcommand
 parser_sport2 = base2_subparsers.add_parser('sport', help='sport help')
 sport2_arg = parser_sport2.add_argument('sport', help='Enter name of a sport', choices=sport_item_strs)
 
 
 class SubcommandsExample(cmd2.Cmd):
     """
-    Example cmd2 application where we a base command which has a couple sub-commands
-    and the "sport" sub-command has tab completion enabled.
+    Example cmd2 application where we a base command which has a couple subcommands
+    and the "sport" subcommand has tab completion enabled.
     """
     def __init__(self):
         super().__init__()
 
-    # sub-command functions for the base command
+    # subcommand functions for the base command
     def base_foo(self, args):
-        """foo sub-command of base command"""
+        """foo subcommand of base command"""
         self.poutput(args.x * args.y)
 
     def base_bar(self, args):
-        """bar sub-command of base command"""
+        """bar subcommand of base command"""
         self.poutput('((%s))' % args.z)
 
     def base_sport(self, args):
-        """sport sub-command of base command"""
+        """sport subcommand of base command"""
         self.poutput('Sport is {}'.format(args.sport))
 
-    # Set handler functions for the sub-commands
+    # Set handler functions for the subcommands
     parser_foo.set_defaults(func=base_foo)
     parser_bar.set_defaults(func=base_bar)
     parser_sport.set_defaults(func=base_sport)
@@ -93,10 +93,10 @@ class SubcommandsExample(cmd2.Cmd):
         """Base command help"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('base')
 
     @cmd2.with_argparser(base2_parser)
@@ -104,10 +104,10 @@ class SubcommandsExample(cmd2.Cmd):
         """Alternate command help"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('alternate')
 
 

--- a/examples/tab_autocompletion.py
+++ b/examples/tab_autocompletion.py
@@ -22,7 +22,7 @@ def query_actors() -> List[str]:
 
 
 class TabCompleteExample(cmd2.Cmd):
-    """ Example cmd2 application where we a base command which has a couple sub-commands."""
+    """ Example cmd2 application where we a base command which has a couple subcommands."""
 
     CAT_AUTOCOMPLETE = 'AutoComplete Examples'
 
@@ -252,7 +252,7 @@ class TabCompleteExample(cmd2.Cmd):
     @cmd2.with_category(CAT_AUTOCOMPLETE)
     @cmd2.with_argparser(video_parser)
     def do_video(self, args):
-        """Video management command demonstrates multiple layers of sub-commands being handled by AutoCompleter"""
+        """Video management command demonstrates multiple layers of subcommands being handled by AutoCompleter"""
         func = getattr(args, 'func', None)
         if func is not None:
             # Call whatever subcommand function was selected

--- a/examples/tab_completion.py
+++ b/examples/tab_completion.py
@@ -14,7 +14,7 @@ sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
 
 class TabCompleteExample(cmd2.Cmd):
-    """ Example cmd2 application where we a base command which has a couple sub-commands."""
+    """ Example cmd2 application where we a base command which has a couple subcommands."""
 
     def __init__(self):
         super().__init__()

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -192,31 +192,31 @@ def test_preservelist(argparse_app):
 
 
 class SubcommandApp(cmd2.Cmd):
-    """ Example cmd2 application where we a base command which has a couple sub-commands."""
+    """ Example cmd2 application where we a base command which has a couple subcommands."""
 
     def __init__(self):
         cmd2.Cmd.__init__(self)
 
-    # sub-command functions for the base command
+    # subcommand functions for the base command
     def base_foo(self, args):
-        """foo sub-command of base command"""
+        """foo subcommand of base command"""
         self.poutput(args.x * args.y)
 
     def base_bar(self, args):
-        """bar sub-command of base command"""
+        """bar subcommand of base command"""
         self.poutput('((%s))' % args.z)
 
     # create the top-level parser for the base command
     base_parser = argparse.ArgumentParser(prog='base')
-    base_subparsers = base_parser.add_subparsers(title='sub-commands', help='sub-command help')
+    base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
-    # create the parser for the "foo" sub-command
+    # create the parser for the "foo" subcommand
     parser_foo = base_subparsers.add_parser('foo', help='foo help')
     parser_foo.add_argument('-x', type=int, default=1, help='integer')
     parser_foo.add_argument('y', type=float, help='float')
     parser_foo.set_defaults(func=base_foo)
 
-    # create the parser for the "bar" sub-command
+    # create the parser for the "bar" subcommand
     parser_bar = base_subparsers.add_parser('bar', help='bar help')
     parser_bar.add_argument('z', help='string')
     parser_bar.set_defaults(func=base_bar)
@@ -226,10 +226,10 @@ class SubcommandApp(cmd2.Cmd):
         """Base command help"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('base')
 
 @pytest.fixture

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -65,14 +65,14 @@ class AutoCompleteTester(cmd2.Cmd):
     # Top level parser for music command
     music_parser = Cmd2ArgumentParser(description='Manage music', prog='music')
 
-    # Add sub-commands to music
+    # Add subcommands to music
     music_subparsers = music_parser.add_subparsers()
 
     # music -> create
     music_create_parser = music_subparsers.add_parser('create', help='Create music')
     music_create_parser.set_defaults(func=_music_create)
 
-    # Add sub-commands to music -> create
+    # Add subcommands to music -> create
     music_create_subparsers = music_create_parser.add_subparsers()
 
     # music -> create -> jazz
@@ -88,10 +88,10 @@ class AutoCompleteTester(cmd2.Cmd):
         """Music command"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             # noinspection PyTypeChecker
             self.do_help('music')
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1030,7 +1030,7 @@ def test_cmd2_help_subcommand_completion_nomatch(sc_app):
     assert first_match is None
 
 def test_subcommand_tab_completion(sc_app):
-    # This makes sure the correct completer for the sport sub-command is called
+    # This makes sure the correct completer for the sport subcommand is called
     text = 'Foot'
     line = 'base sport {}'.format(text)
     endidx = len(line)
@@ -1043,8 +1043,8 @@ def test_subcommand_tab_completion(sc_app):
 
 
 def test_subcommand_tab_completion_with_no_completer(sc_app):
-    # This tests what happens when a sub-command has no completer
-    # In this case, the foo sub-command has no completer defined
+    # This tests what happens when a subcommand has no completer
+    # In this case, the foo subcommand has no completer defined
     text = 'Foot'
     line = 'base foo {}'.format(text)
     endidx = len(line)
@@ -1071,42 +1071,42 @@ def test_subcommand_tab_completion_space_in_text(sc_app):
 
 class SubcommandsWithUnknownExample(cmd2.Cmd):
     """
-    Example cmd2 application where we a base command which has a couple sub-commands
-    and the "sport" sub-command has tab completion enabled.
+    Example cmd2 application where we a base command which has a couple subcommands
+    and the "sport" subcommand has tab completion enabled.
     """
 
     def __init__(self):
         cmd2.Cmd.__init__(self)
 
-    # sub-command functions for the base command
+    # subcommand functions for the base command
     def base_foo(self, args):
-        """foo sub-command of base command"""
+        """foo subcommand of base command"""
         self.poutput(args.x * args.y)
 
     def base_bar(self, args):
-        """bar sub-command of base command"""
+        """bar subcommand of base command"""
         self.poutput('((%s))' % args.z)
 
     def base_sport(self, args):
-        """sport sub-command of base command"""
+        """sport subcommand of base command"""
         self.poutput('Sport is {}'.format(args.sport))
 
     # create the top-level parser for the base command
     base_parser = argparse.ArgumentParser(prog='base')
-    base_subparsers = base_parser.add_subparsers(title='sub-commands', help='sub-command help')
+    base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
-    # create the parser for the "foo" sub-command
+    # create the parser for the "foo" subcommand
     parser_foo = base_subparsers.add_parser('foo', help='foo help')
     parser_foo.add_argument('-x', type=int, default=1, help='integer')
     parser_foo.add_argument('y', type=float, help='float')
     parser_foo.set_defaults(func=base_foo)
 
-    # create the parser for the "bar" sub-command
+    # create the parser for the "bar" subcommand
     parser_bar = base_subparsers.add_parser('bar', help='bar help')
     parser_bar.add_argument('z', help='string')
     parser_bar.set_defaults(func=base_bar)
 
-    # create the parser for the "sport" sub-command
+    # create the parser for the "sport" subcommand
     parser_sport = base_subparsers.add_parser('sport', help='sport help')
     sport_arg = parser_sport.add_argument('sport', help='Enter name of a sport', choices=sport_item_strs)
 
@@ -1115,10 +1115,10 @@ class SubcommandsWithUnknownExample(cmd2.Cmd):
         """Base command help"""
         func = getattr(args, 'func', None)
         if func is not None:
-            # Call whatever sub-command function was selected
+            # Call whatever subcommand function was selected
             func(self, args)
         else:
-            # No sub-command was provided, so call help
+            # No subcommand was provided, so call help
             self.do_help('base')
 
 
@@ -1222,7 +1222,7 @@ def test_cmd2_help_subcommand_completion_nomatch_scu(scu_app):
 
 
 def test_subcommand_tab_completion_scu(scu_app):
-    # This makes sure the correct completer for the sport sub-command is called
+    # This makes sure the correct completer for the sport subcommand is called
     text = 'Foot'
     line = 'base sport {}'.format(text)
     endidx = len(line)
@@ -1235,8 +1235,8 @@ def test_subcommand_tab_completion_scu(scu_app):
 
 
 def test_subcommand_tab_completion_with_no_completer_scu(scu_app):
-    # This tests what happens when a sub-command has no completer
-    # In this case, the foo sub-command has no completer defined
+    # This tests what happens when a subcommand has no completer
+    # In this case, the foo subcommand has no completer defined
     text = 'Foot'
     line = 'base foo {}'.format(text)
     endidx = len(line)


### PR DESCRIPTION
Like `argparse`, our use of **sub-command** and **subcommand** was inconsistent in documentation. Since **subcommand** seems to be the common spelling, I changed all occurrences to that.