### PR TITLE
Fixed ValueError exception when opening old history file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.19 (TBD, 2019)
+* Bug Fixes
+    * Fixed `ValueError` exception which could occur when an old format persistent history file is loaded with new `cmd2`
+
 ## 0.9.18 (October 1, 2019)
 * Bug Fixes
     * Fixed bug introduced in 0.9.17 where help functions for hidden and disabled commands were not being filtered

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3592,7 +3592,8 @@ class Cmd(cmd.Cmd):
         try:
             with open(hist_file, 'rb') as fobj:
                 history = pickle.load(fobj)
-        except (AttributeError, EOFError, FileNotFoundError, ImportError, IndexError, KeyError, pickle.UnpicklingError):
+        except (AttributeError, EOFError, FileNotFoundError, ImportError, IndexError, KeyError, ValueError,
+                pickle.UnpicklingError):
             # If any non-operating system error occurs when attempting to unpickle, just use an empty history
             pass
         except OSError as ex:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3594,7 +3594,7 @@ class Cmd(cmd.Cmd):
                 history = pickle.load(fobj)
         except (AttributeError, EOFError, FileNotFoundError, ImportError, IndexError, KeyError, ValueError,
                 pickle.UnpicklingError):
-            # If any non-operating system error occurs when attempting to unpickle, just use an empty history
+            # If any of these errors occur when attempting to unpickle, just use an empty history
             pass
         except OSError as ex:
             msg = "Can not read persistent history file '{}': {}"


### PR DESCRIPTION
Fixed `ValueError` exception which can occur when opening an old format persistent history file with a new version of `cmd2`.

Closes #785 