### PR TITLE
Formatting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
     * `ACArgumentParser` is now called `Cmd2ArgumentParser`
     * Moved `basic_complete` to utils.py
     * Made optional arguments on the following completer methods keyword-only:
-    `delimiter_complete`, `flag_based_complete`, `index_based_complete`. `path_complete`, `shell_cmd_complete`
+    `delimiter_complete`, `flag_based_complete`, `index_based_complete`, `path_complete`, `shell_cmd_complete`
     * Renamed history option from `--output-file` to `--output_file`
     * Renamed `matches_sort_key` to `default_sort_key`. This value determines the default sort ordering of string
     results like alias, command, category, macro, settable, and shortcut names. Unsorted tab-completion results

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2182,8 +2182,10 @@ class Cmd(cmd.Cmd):
 
             return self.do_shell(statement.command_and_args)
         else:
+            err_msg = self.default_error.format(statement.command)
+
             # Set apply_style to False so default_error's style is not overridden
-            self.perror(self.default_error.format(statement.command), apply_style=False)
+            self.perror(err_msg, apply_style=False)
 
     def _pseudo_raw_input(self, prompt: str) -> str:
         """Began life as a copy of cmd's cmdloop; like raw_input but
@@ -2736,8 +2738,10 @@ class Cmd(cmd.Cmd):
 
             # If there is no help information then print an error
             elif help_func is None and (func is None or not func.__doc__):
+                err_msg = self.help_error.format(args.command)
+
                 # Set apply_style to False so help_error's style is not overridden
-                self.perror(self.help_error.format(args.command), apply_style=False)
+                self.perror(err_msg, apply_style=False)
 
             # Otherwise delegate to cmd base class do_help()
             else:


### PR DESCRIPTION
Replaced uses of `ansi_aware_write()` with appropriate wrapper functions.
Made help command format for argparse commands the same as using "command -h"