### PR TITLE
Took out rstrip() calls that are no longer neeeded

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3358,7 +3358,7 @@ class Cmd(cmd.Cmd):
             with os.fdopen(fd, 'w') as fobj:
                 for command in history:
                     if command.statement.multiline_command:
-                        fobj.write('{}\n'.format(command.expanded.rstrip()))
+                        fobj.write('{}\n'.format(command.expanded))
                     else:
                         fobj.write('{}\n'.format(command.raw))
             try:
@@ -3372,7 +3372,7 @@ class Cmd(cmd.Cmd):
                 with open(os.path.expanduser(args.output_file), 'w') as fobj:
                     for item in history:
                         if item.statement.multiline_command:
-                            fobj.write('{}\n'.format(item.expanded.rstrip()))
+                            fobj.write('{}\n'.format(item.expanded))
                         else:
                             fobj.write('{}\n'.format(item.raw))
                 plural = 's' if len(history) > 1 else ''

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -45,14 +45,14 @@ class HistoryItem():
         """
         if verbose:
             raw = self.raw.rstrip()
-            expanded = self.expanded.rstrip()
+            expanded = self.expanded
 
             ret_str = self._listformat.format(self.idx, raw)
             if raw != expanded:
                 ret_str += '\n' + self._ex_listformat.format(self.idx, expanded)
         else:
             if expanded:
-                ret_str = self.expanded.rstrip()
+                ret_str = self.expanded
             else:
                 ret_str = self.raw.rstrip()
 


### PR DESCRIPTION
Removed some calls to `rstrip()` that I don't think are needed.
@kotfu Is this change correct