### PR TITLE
Removed ability for aliases and macros to share names with commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     * Added `set_choices_function()`, `set_choices_method()`, `set_completer_function()`, and `set_completer_method()`
     to support cases where this functionality needs to be added to an argparse action outside of the normal
     `parser.add_argument()` call.
+* Breaking Changes
+    * Aliases and macros can no longer have the same name as a command
 
 ## 0.9.15 (July 24, 2019)
 * Bug Fixes

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -356,20 +356,17 @@ class StatementParser:
                 errmsg = ''
         return valid, errmsg
 
-    def tokenize(self, line: str, *, expand: bool = True) -> List[str]:
+    def tokenize(self, line: str) -> List[str]:
         """
         Lex a string into a list of tokens. Shortcuts and aliases are expanded and comments are removed
 
         :param line: the command line being lexed
-        :param expand: If True, then aliases and shortcuts will be expanded.
-                       Set this to False if the command token should not be altered. Defaults to True.
         :return: A list of tokens
         :raises ValueError if there are unclosed quotation marks.
         """
 
         # expand shortcuts and aliases
-        if expand:
-            line = self._expand(line)
+        line = self._expand(line)
 
         # check if this line is a comment
         if line.lstrip().startswith(constants.COMMENT_CHAR):
@@ -382,15 +379,13 @@ class StatementParser:
         tokens = self.split_on_punctuation(tokens)
         return tokens
 
-    def parse(self, line: str, *, expand: bool = True) -> Statement:
+    def parse(self, line: str) -> Statement:
         """
         Tokenize the input and parse it into a Statement object, stripping
         comments, expanding aliases and shortcuts, and extracting output
         redirection directives.
 
         :param line: the command line being parsed
-        :param expand: If True, then aliases and shortcuts will be expanded.
-                       Set this to False if the command token should not be altered. Defaults to True.
         :return: the created Statement
         :raises ValueError if there are unclosed quotation marks
         """
@@ -407,7 +402,7 @@ class StatementParser:
         arg_list = []
 
         # lex the input into a list of tokens
-        tokens = self.tokenize(line, expand=expand)
+        tokens = self.tokenize(line)
 
         # of the valid terminators, find the first one to occur in the input
         terminator_pos = len(tokens) + 1
@@ -529,7 +524,7 @@ class StatementParser:
                               output_to=output_to)
         return statement
 
-    def parse_command_only(self, rawinput: str, *, expand: bool = True) -> Statement:
+    def parse_command_only(self, rawinput: str) -> Statement:
         """Partially parse input into a Statement object.
 
         The command is identified, and shortcuts and aliases are expanded.
@@ -554,15 +549,12 @@ class StatementParser:
         whitespace.
 
         :param rawinput: the command line as entered by the user
-        :param expand: If True, then aliases and shortcuts will be expanded.
-                       Set this to False if the command token should not be altered. Defaults to True.
         :return: the created Statement
         """
         line = rawinput
 
         # expand shortcuts and aliases
-        if expand:
-            line = self._expand(rawinput)
+        line = self._expand(rawinput)
 
         command = ''
         args = ''
