### PR TITLE
Fix bug where cmd2 ran 'stty sane' command when stdin was not a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Bug Fixes
     * Fixed bug where setting `use_ipython` to False removed ipy command from the entire `cmd2.Cmd` class instead of
     just the instance being created
+    * Fix bug where cmd2 ran 'stty sane' command when stdin was not a terminal
 * Enhancements
     * Send all startup script paths to run_script. Previously we didn't do this if the file was empty, but that
     showed no record of the run_script command in history. 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1607,7 +1607,7 @@ class Cmd(cmd.Cmd):
         """Run the command finalization hooks"""
 
         with self.sigint_protection:
-            if not sys.platform.startswith('win') and self.stdout.isatty():
+            if not sys.platform.startswith('win') and self.stdin.isatty():
                 # Before the next command runs, fix any terminal problems like those
                 # caused by certain binary characters having been printed to it.
                 import subprocess


### PR DESCRIPTION
Fixes #803