### PR TITLE
Missing subcommand no longer prints all help text

### DIFF
--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1620,7 +1620,8 @@ def test_get_settable_completion_items(base_app):
 
 def test_alias_no_subcommand(base_app):
     out, err = run_cmd(base_app, 'alias')
-    assert "Usage: alias [-h]" in out[0]
+    assert "Usage: alias [-h]" in err[0]
+    assert "Error: the following arguments are required: subcommand" in err[1]
 
 def test_alias_create(base_app):
     # Create the alias
@@ -1713,7 +1714,8 @@ def test_multiple_aliases(base_app):
 
 def test_macro_no_subcommand(base_app):
     out, err = run_cmd(base_app, 'macro')
-    assert "Usage: macro [-h]" in out[0]
+    assert "Usage: macro [-h]" in err[0]
+    assert "Error: the following arguments are required: subcommand" in err[1]
 
 def test_macro_create(base_app):
     # Create the macro

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1179,7 +1179,7 @@ def test_cmd2_help_subcommand_completion_with_flags_before_command(scu_app):
     first_match = complete_tester(text, line, begidx, endidx, scu_app)
     assert first_match is not None and scu_app.completion_matches == ['bar', 'foo', 'sport']
 
-def test_complete_help_subcommand_with_blank_command(scu_app):
+def test_complete_help_subcommands_with_blank_command(scu_app):
     text = ''
     line = 'help "" {}'.format(text)
     endidx = len(line)

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -224,13 +224,13 @@ def test_generate_transcript_stop(capsys):
     os.close(fd)
 
     # This should run all commands
-    commands = ['help', 'alias']
+    commands = ['help', 'set']
     app._generate_transcript(commands, transcript_fname)
     _, err = capsys.readouterr()
     assert err.startswith("2 commands")
 
     # Since quit returns True for stop, only the first 2 commands will run
-    commands = ['help', 'quit', 'alias']
+    commands = ['help', 'quit', 'set']
     app._generate_transcript(commands, transcript_fname)
     _, err = capsys.readouterr()
     assert err.startswith("Command 2 triggered a stop")


### PR DESCRIPTION
No longer printing all help text for alias and macro when the subcommand is omitted. Instead allow argparse to handle the error.

This was done to simplify our code and make error handling consistent across commands.