### PR TITLE
Set max version restriction for coverage dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     # Extra dependencies for running unit tests
     'test': ["gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in tox env
              "mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
-             'codecov', 'pytest', 'pytest-cov', 'pytest-mock'],
+             'codecov', 'pytest', 'pytest-cov', 'pytest-mock', 'coverage < 5.0'],
     # development only dependencies:  install with 'pip install -e .[dev]'
     'dev': ["mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
             'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'flake8',


### PR DESCRIPTION
This forces using `coverage` versions prior to 5.0 since it was a change in this transitive dependency which caused our Windows unit tests to start failing on AppVeyor about 20 days ago.

Closes #836 