### PR TITLE
Fixed inconsistent treatment of allow_redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.9.16 (TBD, 2019)
+* Bug Fixes
+    * Fixed inconsistent parsing/tab completion behavior based on the value of `allow_redirection`. This flag is
+    only meant to be a security setting that prevents redirection of stdout and should not alter parsing logic.
 * Enhancements
     * Raise `TypeError` if trying to set choices/completions on argparse action that accepts no arguments
     * Create directory for the persistent history file if it does not already exist

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -245,7 +245,6 @@ class StatementParser:
     the expansion.
     """
     def __init__(self,
-                 allow_redirection: bool = True,
                  terminators: Optional[Iterable[str]] = None,
                  multiline_commands: Optional[Iterable[str]] = None,
                  aliases: Optional[Dict[str, str]] = None,
@@ -257,13 +256,11 @@ class StatementParser:
         * multiline commands
         * shortcuts
 
-        :param allow_redirection: should redirection and pipes be allowed?
         :param terminators: iterable containing strings which should terminate commands
         :param multiline_commands: iterable containing the names of commands that accept multiline input
         :param aliases: dictionary containing aliases
         :param shortcuts: dictionary containing shortcuts
         """
-        self.allow_redirection = allow_redirection
         if terminators is None:
             self.terminators = (constants.MULTILINE_TERMINATOR,)
         else:
@@ -690,8 +687,7 @@ class StatementParser:
         """
         punctuation = []
         punctuation.extend(self.terminators)
-        if self.allow_redirection:
-            punctuation.extend(constants.REDIRECTION_CHARS)
+        punctuation.extend(constants.REDIRECTION_CHARS)
 
         punctuated_tokens = []
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -558,7 +558,7 @@ def test_feedback_to_output_false(base_app):
 
 def test_disallow_redirection(base_app):
     # Set allow_redirection to False
-    base_app.statement_parser.allow_redirection = False
+    base_app.allow_redirection = False
 
     filename = 'test_allow_redirect.txt'
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -695,7 +695,6 @@ def test_tokens_for_completion_redirect(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    cmd2_app.allow_redirection = True
     expected_tokens = ['command', '|', '<', '>>', 'file']
     expected_raw_tokens = ['command', '|', '<', '>>', 'file']
 
@@ -712,20 +711,6 @@ def test_tokens_for_completion_quoted_redirect(cmd2_app):
     cmd2_app.statement_parser.redirection = True
     expected_tokens = ['command', '>file']
     expected_raw_tokens = ['command', '">file']
-
-    tokens, raw_tokens = cmd2_app.tokens_for_completion(line, begidx, endidx)
-    assert expected_tokens == tokens
-    assert expected_raw_tokens == raw_tokens
-
-def test_tokens_for_completion_redirect_off(cmd2_app):
-    text = '>file'
-    line = 'command {}'.format(text)
-    endidx = len(line)
-    begidx = endidx - len(text)
-
-    cmd2_app.statement_parser.allow_redirection = False
-    expected_tokens = ['command', '>file']
-    expected_raw_tokens = ['command', '>file']
 
     tokens, raw_tokens = cmd2_app.tokens_for_completion(line, begidx, endidx)
     assert expected_tokens == tokens

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -268,7 +268,6 @@ def histitem():
 def parser():
     from cmd2.parsing import StatementParser
     parser = StatementParser(
-        allow_redirection=True,
         terminators=[';', '&'],
         multiline_commands=['multiline'],
         aliases={'helpalias': 'help',

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -13,7 +13,6 @@ from cmd2.parsing import StatementParser, shlex_split
 @pytest.fixture
 def parser():
     parser = StatementParser(
-        allow_redirection=True,
         terminators=[';', '&'],
         multiline_commands=['multiline'],
         aliases={'helpalias': 'help',


### PR DESCRIPTION
Fixed inconsistent parsing/tab completion behavior based on the value of `allow_redirection`. This flag is only meant to be a security setting that prevents redirection of stdout and should not alter parsing logic.

Fixed #746 