### PR TITLE
Disabled tab completion during a select call

### DIFF
--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -639,7 +639,7 @@ def _expected_no_editor_error():
 
     expected_text = normalize("""
 EXCEPTION of type '{}' occurred with message: 'Please use 'set editor' to specify your text editing program of choice.'
-To enable full traceback, run the following command:  'set debug true'
+To enable full traceback, run the following command: 'set debug true'
 """.format(expected_exception))
 
     return expected_text
@@ -1098,6 +1098,7 @@ def test_select_invalid_option_too_big(select_app):
     arg = 'Sauce? '
     calls = [mock.call(arg), mock.call(arg)]
     m.assert_has_calls(calls)
+    assert m.call_count == 2
 
     # And verify the expected output to stdout
     assert out == expected
@@ -1122,6 +1123,7 @@ def test_select_invalid_option_too_small(select_app):
     arg = 'Sauce? '
     calls = [mock.call(arg), mock.call(arg)]
     m.assert_has_calls(calls)
+    assert m.call_count == 2
 
     # And verify the expected output to stdout
     assert out == expected
@@ -1181,6 +1183,19 @@ Charm us with the {}...
     # And verify the expected output to stdout
     assert out == expected
 
+def test_select_eof(select_app):
+    # Ctrl-D during select causes an EOFError that just reprompts the user
+    m = mock.MagicMock(name='input', side_effect=[EOFError, 2])
+    builtins.input = m
+
+    food = 'fish'
+    out, err = run_cmd(select_app, "eat {}".format(food))
+
+    # Make sure our mock was called exactly twice with the expected arguments
+    arg = 'Sauce? '
+    calls = [mock.call(arg), mock.call(arg)]
+    m.assert_has_calls(calls)
+    assert m.call_count == 2
 
 class HelpNoDocstringApp(cmd2.Cmd):
     greet_parser = argparse.ArgumentParser()


### PR DESCRIPTION
Disabled tab completion during a select call.
Added graceful handling of Ctrl-D during select. It now reprompts the user.