### PR TITLE
ansi to style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 * Bug Fixes
     * Fixed bug where startup script containing a single quote in its file name was incorrectly quoted
     * Added missing implicit dependency on `setuptools` due to build with `setuptools_scm`
+* Enhancements
+    * Added dim text style support via `style()` function and `ansi.INTENSITY_DIM` setting.
 * Breaking changes
     * Renamed the following `ansi` members for accuracy in what types of ANSI escape sequences are handled
         * `ansi.allow_ansi` -> `ansi.allow_style`
         * `ansi.ansi_safe_wcswidth()` -> `ansi.style_aware_wcswidth()`
         * `ansi.ansi_aware_write()` -> `ansi.style_aware_write()`
+    * Renamed the following `ansi` members for clarification
+        * `ansi.BRIGHT` -> `ansi.INTENSITY_BRIGHT`
+        * `ansi.NORMAL` -> `ansi.INTENSITY_NORMAL`
 
 ## 0.9.22 (December 9, 2019)
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.9.23 (TBD, 2019)
 * Bug Fixes
     * Fixed bug where startup script containing a single quote in its file name was incorrectly quoted
+* Breaking changes
+    * Renamed the following `ansi` members for accuracy in what types of ANSI escape sequences are handled
+        * `ansi.allow_ansi` -> `ansi.allow_style`
+        * `ansi.ansi_safe_wcswidth()` -> `ansi.style_aware_wcswidth()`
+        * `ansi.ansi_aware_write()` -> `ansi.style_aware_write()`
 
 ## 0.9.22 (December 9, 2019)
 * Bug Fixes

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ example/transcript_regex.txt:
 # The regex for editor will match whatever program you use.
 # regexes on prompts just make the trailing space obvious
 (Cmd) set
-allow_ansi: Terminal
+allow_style: Terminal
 continuation_prompt: >/ /
 debug: False
 echo: False

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -22,9 +22,8 @@ STYLE_ALWAYS = 'Always'
 # Controls when ANSI style style sequences are allowed in output
 allow_style = STYLE_TERMINAL
 
