### PR TITLE
Upgrade Travis and AzurePipelines to use release version of Python 3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,14 +8,11 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       TOXENV: "py36"
+
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       TOXENV: "py37"
-    - PYTHON: "C:\\Miniconda38-x64"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py38"
 
 init:
   - "%PYTHON%/python -V"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,11 +8,14 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       TOXENV: "py36"
-
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       TOXENV: "py37"
+    - PYTHON: "C:\\Miniconda38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py38"
 
 init:
   - "%PYTHON%/python -V"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           dist: xenial
           env: TOXENV=py39
         - os: linux
-          python: 3.5
+          python: 3.7
           env: TOXENV=docs
 #        # Warning: Don't try to use code coverage analysis with pypy as it is insanely slow
 #        - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ matrix:
           dist: xenial
           env: TOXENV=py37
         - os: linux
-          python: 3.8-dev
+          python: 3.8
           dist: xenial
           env: TOXENV=py38
+        - os: linux
+          python: 3.9-dev
+          dist: xenial
+          env: TOXENV=py39
         - os: linux
           python: 3.5
           env: TOXENV=docs
@@ -43,7 +47,7 @@ install:
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  if [[ $TOXENV == py37 ]]; then
+  if [[ $TOXENV == py38 ]]; then
     flake8 . --count --ignore=E252,W503 --max-complexity=26 --max-line-length=127 --show-source --statistics ;
   fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     * Added function to truncate a single line to fit within a given display width. `cmd2.utils.truncate_line`
     supports characters with display widths greater than 1 and ANSI style sequences.
     * Added line truncation support to `cmd2.utils` text alignment functions.
+    * Added support for Python 3.9 alpha
 
 ## 0.9.23 (January 9, 2020)
 * Bug Fixes

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 attrs = ">=16.3.0"
 colorama = ">=0.3.7"
 pyperclip = ">=1.6"
+setuptools = ">=34.4"
 wcwidth = ">=0.1.7"
 
 [dev-packages]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,9 @@ jobs:
       Python37:
         python.version: '3.7'
         TOXENV: 'py37'
+      Python38:
+        python.version: '3.8'
+        TOXENV: 'py38'
     # Increase the maxParallel value to simultaneously run the job for all versions in the matrix (max 10 for free open-source)
     maxParallel: 4
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines())))  # noqa: E128

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,py35,py36,py37,py38
+envlist = docs,py35,py36,py37,py38,py39
 
 [pytest]
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
   codecov
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.7
 deps =
   sphinx
   sphinx-rtd-theme


### PR DESCRIPTION
Changes include:
- Change TravisCI from 3.8-dev to 3.8
- Add 3.9-dev to TravisCI
- Change Sphinx doc build on Travis to use Python 3.7 instead of 3.5 since that is version used now by ReadTheDocs for Buidls
- Add 3.8 to AzurePipelines
- Change `flake8` to use Python 3.8 instead of 3.7

Closes #848 
Closes #849 