@@ -616,7 +608,7 @@ class StatementParser:
         """
         # Check if to_parse needs to be converted to a Statement
         if not isinstance(to_parse, Statement):
-            to_parse = self.parse(command_name + ' ' + to_parse, expand=False)
+            to_parse = self.parse(command_name + ' ' + to_parse)
 
         if preserve_quotes:
             return to_parse, to_parse.arg_list

--- a/docs/features/shortcuts_aliases_macros.rst
+++ b/docs/features/shortcuts_aliases_macros.rst
@@ -65,6 +65,7 @@ Use ``alias delete`` to remove aliases
 
 For more details run: ``help alias delete``
 
+Note: Aliases cannot have the same name as a command or macro
 
 Macros
 ------
@@ -93,3 +94,5 @@ sessions.
 For more details on listing macros run: ``help macro list``
 
 For more details on deleting macros run: ``help macro delete``
+
+Note: Macros cannot have the same name as a command or alias

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1625,6 +1625,10 @@ def test_alias_create_invalid_name(base_app, alias_name, capsys):
     out, err = run_cmd(base_app, 'alias create {} help'.format(alias_name))
     assert "Invalid alias name" in err[0]
 
+def test_alias_create_with_command_name(base_app):
+    out, err = run_cmd(base_app, 'alias create help stuff')
+    assert "Alias cannot have the same name as a command" in err[0]
+
 def test_alias_create_with_macro_name(base_app):
     macro = "my_macro"
     run_cmd(base_app, 'macro create {} help'.format(macro))
@@ -1713,18 +1717,15 @@ def test_macro_create_invalid_name(base_app, macro_name):
     out, err = run_cmd(base_app, 'macro create {} help'.format(macro_name))
     assert "Invalid macro name" in err[0]
 
+def test_macro_create_with_command_name(base_app):
+    out, err = run_cmd(base_app, 'macro create help stuff')
+    assert "Macro cannot have the same name as a command" in err[0]
+
 def test_macro_create_with_alias_name(base_app):
     macro = "my_macro"
     run_cmd(base_app, 'alias create {} help'.format(macro))
     out, err = run_cmd(base_app, 'macro create {} help'.format(macro))
     assert "Macro cannot have the same name as an alias" in err[0]
-
-def test_macro_create_with_command_name(multiline_app):
-    out, err = run_cmd(multiline_app, 'macro create help stuff')
-    assert out == normalize("Macro 'help' created")
-
-    out, err = run_cmd(multiline_app, 'macro create orate stuff')
-    assert "Macro cannot have the same name as a multiline command" in err[0]
 
 def test_macro_create_with_args(base_app):
     # Create the macro
@@ -1842,37 +1843,6 @@ def test_nonexistent_macro(base_app):
         exception = e
 
     assert exception is not None
-
-def test_input_line_to_statement_expand(base_app):
-    # Enable/Disable expansion of shortcuts
-    line = '!ls'
-    statement = base_app._input_line_to_statement(line, expand=True)
-    assert statement.command == 'shell'
-
-    statement = base_app._input_line_to_statement(line, expand=False)
-    assert statement.command == '!ls'
-
-    # Enable/Disable expansion of aliases
-    run_cmd(base_app, 'alias create help macro')
-
-    line = 'help'
-    statement = base_app._input_line_to_statement(line, expand=True)
-    assert statement.command == 'macro'
-
-    statement = base_app._input_line_to_statement(line, expand=False)
-    assert statement.command == 'help'
-
-    run_cmd(base_app, 'alias delete help')
-
-    # Enable/Disable expansion of macros
-    run_cmd(base_app, 'macro create help alias')
-
-    line = 'help'
-    statement = base_app._input_line_to_statement(line, expand=True)
-    assert statement.command == 'alias'
-
-    statement = base_app._input_line_to_statement(line, expand=False)
-    assert statement.command == 'help'
 
 def test_ppaged(outsim_app):
     msg = 'testing...'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -604,17 +604,9 @@ def test_empty_statement_raises_exception():
     ('l', 'shell', 'ls -al')
 ])
 def test_parse_alias_and_shortcut_expansion(parser, line, command, args):
-    # Test first with expansion
     statement = parser.parse(line)
     assert statement.command == command
     assert statement == args
-    assert statement.args == statement
-
-    # Now allow no expansion
-    tokens = shlex_split(line)
-    statement = parser.parse(line, expand=False)
-    assert statement.command == tokens[0]
-    assert shlex_split(statement) == tokens[1:]
     assert statement.args == statement
 
 def test_parse_alias_on_multiline_command(parser):


### PR DESCRIPTION
Closes #751 
This will help avoid confusion for both developers and users.

Developers won't have to worry that calling the onecmd() family of functions will run a different command than expected because it was aliased. Each of these functions was simplified by removing their **expand** boolean argument. That results in less maintenance.

User will always know what command they are running if a command name is used since these names can no longer be used for aliases or macros.