### PR TITLE
Script check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.20 (TBD, 2019)
+* Enhancements
+    * Send all startup script paths to run_script. Previously we didn't do this if the file was empty, but that
+    showed no record of the run_script command in history. 
+
 ## 0.9.19 (October 14, 2019)
 * Bug Fixes
     * Fixed `ValueError` exception which could occur when an old format persistent history file is loaded with new `cmd2`

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -498,10 +498,10 @@ class Cmd(cmd.Cmd):
         # Commands that will run at the beginning of the command loop
         self._startup_commands = []
 
-        # If a startup script is provided, then execute it in the startup commands
+        # If a startup script is provided and exists, then execute it in the startup commands
         if startup_script:
             startup_script = os.path.abspath(os.path.expanduser(startup_script))
-            if os.path.exists(startup_script) and os.path.getsize(startup_script) > 0:
+            if os.path.exists(startup_script):
                 self._startup_commands.append("run_script '{}'".format(startup_script))
 
         # Transcript files to run instead of interactive command loop


### PR DESCRIPTION
Send all startup script paths to run_script. Previously we didn't do this if the file was empty, but that showed no record of the run_script command in history.