-# Regular expression to match ANSI style sequences
-# This matches: colorama.ansi.CSI + 0 or more digits + m
-ANSI_STYLE_RE = re.compile(r'\033\[[0-9]*m')
+# Regular expression to match ANSI style sequences (including 8-bit and 24-bit colors)
+ANSI_STYLE_RE = re.compile(r'\x1b\[[^m]*m')
 
 # Foreground color presets
 FG_COLORS = {
@@ -72,8 +71,10 @@ FG_RESET = FG_COLORS['reset']
 BG_RESET = BG_COLORS['reset']
 RESET_ALL = Style.RESET_ALL
 
-BRIGHT = Style.BRIGHT
-NORMAL = Style.NORMAL
+# Text intensities
+INTENSITY_BRIGHT = Style.BRIGHT
+INTENSITY_DIM = Style.DIM
+INTENSITY_NORMAL = Style.NORMAL
 
 # ANSI style sequences not provided by colorama
 UNDERLINE_ENABLE = colorama.ansi.code_to_chars(4)
@@ -139,7 +140,8 @@ def bg_lookup(bg_name: str) -> str:
     return ansi_escape
 
 
-def style(text: Any, *, fg: str = '', bg: str = '', bold: bool = False, underline: bool = False) -> str:
+def style(text: Any, *, fg: str = '', bg: str = '', bold: bool = False,
+          dim: bool = False, underline: bool = False) -> str:
     """
     Apply ANSI colors and/or styles to a string and return it.
     The styling is self contained which means that at the end of the string reset code(s) are issued
@@ -148,7 +150,8 @@ def style(text: Any, *, fg: str = '', bg: str = '', bold: bool = False, underlin
     :param text: Any object compatible with str.format()
     :param fg: foreground color. Relies on `fg_lookup()` to retrieve ANSI escape based on name. Defaults to no color.
     :param bg: background color. Relies on `bg_lookup()` to retrieve ANSI escape based on name. Defaults to no color.
-    :param bold: apply the bold style if True. Defaults to False.
+    :param bold: apply the bold style if True. Can be combined with dim. Defaults to False.
+    :param dim: apply the dim style if True. Can be combined with bold. Defaults to False.
     :param underline: apply the underline style if True. Defaults to False.
     :return: the stylized string
     """
@@ -171,8 +174,12 @@ def style(text: Any, *, fg: str = '', bg: str = '', bold: bool = False, underlin
         removals.append(BG_RESET)
 
     if bold:
-        additions.append(Style.BRIGHT)
-        removals.append(Style.NORMAL)
+        additions.append(INTENSITY_BRIGHT)
+        removals.append(INTENSITY_NORMAL)
+
+    if dim:
+        additions.append(INTENSITY_DIM)
+        removals.append(INTENSITY_NORMAL)
 
     if underline:
         additions.append(UNDERLINE_ENABLE)

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -23,8 +23,8 @@ STYLE_ALWAYS = 'Always'
 allow_style = STYLE_TERMINAL
 
 # Regular expression to match ANSI style sequences
-# This matches: colorama.ansi.CSI + digit(s) + m
-ANSI_STYLE_RE = re.compile(r'\033\[[0-9]+m')
+# This matches: colorama.ansi.CSI + 0 or more digits + m
+ANSI_STYLE_RE = re.compile(r'\033\[[0-9]*m')
 
 # Foreground color presets
 FG_COLORS = {

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -90,20 +90,18 @@ def strip_style(text: str) -> str:
     return ANSI_STYLE_RE.sub('', text)
 
 
-def ansi_safe_wcswidth(text: str) -> int:
+def style_aware_wcswidth(text: str) -> int:
     """
     Wrap wcswidth to make it compatible with strings that contains ANSI style sequences
-
     :param text: the string being measured
     """
     # Strip ANSI style sequences since they cause wcswidth to return -1
     return wcswidth(strip_style(text))
 
 
-def ansi_aware_write(fileobj: IO, msg: str) -> None:
+def style_aware_write(fileobj: IO, msg: str) -> None:
     """
     Write a string to a fileobject and strip its ANSI style sequences if required by allow_style setting
-
     :param fileobj: the file object being written to
     :param msg: the string being written
     """
@@ -114,8 +112,8 @@ def ansi_aware_write(fileobj: IO, msg: str) -> None:
 
 
 def fg_lookup(fg_name: str) -> str:
-    """Look up ANSI escape codes based on foreground color name.
-
+    """
+    Look up ANSI escape codes based on foreground color name.
     :param fg_name: foreground color name to look up ANSI escape code(s) for
     :return: ANSI escape code(s) associated with this color
     :raises ValueError if the color cannot be found
@@ -128,8 +126,8 @@ def fg_lookup(fg_name: str) -> str:
 
 
 def bg_lookup(bg_name: str) -> str:
-    """Look up ANSI escape codes based on background color name.
-
+    """
+    Look up ANSI escape codes based on background color name.
     :param bg_name: background color name to look up ANSI escape code(s) for
     :return: ANSI escape code(s) associated with this color
     :raises ValueError if the color cannot be found
@@ -142,8 +140,8 @@ def bg_lookup(bg_name: str) -> str:
 
 
 def style(text: Any, *, fg: str = '', bg: str = '', bold: bool = False, underline: bool = False) -> str:
-    """Styles a string with ANSI colors and/or styles and returns the new string.
-
+    """
+    Apply ANSI colors and/or styles to a string and return it.
     The styling is self contained which means that at the end of the string reset code(s) are issued
     to undo whatever styling was done at the beginning.
 
@@ -210,14 +208,14 @@ def async_alert_str(*, terminal_columns: int, prompt: str, line: str, cursor_off
     # That will be included in the input lines calculations since that is where the cursor is.
     num_prompt_terminal_lines = 0
     for line in prompt_lines[:-1]:
-        line_width = ansi_safe_wcswidth(line)
+        line_width = style_aware_wcswidth(line)
         num_prompt_terminal_lines += int(line_width / terminal_columns) + 1
 
     # Now calculate how many terminal lines are take up by the input
     last_prompt_line = prompt_lines[-1]
-    last_prompt_line_width = ansi_safe_wcswidth(last_prompt_line)
+    last_prompt_line_width = style_aware_wcswidth(last_prompt_line)
 
-    input_width = last_prompt_line_width + ansi_safe_wcswidth(line)
+    input_width = last_prompt_line_width + style_aware_wcswidth(line)
 
     num_input_terminal_lines = int(input_width / terminal_columns) + 1
 

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -444,11 +444,11 @@ class AutoCompleter(object):
                 completions.sort(key=self._cmd2_app.default_sort_key)
                 self._cmd2_app.matches_sorted = True
 
-            token_width = ansi.ansi_safe_wcswidth(action.dest)
+            token_width = ansi.style_aware_wcswidth(action.dest)
             completions_with_desc = []
 
             for item in completions:
-                item_width = ansi.ansi_safe_wcswidth(item)
+                item_width = ansi.style_aware_wcswidth(item)
                 if item_width > token_width:
                     token_width = item_width
 
@@ -585,7 +585,7 @@ class AutoCompleter(object):
     def _print_message(msg: str) -> None:
         """Print a message instead of tab completions and redraw the prompt and input line"""
         import sys
-        ansi.ansi_aware_write(sys.stdout, msg + '\n')
+        ansi.style_aware_write(sys.stdout, msg + '\n')
         rl_force_redisplay()
 
     def _print_arg_hint(self, arg_action: argparse.Action) -> None:

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -802,11 +802,11 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         return formatter.format_help() + '\n'
 
     def _print_message(self, message, file=None):
-        # Override _print_message to use ansi_aware_write() since we use ANSI escape characters to support color
+        # Override _print_message to use style_aware_write() since we use ANSI escape characters to support color
         if message:
             if file is None:
                 file = sys.stderr
-            ansi.ansi_aware_write(file, message)
+            ansi.style_aware_write(file, message)
 
 
 # The default ArgumentParser class for a cmd2 app

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -439,7 +439,7 @@ class Cmd(cmd.Cmd):
         :param end: string appended after the end of the message, default a newline
         """
         try:
-            ansi.ansi_aware_write(self.stdout, "{}{}".format(msg, end))
+            ansi.style_aware_write(self.stdout, "{}{}".format(msg, end))
         except BrokenPipeError:
             # This occurs if a command's output is being piped to another
             # process and that process closes before the command is
@@ -462,7 +462,7 @@ class Cmd(cmd.Cmd):
             final_msg = ansi.style_error(msg)
         else:
             final_msg = "{}".format(msg)
-        ansi.ansi_aware_write(sys.stderr, final_msg + end)
+        ansi.style_aware_write(sys.stderr, final_msg + end)
 
     def pwarning(self, msg: Any = '', *, end: str = '\n', apply_style: bool = True) -> None:
         """Wraps perror, but applies ansi.style_warning by default
@@ -1096,7 +1096,7 @@ class Cmd(cmd.Cmd):
                 longest_match_length = 0
 
                 for cur_match in matches_to_display:
-                    cur_length = ansi.ansi_safe_wcswidth(cur_match)
+                    cur_length = ansi.style_aware_wcswidth(cur_match)
                     if cur_length > longest_match_length:
                         longest_match_length = cur_length
             else:
@@ -2653,7 +2653,7 @@ class Cmd(cmd.Cmd):
                 widest = 0
                 # measure the commands
                 for command in cmds:
-                    width = ansi.ansi_safe_wcswidth(command)
+                    width = ansi.style_aware_wcswidth(command)
                     if width > widest:
                         widest = width
                 # add a 4-space pad
@@ -3737,7 +3737,7 @@ class Cmd(cmd.Cmd):
         test_results = runner.run(testcase)
         execution_time = time.time() - start_time
         if test_results.wasSuccessful():
-            ansi.ansi_aware_write(sys.stderr, stream.read())
+            ansi.style_aware_write(sys.stderr, stream.read())
             finish_msg = ' {0} transcript{1} passed in {2:.3f} seconds '.format(num_transcripts, plural, execution_time)
             finish_msg = ansi.style_success(utils.align_center(finish_msg, fill_char='='))
             self.poutput(finish_msg)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -207,7 +207,7 @@ class Cmd(cmd.Cmd):
         self.settable = \
             {
                 # allow_style is a special case in which it's an application-wide setting defined in ansi.py
-                'allow_style': ('Allow ANSI style sequences in output '
+                'allow_style': ('Allow ANSI text style sequences in output '
                                 '(valid values: {}, {}, {})'.format(ansi.STYLE_TERMINAL,
                                                                     ansi.STYLE_ALWAYS,
                                                                     ansi.STYLE_NEVER)),

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -206,11 +206,11 @@ class Cmd(cmd.Cmd):
         # To make an attribute settable with the "do_set" command, add it to this ...
         self.settable = \
             {
-                # allow_ansi is a special case in which it's an application-wide setting defined in ansi.py
-                'allow_ansi': ('Allow ANSI escape sequences in output '
-                               '(valid values: {}, {}, {})'.format(ansi.ANSI_TERMINAL,
-                                                                   ansi.ANSI_ALWAYS,
-                                                                   ansi.ANSI_NEVER)),
+                # allow_style is a special case in which it's an application-wide setting defined in ansi.py
+                'allow_style': ('Allow ANSI style sequences in output '
+                                '(valid values: {}, {}, {})'.format(ansi.STYLE_TERMINAL,
+                                                                    ansi.STYLE_ALWAYS,
+                                                                    ansi.STYLE_NEVER)),
                 'continuation_prompt': 'On 2nd+ line of input',
                 'debug': 'Show full error stack on error',
                 'echo': 'Echo command issued into output',
@@ -366,7 +366,7 @@ class Cmd(cmd.Cmd):
         else:
             # Here is the meaning of the various flags we are using with the less command:
             # -S causes lines longer than the screen width to be chopped (truncated) rather than wrapped
-            # -R causes ANSI "color" escape sequences to be output in raw form (i.e. colors are displayed)
+            # -R causes ANSI "style" escape sequences to be output in raw form (i.e. colors are displayed)
             # -X disables sending the termcap initialization and deinitialization strings to the terminal
             # -F causes less to automatically exit if the entire file can be displayed on the first screen
             self.pager = 'less -RXF'
@@ -395,23 +395,23 @@ class Cmd(cmd.Cmd):
     # -----  Methods related to presenting output to the user -----
 
     @property
-    def allow_ansi(self) -> str:
-        """Read-only property needed to support do_set when it reads allow_ansi"""
-        return ansi.allow_ansi
+    def allow_style(self) -> str:
+        """Read-only property needed to support do_set when it reads allow_style"""
+        return ansi.allow_style
 
-    @allow_ansi.setter
-    def allow_ansi(self, new_val: str) -> None:
-        """Setter property needed to support do_set when it updates allow_ansi"""
+    @allow_style.setter
+    def allow_style(self, new_val: str) -> None:
+        """Setter property needed to support do_set when it updates allow_style"""
         new_val = new_val.lower()
-        if new_val == ansi.ANSI_TERMINAL.lower():
-            ansi.allow_ansi = ansi.ANSI_TERMINAL
-        elif new_val == ansi.ANSI_ALWAYS.lower():
-            ansi.allow_ansi = ansi.ANSI_ALWAYS
-        elif new_val == ansi.ANSI_NEVER.lower():
-            ansi.allow_ansi = ansi.ANSI_NEVER
+        if new_val == ansi.STYLE_TERMINAL.lower():
+            ansi.allow_style = ansi.STYLE_TERMINAL
+        elif new_val == ansi.STYLE_ALWAYS.lower():
+            ansi.allow_style = ansi.STYLE_ALWAYS
+        elif new_val == ansi.STYLE_NEVER.lower():
+            ansi.allow_style = ansi.STYLE_NEVER
         else:
-            self.perror('Invalid value: {} (valid values: {}, {}, {})'.format(new_val, ansi.ANSI_TERMINAL,
-                                                                              ansi.ANSI_ALWAYS, ansi.ANSI_NEVER))
+            self.perror('Invalid value: {} (valid values: {}, {}, {})'.format(new_val, ansi.STYLE_TERMINAL,
+                                                                              ansi.STYLE_ALWAYS, ansi.STYLE_NEVER))
 
     def _completion_supported(self) -> bool:
         """Return whether tab completion is supported"""
@@ -419,14 +419,14 @@ class Cmd(cmd.Cmd):
 
     @property
     def visible_prompt(self) -> str:
-        """Read-only property to get the visible prompt with any ANSI escape codes stripped.
+        """Read-only property to get the visible prompt with any ANSI style escape codes stripped.
 
         Used by transcript testing to make it easier and more reliable when users are doing things like coloring the
         prompt using ANSI color codes.
 
         :return: prompt stripped of any ANSI escape codes
         """
-        return ansi.strip_ansi(self.prompt)
+        return ansi.strip_style(self.prompt)
 
     def poutput(self, msg: Any = '', *, end: str = '\n') -> None:
         """Print message to self.stdout and appends a newline by default
@@ -551,8 +551,8 @@ class Cmd(cmd.Cmd):
             # Don't attempt to use a pager that can block if redirecting or running a script (either text or Python)
             # Also only attempt to use a pager if actually running in a real fully functional terminal
             if functional_terminal and not self._redirecting and not self.in_pyscript() and not self.in_script():
-                if ansi.allow_ansi.lower() == ansi.ANSI_NEVER.lower():
-                    msg_str = ansi.strip_ansi(msg_str)
+                if ansi.allow_style.lower() == ansi.STYLE_NEVER.lower():
+                    msg_str = ansi.strip_style(msg_str)
                 msg_str += end
 
                 pager = self.pager

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -193,7 +193,7 @@ def rl_set_prompt(prompt: str) -> None:  # pragma: no cover
 
 
 def rl_make_safe_prompt(prompt: str) -> str:  # pragma: no cover
-    """Overcome bug in GNU Readline in relation to calculation of prompt length in presence of ANSI escape codes.
+    """Overcome bug in GNU Readline in relation to calculation of prompt length in presence of ANSI escape codes
 
     :param prompt: original prompt
     :return: prompt safe to pass to GNU Readline

--- a/cmd2/transcript.py
+++ b/cmd2/transcript.py
@@ -56,13 +56,13 @@ class Cmd2TestCase(unittest.TestCase):
     def _test_transcript(self, fname: str, transcript):
         line_num = 0
         finished = False
-        line = ansi.strip_ansi(next(transcript))
+        line = ansi.strip_style(next(transcript))
         line_num += 1
         while not finished:
             # Scroll forward to where actual commands begin
             while not line.startswith(self.cmdapp.visible_prompt):
                 try:
-                    line = ansi.strip_ansi(next(transcript))
+                    line = ansi.strip_style(next(transcript))
                 except StopIteration:
                     finished = True
                     break
@@ -89,7 +89,7 @@ class Cmd2TestCase(unittest.TestCase):
             result = self.cmdapp.stdout.read()
             stop_msg = 'Command indicated application should quit, but more commands in transcript'
             # Read the expected result from transcript
-            if ansi.strip_ansi(line).startswith(self.cmdapp.visible_prompt):
+            if ansi.strip_style(line).startswith(self.cmdapp.visible_prompt):
                 message = '\nFile {}, line {}\nCommand was:\n{}\nExpected: (nothing)\nGot:\n{}\n'.format(
                           fname, line_num, command, result)
                 self.assertTrue(not (result.strip()), message)
@@ -97,7 +97,7 @@ class Cmd2TestCase(unittest.TestCase):
                 self.assertFalse(stop, stop_msg)
                 continue
             expected = []
-            while not ansi.strip_ansi(line).startswith(self.cmdapp.visible_prompt):
+            while not ansi.strip_style(line).startswith(self.cmdapp.visible_prompt):
                 expected.append(line)
                 try:
                     line = next(transcript)

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -669,7 +669,7 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
     if len(fill_char) != 1:
         raise TypeError("Fill character must be exactly one character long")
 
-    fill_char_width = ansi.ansi_safe_wcswidth(fill_char)
+    fill_char_width = ansi.style_aware_wcswidth(fill_char)
     if fill_char_width == -1:
         raise (ValueError("Fill character is an unprintable character"))
 
@@ -687,9 +687,9 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
         if index > 0:
             text_buf.write('\n')
 
-        # Use ansi_safe_wcswidth to support characters with display widths
+        # Use style_aware_wcswidth to support characters with display widths
         # greater than 1 as well as ANSI style sequences
-        line_width = ansi.ansi_safe_wcswidth(line)
+        line_width = ansi.style_aware_wcswidth(line)
         if line_width == -1:
             raise(ValueError("Text to align contains an unprintable character"))
 
@@ -717,8 +717,8 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
 
         # In cases where the fill character display width didn't divide evenly into
         # the gaps being filled, pad the remainder with spaces.
-        left_fill += ' ' * (left_fill_width - ansi.ansi_safe_wcswidth(left_fill))
-        right_fill += ' ' * (right_fill_width - ansi.ansi_safe_wcswidth(right_fill))
+        left_fill += ' ' * (left_fill_width - ansi.style_aware_wcswidth(left_fill))
+        right_fill += ' ' * (right_fill_width - ansi.style_aware_wcswidth(right_fill))
 
         text_buf.write(left_fill + line + right_fill)
 

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -641,7 +641,7 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
                width: Optional[int] = None, tab_width: int = 4) -> str:
     """
     Align text for display within a given width. Supports characters with display widths greater than 1.
-    ANSI escape sequences are safely ignored and do not count toward the display width. This means colored text is
+    ANSI style sequences are safely ignored and do not count toward the display width. This means colored text is
     supported. If text has line breaks, then each line is aligned independently.
 
     There are convenience wrappers around this function: align_left(), align_center(), and align_right()
@@ -688,7 +688,7 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
             text_buf.write('\n')
 
         # Use ansi_safe_wcswidth to support characters with display widths
-        # greater than 1 as well as ANSI escape sequences
+        # greater than 1 as well as ANSI style sequences
         line_width = ansi.ansi_safe_wcswidth(line)
         if line_width == -1:
             raise(ValueError("Text to align contains an unprintable character"))
@@ -728,7 +728,7 @@ def align_text(text: str, alignment: TextAlignment, *, fill_char: str = ' ',
 def align_left(text: str, *, fill_char: str = ' ', width: Optional[int] = None, tab_width: int = 4) -> str:
     """
     Left align text for display within a given width. Supports characters with display widths greater than 1.
-    ANSI escape sequences are safely ignored and do not count toward the display width. This means colored text is
+    ANSI style sequences are safely ignored and do not count toward the display width. This means colored text is
     supported. If text has line breaks, then each line is aligned independently.
 
     :param text: text to left align (can contain multiple lines)
@@ -746,7 +746,7 @@ def align_left(text: str, *, fill_char: str = ' ', width: Optional[int] = None, 
 def align_center(text: str, *, fill_char: str = ' ', width: Optional[int] = None, tab_width: int = 4) -> str:
     """
     Center text for display within a given width. Supports characters with display widths greater than 1.
-    ANSI escape sequences are safely ignored and do not count toward the display width. This means colored text is
+    ANSI style sequences are safely ignored and do not count toward the display width. This means colored text is
     supported. If text has line breaks, then each line is aligned independently.
 
     :param text: text to center (can contain multiple lines)
@@ -764,7 +764,7 @@ def align_center(text: str, *, fill_char: str = ' ', width: Optional[int] = None
 def align_right(text: str, *, fill_char: str = ' ', width: Optional[int] = None, tab_width: int = 4) -> str:
     """
     Right align text for display within a given width. Supports characters with display widths greater than 1.
-    ANSI escape sequences are safely ignored and do not count toward the display width. This means colored text is
+    ANSI style sequences are safely ignored and do not count toward the display width. This means colored text is
     supported. If text has line breaks, then each line is aligned independently.
 
     :param text: text to right align (can contain multiple lines)

--- a/docs/features/generating_output.rst
+++ b/docs/features/generating_output.rst
@@ -45,23 +45,23 @@ changing the value of the ``quiet`` setting.
 Colored Output
 --------------
 
-The output methods in the previous section all honor the ``allow_ansi``
+The output methods in the previous section all honor the ``allow_style``
 setting, which has three possible values:
 
 Never
-    poutput(), pfeedback(), and ppaged() strip all ANSI escape sequences
+    poutput(), pfeedback(), and ppaged() strip all ANSI style sequences
     which instruct the terminal to colorize output
 
 Terminal
     (the default value) poutput(), pfeedback(), and ppaged() do not strip any
-    ANSI escape sequences when the output is a terminal, but if the output is a
-    pipe or a file the escape sequences are stripped. If you want colorized
-    output you must add ANSI escape sequences using either cmd2's internal ansi
+    ANSI style sequences when the output is a terminal, but if the output is a
+    pipe or a file the style sequences are stripped. If you want colorized
+    output you must add ANSI style sequences using either cmd2's internal ansi
     module or another color library such as `plumbum.colors`, `colorama`, or
     `colored`.
 
 Always
-    poutput(), pfeedback(), and ppaged() never strip ANSI escape sequences,
+    poutput(), pfeedback(), and ppaged() never strip ANSI style sequences,
     regardless of the output destination
 
 Colored and otherwise styled output can be generated using the `ansi.style()`

--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -46,7 +46,7 @@ comments, is viewable from within a running application
 with::
 
     (Cmd) set --long
-    allow_style: Terminal          # Allow ANSI style sequences in output (valid values: Terminal, Always, Never)
+    allow_style: Terminal          # Allow ANSI text style sequences in output (valid values: Terminal, Always, Never)
     continuation_prompt: >         # On 2nd+ line of input
     debug: False                   # Show full error stack on error
     echo: False                    # Echo command issued into output

--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -46,7 +46,7 @@ comments, is viewable from within a running application
 with::
 
     (Cmd) set --long
-    allow_ansi: Terminal           # Allow ANSI escape sequences in output (valid values: Terminal, Always, Never)
+    allow_style: Terminal          # Allow ANSI style sequences in output (valid values: Terminal, Always, Never)
     continuation_prompt: >         # On 2nd+ line of input
     debug: False                   # Show full error stack on error
     echo: False                    # Echo command issued into output
@@ -61,7 +61,7 @@ with::
 Any of these user-settable parameters can be set while running your app with
 the ``set`` command like so::
 
-    set allow_ansi Never
+    set allow_style Never
 
 
 

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -6,21 +6,21 @@ A sample application for cmd2. Demonstrating colorized output.
 Experiment with the command line options on the `speak` command to see how
 different output colors ca
 
-The allow_ansi setting has three possible values:
+The allow_style setting has three possible values:
 
 Never
-    poutput(), pfeedback(), and ppaged() strip all ANSI escape sequences
+    poutput(), pfeedback(), and ppaged() strip all ANSI style sequences
     which instruct the terminal to colorize output
 
 Terminal
     (the default value) poutput(), pfeedback(), and ppaged() do not strip any
-    ANSI escape sequences when the output is a terminal, but if the output is
-    a pipe or a file the escape sequences are stripped. If you want colorized
-    output you must add ANSI escape sequences using either cmd2's internal ansi
+    ANSI style sequences when the output is a terminal, but if the output is
+    a pipe or a file the style sequences are stripped. If you want colorized
+    output you must add ANSI style sequences using either cmd2's internal ansi
     module or another color library such as `plumbum.colors` or `colorama`.
 
 Always
-    poutput(), pfeedback(), and ppaged() never strip ANSI escape sequences,
+    poutput(), pfeedback(), and ppaged() never strip ANSI style sequences,
     regardless of the output destination
 """
 import argparse
@@ -40,7 +40,7 @@ class CmdLineApp(cmd2.Cmd):
         self.settable['maxrepeats'] = 'max repetitions for speak command'
 
         # Should ANSI color output be allowed
-        self.allow_ansi = ansi.ANSI_TERMINAL
+        self.allow_style = ansi.STYLE_TERMINAL
 
     speak_parser = argparse.ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')

--- a/examples/plumbum_colors.py
+++ b/examples/plumbum_colors.py
@@ -6,21 +6,21 @@ A sample application for cmd2. Demonstrating colorized output using the plumbum 
 Experiment with the command line options on the `speak` command to see how
 different output colors ca
 
-The allow_ansi setting has three possible values:
+The allow_style setting has three possible values:
 
 Never
-    poutput(), pfeedback(), and ppaged() strip all ANSI escape sequences
+    poutput(), pfeedback(), and ppaged() strip all ANSI style sequences
     which instruct the terminal to colorize output
 
 Terminal
     (the default value) poutput(), pfeedback(), and ppaged() do not strip any
-    ANSI escape sequences when the output is a terminal, but if the output is
-    a pipe or a file the escape sequences are stripped. If you want colorized
-    output you must add ANSI escape sequences using either cmd2's internal ansi
+    ANSI style sequences when the output is a terminal, but if the output is
+    a pipe or a file the style sequences are stripped. If you want colorized
+    output you must add ANSI style sequences using either cmd2's internal ansi
     module or another color library such as `plumbum.colors` or `colorama`.
 
 Always
-    poutput(), pfeedback(), and ppaged() never strip ANSI escape sequences,
+    poutput(), pfeedback(), and ppaged() never strip ANSI style sequences,
     regardless of the output destination
 
 WARNING: This example requires the plumbum package, which isn't normally required by cmd2.
@@ -78,7 +78,7 @@ class CmdLineApp(cmd2.Cmd):
         self.settable['maxrepeats'] = 'max repetitions for speak command'
 
         # Should ANSI color output be allowed
-        self.allow_ansi = ansi.ANSI_TERMINAL
+        self.allow_style = ansi.STYLE_TERMINAL
 
     speak_parser = argparse.ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')

--- a/examples/transcripts/exampleSession.txt
+++ b/examples/transcripts/exampleSession.txt
@@ -3,7 +3,7 @@
 # The regex for editor will match whatever program you use.
 # regexes on prompts just make the trailing space obvious
 (Cmd) set
-allow_ansi: /(Terminal|Always|Never)/
+allow_style: /(Terminal|Always|Never)/
 continuation_prompt: >/ /
 debug: False
 echo: False

--- a/examples/transcripts/transcript_regex.txt
+++ b/examples/transcripts/transcript_regex.txt
@@ -3,7 +3,7 @@
 # The regex for editor will match whatever program you use.
 # regexes on prompts just make the trailing space obvious
 (Cmd) set
-allow_ansi: /(Terminal|Always|Never)/
+allow_style: /(Terminal|Always|Never)/
 continuation_prompt: >/ /
 debug: False
 echo: False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ timing: False
 """
 
 SHOW_LONG = """
-allow_style: Terminal     # Allow ANSI style sequences in output (valid values: Terminal, Always, Never)
+allow_style: Terminal     # Allow ANSI text style sequences in output (valid values: Terminal, Always, Never)
 continuation_prompt: >    # On 2nd+ line of input
 debug: False              # Show full error stack on error
 echo: False               # Echo command issued into output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ SHORTCUTS_TXT = """Shortcuts for other commands:
 """
 
 # Output from the show command with default settings
-SHOW_TXT = """allow_ansi: Terminal
+SHOW_TXT = """allow_style: Terminal
 continuation_prompt: >
 debug: False
 echo: False
@@ -102,7 +102,7 @@ timing: False
 """
 
 SHOW_LONG = """
-allow_ansi: Terminal      # Allow ANSI escape sequences in output (valid values: Terminal, Always, Never)
+allow_style: Terminal     # Allow ANSI style sequences in output (valid values: Terminal, Always, Never)
 continuation_prompt: >    # On 2nd+ line of input
 debug: False              # Show full error stack on error
 echo: False               # Echo command issued into output

--- a/tests/scripts/postcmds.txt
+++ b/tests/scripts/postcmds.txt
@@ -1,1 +1,1 @@
-set allow_ansi Never
+set allow_style Never

--- a/tests/scripts/precmds.txt
+++ b/tests/scripts/precmds.txt
@@ -1,1 +1,1 @@
-set allow_ansi Always
+set allow_style Always

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -17,10 +17,10 @@ def test_strip_style():
     assert base_str == ansi.strip_style(ansi_str)
 
 
-def test_ansi_safe_wcswidth():
+def test_style_aware_wcswidth():
     base_str = HELLO_WORLD
     ansi_str = ansi.style(base_str, fg='green')
-    assert ansi.ansi_safe_wcswidth(ansi_str) != len(ansi_str)
+    assert ansi.style_aware_wcswidth(ansi_str) != len(ansi_str)
 
 
 def test_style_none():

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -45,8 +45,14 @@ def test_style_bg():
 
 def test_style_bold():
     base_str = HELLO_WORLD
-    ansi_str = ansi.BRIGHT + base_str + ansi.NORMAL
+    ansi_str = ansi.INTENSITY_BRIGHT + base_str + ansi.INTENSITY_NORMAL
     assert ansi.style(base_str, bold=True) == ansi_str
+
+
+def test_style_dim():
+    base_str = HELLO_WORLD
+    ansi_str = ansi.INTENSITY_DIM + base_str + ansi.INTENSITY_NORMAL
+    assert ansi.style(base_str, dim=True) == ansi_str
 
 
 def test_style_underline():
@@ -59,9 +65,12 @@ def test_style_multi():
     base_str = HELLO_WORLD
     fg_color = 'blue'
     bg_color = 'green'
-    ansi_str = ansi.FG_COLORS[fg_color] + ansi.BG_COLORS[bg_color] + ansi.BRIGHT + ansi.UNDERLINE_ENABLE + \
-               base_str + ansi.FG_RESET + ansi.BG_RESET + ansi.NORMAL + ansi.UNDERLINE_DISABLE
-    assert ansi.style(base_str, fg=fg_color, bg=bg_color, bold=True, underline=True) == ansi_str
+    ansi_str = (ansi.FG_COLORS[fg_color] + ansi.BG_COLORS[bg_color] +
+                ansi.INTENSITY_BRIGHT + ansi.INTENSITY_DIM + ansi.UNDERLINE_ENABLE +
+                base_str +
+                ansi.FG_RESET + ansi.BG_RESET +
+                ansi.INTENSITY_NORMAL + ansi.INTENSITY_NORMAL + ansi.UNDERLINE_DISABLE)
+    assert ansi.style(base_str, fg=fg_color, bg=bg_color, bold=True, dim=True, underline=True) == ansi_str
 
 
 def test_style_color_not_exist():

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -10,11 +10,11 @@ import cmd2.ansi as ansi
 HELLO_WORLD = 'Hello, world!'
 
 
-def test_strip_ansi():
+def test_strip_style():
     base_str = HELLO_WORLD
     ansi_str = ansi.style(base_str, fg='green')
     assert base_str != ansi_str
-    assert base_str == ansi.strip_ansi(ansi_str)
+    assert base_str == ansi.strip_style(ansi_str)
 
 
 def test_ansi_safe_wcswidth():

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -187,26 +187,26 @@ now: True
     assert out == ['quiet: True']
 
 @pytest.mark.parametrize('new_val, is_valid, expected', [
-    (ansi.ANSI_NEVER, False, ansi.ANSI_NEVER),
-    ('neVeR', False, ansi.ANSI_NEVER),
-    (ansi.ANSI_TERMINAL, False, ansi.ANSI_TERMINAL),
-    ('TeRMInal', False, ansi.ANSI_TERMINAL),
-    (ansi.ANSI_ALWAYS, False, ansi.ANSI_ALWAYS),
-    ('AlWaYs', False, ansi.ANSI_ALWAYS),
-    ('invalid', True, ansi.ANSI_TERMINAL),
+    (ansi.STYLE_NEVER, False, ansi.STYLE_NEVER),
+    ('neVeR', False, ansi.STYLE_NEVER),
+    (ansi.STYLE_TERMINAL, False, ansi.STYLE_TERMINAL),
+    ('TeRMInal', False, ansi.STYLE_TERMINAL),
+    (ansi.STYLE_ALWAYS, False, ansi.STYLE_ALWAYS),
+    ('AlWaYs', False, ansi.STYLE_ALWAYS),
+    ('invalid', True, ansi.STYLE_TERMINAL),
 ])
-def test_set_allow_ansi(base_app, new_val, is_valid, expected):
-    # Initialize allow_ansi for this test
-    ansi.allow_ansi = ansi.ANSI_TERMINAL
+def test_set_allow_style(base_app, new_val, is_valid, expected):
+    # Initialize allow_style for this test
+    ansi.allow_style = ansi.STYLE_TERMINAL
 
     # Use the set command to alter it
-    out, err = run_cmd(base_app, 'set allow_ansi {}'.format(new_val))
+    out, err = run_cmd(base_app, 'set allow_style {}'.format(new_val))
 
     # Verify the results
     assert bool(err) == is_valid
-    assert ansi.allow_ansi == expected
+    assert ansi.allow_style == expected
 
-    # Reload ansi module to reset allow_ansi to its default since it's an
+    # Reload ansi module to reset allow_style to its default since it's an
     # application-wide setting that can affect other unit tests.
     import importlib
     importlib.reload(ansi)
@@ -376,11 +376,11 @@ def test_run_script_nested_run_scripts(base_app, request):
     expected = """
 %s
 _relative_run_script precmds.txt
-set allow_ansi Always
+set allow_style Always
 help
 shortcuts
 _relative_run_script postcmds.txt
-set allow_ansi Never""" % initial_run
+set allow_style Never""" % initial_run
     out, err = run_cmd(base_app, 'history -s')
     assert out == normalize(expected)
 
@@ -395,11 +395,11 @@ def test_runcmds_plus_hooks(base_app, request):
                                  'run_script ' + postfilepath])
     expected = """
 run_script %s
-set allow_ansi Always
+set allow_style Always
 help
 shortcuts
 run_script %s
-set allow_ansi Never""" % (prefilepath, postfilepath)
+set allow_style Never""" % (prefilepath, postfilepath)
 
     out, err = run_cmd(base_app, 'history -s')
     assert out == normalize(expected)
@@ -1564,7 +1564,7 @@ def test_poutput_none(outsim_app):
 
 def test_poutput_ansi_always(outsim_app):
     msg = 'Hello World'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     colored_msg = ansi.style(msg, fg='cyan')
     outsim_app.poutput(colored_msg)
     out = outsim_app.stdout.getvalue()
@@ -1574,7 +1574,7 @@ def test_poutput_ansi_always(outsim_app):
 
 def test_poutput_ansi_never(outsim_app):
     msg = 'Hello World'
-    ansi.allow_ansi = ansi.ANSI_NEVER
+    ansi.allow_style = ansi.STYLE_NEVER
     colored_msg = ansi.style(msg, fg='cyan')
     outsim_app.poutput(colored_msg)
     out = outsim_app.stdout.getvalue()
@@ -1885,7 +1885,7 @@ def test_nonexistent_macro(base_app):
 def test_perror_style(base_app, capsys):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     base_app.perror(msg)
     out, err = capsys.readouterr()
     assert err == ansi.style_error(msg) + end
@@ -1893,7 +1893,7 @@ def test_perror_style(base_app, capsys):
 def test_perror_no_style(base_app, capsys):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     base_app.perror(msg, apply_style=False)
     out, err = capsys.readouterr()
     assert err == msg + end
@@ -1901,7 +1901,7 @@ def test_perror_no_style(base_app, capsys):
 def test_pwarning_style(base_app, capsys):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     base_app.pwarning(msg)
     out, err = capsys.readouterr()
     assert err == ansi.style_warning(msg) + end
@@ -1909,7 +1909,7 @@ def test_pwarning_style(base_app, capsys):
 def test_pwarning_no_style(base_app, capsys):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     base_app.pwarning(msg, apply_style=False)
     out, err = capsys.readouterr()
     assert err == msg + end
@@ -1936,7 +1936,7 @@ def test_ppaged_none(outsim_app):
 def test_ppaged_strips_ansi_when_redirecting(outsim_app):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_TERMINAL
+    ansi.allow_style = ansi.STYLE_TERMINAL
     outsim_app._redirecting = True
     outsim_app.ppaged(ansi.style(msg, fg='red'))
     out = outsim_app.stdout.getvalue()
@@ -1945,7 +1945,7 @@ def test_ppaged_strips_ansi_when_redirecting(outsim_app):
 def test_ppaged_strips_ansi_when_redirecting_if_always(outsim_app):
     msg = 'testing...'
     end = '\n'
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     outsim_app._redirecting = True
     colored_msg = ansi.style(msg, fg='red')
     outsim_app.ppaged(colored_msg)
@@ -2112,13 +2112,13 @@ class AnsiApp(cmd2.Cmd):
 
 def test_ansi_pouterr_always_tty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     mocker.patch.object(app.stdout, 'isatty', return_value=True)
     mocker.patch.object(sys.stderr, 'isatty', return_value=True)
 
     app.onecmd_plus_hooks('echo_error oopsie')
     out, err = capsys.readouterr()
-    # if colors are on, the output should have some escape sequences in it
+    # if colors are on, the output should have some ANSI style sequences in it
     assert len(out) > len('oopsie\n')
     assert 'oopsie' in out
     assert len(err) > len('oopsie\n')
@@ -2134,13 +2134,13 @@ def test_ansi_pouterr_always_tty(mocker, capsys):
 
 def test_ansi_pouterr_always_notty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_ALWAYS
+    ansi.allow_style = ansi.STYLE_ALWAYS
     mocker.patch.object(app.stdout, 'isatty', return_value=False)
     mocker.patch.object(sys.stderr, 'isatty', return_value=False)
 
     app.onecmd_plus_hooks('echo_error oopsie')
     out, err = capsys.readouterr()
-    # if colors are on, the output should have some escape sequences in it
+    # if colors are on, the output should have some ANSI style sequences in it
     assert len(out) > len('oopsie\n')
     assert 'oopsie' in out
     assert len(err) > len('oopsie\n')
@@ -2156,12 +2156,12 @@ def test_ansi_pouterr_always_notty(mocker, capsys):
 
 def test_ansi_terminal_tty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_TERMINAL
+    ansi.allow_style = ansi.STYLE_TERMINAL
     mocker.patch.object(app.stdout, 'isatty', return_value=True)
     mocker.patch.object(sys.stderr, 'isatty', return_value=True)
 
     app.onecmd_plus_hooks('echo_error oopsie')
-    # if colors are on, the output should have some escape sequences in it
+    # if colors are on, the output should have some ANSI style sequences in it
     out, err = capsys.readouterr()
     assert len(out) > len('oopsie\n')
     assert 'oopsie' in out
@@ -2177,7 +2177,7 @@ def test_ansi_terminal_tty(mocker, capsys):
 
 def test_ansi_terminal_notty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_TERMINAL
+    ansi.allow_style = ansi.STYLE_TERMINAL
     mocker.patch.object(app.stdout, 'isatty', return_value=False)
     mocker.patch.object(sys.stderr, 'isatty', return_value=False)
 
@@ -2191,7 +2191,7 @@ def test_ansi_terminal_notty(mocker, capsys):
 
 def test_ansi_never_tty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_NEVER
+    ansi.allow_style = ansi.STYLE_NEVER
     mocker.patch.object(app.stdout, 'isatty', return_value=True)
     mocker.patch.object(sys.stderr, 'isatty', return_value=True)
 
@@ -2205,7 +2205,7 @@ def test_ansi_never_tty(mocker, capsys):
 
 def test_ansi_never_notty(mocker, capsys):
     app = AnsiApp()
-    ansi.allow_ansi = ansi.ANSI_NEVER
+    ansi.allow_style = ansi.STYLE_NEVER
     mocker.patch.object(app.stdout, 'isatty', return_value=False)
     mocker.patch.object(sys.stderr, 'isatty', return_value=False)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -349,7 +349,7 @@ def test_align_text_term_width():
     fill_char = ' '
 
     term_width = shutil.get_terminal_size().columns
-    expected_fill = (term_width - ansi.ansi_safe_wcswidth(text)) * fill_char
+    expected_fill = (term_width - ansi.style_aware_wcswidth(text)) * fill_char
 
     aligned = cu.align_text(text, fill_char=fill_char, alignment=cu.TextAlignment.LEFT)
     assert aligned == text + expected_fill

--- a/tests/transcripts/regex_set.txt
+++ b/tests/transcripts/regex_set.txt
@@ -4,7 +4,7 @@
 # Regexes on prompts just make the trailing space obvious
 
 (Cmd) set
-allow_ansi: /(Terminal|Always|Never)/
+allow_style: /(Terminal|Always|Never)/
 continuation_prompt: >/ /
 debug: False
 echo: False


### PR DESCRIPTION
* Enhancements
    * Added dim text style support via `style()` function and `ansi.INTENSITY_DIM` setting.
* Breaking changes
    * Renamed the following `ansi` members for accuracy in what types of ANSI escape sequences are handled
        * `ansi.allow_ansi` -> `ansi.allow_style`
        * `ansi.ansi_safe_wcswidth()` -> `ansi.style_aware_wcswidth()`
        * `ansi.ansi_aware_write()` -> `ansi.style_aware_write()`
    * Renamed the following `ansi` members for clarification
        * `ansi.BRIGHT` -> `ansi.INTENSITY_BRIGHT`
        * `ansi.NORMAL` -> `ansi.INTENSITY_NORMAL`