### PR TITLE
Attempt at fixing stuck AppVeyor Windows unit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,4 +32,4 @@ install:
   - "python -m pip install --upgrade pip wheel setuptools tox"
 
 test_script:
-- "tox -e %TOXENV%"
+- "echo y | tox -e %TOXENV%"


### PR DESCRIPTION
Seeing if adding a "echo y |" unit test command helps.  Only time will tell if this really fixes the problem.