### PR TITLE
Verifying command names in __init__

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -448,6 +448,12 @@ class Cmd(cmd.Cmd):
                                                 multiline_commands=multiline_commands,
                                                 shortcuts=shortcuts)
 
+        # Verify commands don't have invalid names (like starting with a shortcut)
+        for cmd in self.get_all_commands():
+            valid, errmsg = self.statement_parser.is_valid_command(cmd)
+            if not valid:
+                raise ValueError("Invalid command name {!r}: {}".format(cmd, errmsg))
+
         # Stores results from the last command run to enable usage of results in a Python script or interactive console
         # Built-in commands don't make use of this.  It is purely there for user-defined commands and convenience.
         self.last_result = None

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -449,10 +449,10 @@ class Cmd(cmd.Cmd):
                                                 shortcuts=shortcuts)
 
         # Verify commands don't have invalid names (like starting with a shortcut)
-        for cmd in self.get_all_commands():
-            valid, errmsg = self.statement_parser.is_valid_command(cmd)
+        for cur_cmd in self.get_all_commands():
+            valid, errmsg = self.statement_parser.is_valid_command(cur_cmd)
             if not valid:
-                raise ValueError("Invalid command name {!r}: {}".format(cmd, errmsg))
+                raise ValueError("Invalid command name {!r}: {}".format(cur_cmd, errmsg))
 
         # Stores results from the last command run to enable usage of results in a Python script or interactive console
         # Built-in commands don't make use of this.  It is purely there for user-defined commands and convenience.

--- a/docs/features/shortcuts_aliases_macros.rst
+++ b/docs/features/shortcuts_aliases_macros.rst
@@ -38,6 +38,7 @@ To define more shortcuts, update the dict ``App.shortcuts`` with the
   updating the ``shortcuts`` attribute  This warning applies in general to many
   other attributes which are not settable at runtime.
 
+Note: Command, alias, and macro names cannot start with a shortcut
 
 Aliases
 -------

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -87,6 +87,10 @@ def test_base_shortcuts(base_app):
     expected = normalize(SHORTCUTS_TXT)
     assert out == expected
 
+def test_command_starts_with_shortcut():
+    with pytest.raises(ValueError) as excinfo:
+        app = cmd2.Cmd(shortcuts={'help': 'fake'})
+    assert "Invalid command name 'help'" in str(excinfo.value)
 
 def test_base_show(base_app):
     # force editor to be 'vim' so test is repeatable across platforms


### PR DESCRIPTION
Preventing things like commands that begin with a shortcut