### PR TITLE
Replace non-ASCII quotes in .coveragerc with ASCII ones

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,5 +20,5 @@ precision = 1
 
 
 [html]
-# (string, default “htmlcov”): where to write the HTML report files.
+# (string, default "htmlcov"): where to write the HTML report files.
 directory = htmlcov

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     # Extra dependencies for running unit tests
     'test': ["gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in tox env
              "mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
-             'codecov', 'pytest', 'pytest-cov', 'pytest-mock', 'coverage < 5.0'],
+             'codecov', 'coverage', 'pytest', 'pytest-cov', 'pytest-mock'],
     # development only dependencies:  install with 'pip install -e .[dev]'
     'dev': ["mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
             'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'flake8',


### PR DESCRIPTION
This is so that AppVeyor Windows tests can work and we can remove the current restriction which forces use of older versions of `coverage`.

Closes #841 