### PR TITLE
Fixed a bug when using WSL when all Windows paths have been removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.9.17 (TBD, 2019)
+* Bug Fixes
+    * Fixed a bug when using WSL when all Windows paths have been removed from $PATH
 * Enhancements
     * No longer treating empty text scripts as an error condition
 

--- a/cmd2/clipboard.py
+++ b/cmd2/clipboard.py
@@ -10,7 +10,8 @@ from pyperclip import PyperclipException
 try:
     # Try getting the contents of the clipboard
     _ = pyperclip.paste()
-except PyperclipException:
+except (PyperclipException, FileNotFoundError):
+    # NOTE: FileNotFoundError is for Windows Subsystem for Linux (WSL) when Windows paths are removed from $PATH
     can_clip = False
 else:
     can_clip = True


### PR DESCRIPTION
Fixed a bug when using WSL when all Windows paths have been removed from $PATH.

This is a known [Pyperclip Issue](https://github.com/asweigart/pyperclip/issues/144) which ideally should be fixed in Pyperclip.  That being said, maintenance on Pyperclip can be a bit slow.  So we will go ahead and kludge around this issue in `cmd2` in order to provide the best possible experience for our users.

Closes #760 