### PR TITLE
Added terminators to completion delimiters

### DIFF
--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -379,7 +379,7 @@ class StatementParser:
         tokens = shlex_split(line)
 
         # custom lexing
-        tokens = self._split_on_punctuation(tokens)
+        tokens = self.split_on_punctuation(tokens)
         return tokens
 
     def parse(self, line: str, *, expand: bool = True) -> Statement:
@@ -675,7 +675,7 @@ class StatementParser:
 
         return command, args
 
-    def _split_on_punctuation(self, tokens: List[str]) -> List[str]:
+    def split_on_punctuation(self, tokens: List[str]) -> List[str]:
         """Further splits tokens from a command line using punctuation characters
 
         Punctuation characters are treated as word breaks when they are in

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -689,26 +689,27 @@ def test_tokens_for_completion_unclosed_quote(cmd2_app):
     assert expected_tokens == tokens
     assert expected_raw_tokens == raw_tokens
 
-def test_tokens_for_completion_redirect(cmd2_app):
-    text = '>>file'
-    line = 'command | < {}'.format(text)
+def test_tokens_for_completion_punctuation(cmd2_app):
+    """Test that redirectors and terminators are word delimiters"""
+    text = 'file'
+    line = 'command | < ;>>{}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    expected_tokens = ['command', '|', '<', '>>', 'file']
-    expected_raw_tokens = ['command', '|', '<', '>>', 'file']
+    expected_tokens = ['command', '|', '<', ';', '>>', 'file']
+    expected_raw_tokens = ['command', '|', '<', ';', '>>', 'file']
 
     tokens, raw_tokens = cmd2_app.tokens_for_completion(line, begidx, endidx)
     assert expected_tokens == tokens
     assert expected_raw_tokens == raw_tokens
 
-def test_tokens_for_completion_quoted_redirect(cmd2_app):
+def test_tokens_for_completion_quoted_punctuation(cmd2_app):
+    """Test that quoted punctuation characters are not word delimiters"""
     text = '>file'
     line = 'command "{}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
 
-    cmd2_app.statement_parser.redirection = True
     expected_tokens = ['command', '>file']
     expected_raw_tokens = ['command', '">file']
 


### PR DESCRIPTION
Tab completion should have always been using terminators as word delimiters.
This change also resulted in eliminating duplicated code since cmd2's `tokens_for_completion()` can just call  `StatementParser.split_on_punctuation()` now.

@kotfu @tleonhardt What are your thoughts on me changing `StatementParser.split_on_punctuation()` to public?