### PR TITLE
ipy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.9.20 (TBD, 2019)
+* Bug Fixes
+    * Fixed bug where setting `use_ipython` to False removed ipy command from the entire `cmd2.Cmd` class instead of
+    just the instance being created
 * Enhancements
     * Send all startup script paths to run_script. Previously we didn't do this if the file was empty, but that
     showed no record of the run_script command in history. 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -368,10 +368,10 @@ class Cmd(cmd.Cmd):
         :param shortcuts: dictionary containing shortcuts for commands. If not supplied, then defaults to
                           constants.DEFAULT_SHORTCUTS.
         """
-        # If use_ipython is False, make sure the do_ipy() method doesn't exit
+        # If use_ipython is False, make sure the ipy command isn't available in this instance
         if not use_ipython:
             try:
-                del Cmd.do_ipy
+                self.do_ipy = None
             except AttributeError:
                 pass
 


### PR DESCRIPTION
Fixed bug where setting `use_ipython` to False removed ipy command from the entire `cmd2.Cmd` class instead of just the instance being created
Fixes #792 