### PR TITLE
Add missing setuptools dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.23 (TBD, 2019)
 * Bug Fixes
     * Fixed bug where startup script containing a single quote in its file name was incorrectly quoted
+    * Added missing implicit dependency on `setuptools` due to build with `setuptools_scm`
 
 ## 0.9.22 (December 9, 2019)
 * Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ The tables below list all prerequisites along with the minimum required version 
 | [attrs](https://github.com/python-attrs/attrs)      | `16.3`          |
 | [colorama](https://github.com/tartley/colorama)     | `0.3.7`         |
 | [pyperclip](https://github.com/asweigart/pyperclip) | `1.6`           |
+| [setuptools](https://pypi.org/project/setuptools/)  | `34.4`          |
 | [wcwidth](https://pypi.python.org/pypi/wcwidth)     | `0.1.7`         |
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines())))  # noqa: E128
 
-SETUP_REQUIRES = ['setuptools_scm']
+SETUP_REQUIRES = ['setuptools_scm >= 3.0.0']
 
-INSTALL_REQUIRES = ['pyperclip >= 1.6', 'colorama >= 0.3.7', 'attrs >= 16.3.0', 'wcwidth >= 0.1.7']
+INSTALL_REQUIRES = ['attrs >= 16.3.0', 'colorama >= 0.3.7', 'pyperclip >= 1.6', 'setuptools >= 34.4', 'wcwidth >= 0.1.7']
 
 EXTRAS_REQUIRE = {
     # Windows also requires pyreadline to ensure tab completion works


### PR DESCRIPTION
`cmd2` has an implicit runtime dependency on [setuptools](https://pypi.org/project/setuptools/) picked up via the build dependency on [setuptools_scm](https://pypi.org/project/setuptools-scm/).  This is because the `cmd2/__init__.py` file imports from **pkg_resources**.  The [pkg_resources](https://setuptools.readthedocs.io/en/latest/pkg_resources.html) module distributed with `setuptools` provides an API for Python libraries to access their resource files.

This PR adds an explicit dependency on `setuptools` to prevent `cmd2` not working in any environments which don't happen to have `setuptools` already installed.  Additionally, it adds minimum required versions for both `setuptools` and `setuptools_scm` as follows:
* setuptools_scm >= 3.0.0
* setuptools >= 34.4

Closes #837 