### PR TITLE
Update copyright through 2020 and restore original documentation copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2019 Catherine Devlin and others
+Copyright (c) 2008-2020 Catherine Devlin and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'cmd2'
-copyright = '2010-2019, cmd2 contributors'
+copyright = '2010-2020, cmd2 contributors'
 author = 'cmd2 contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -1,7 +1,6 @@
 Copyright
 =========
 
-The ``cmd2`` documentation is Copyright 2010-2019 by the `cmd2 contributors
+The ``cmd2`` documentation is Copyright 2010-2020 by the `cmd2 contributors
 <https://github.com/python-cmd2/cmd2/graphs/contributors>`_ and is licensed
-under a `Creative Commons Attribution 4.0 International License
-<http://creativecommons.org/licenses/by/4.0/>`_.
+under an `MIT License <https://github.com/python-cmd2/cmd2/blob/master/LICENSE>`_.


### PR DESCRIPTION
Update copyright through 2020 and restore original documentation copyright to MIT license.

During recent work to upgrade the format of the Sphinx documentation, the license the docs are copyright under was accidentally changed from MIT to CreativeCommons.  This restores the documentation to be under an MIT license so there is a single license governing both code and documentation.

It also updates copyright through the current year (2020).