### PR TITLE
Update Azure Pipelines MacOs image from 10.13 to 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
 
   # Configure Build Environment to use Azure Pipelines to build Python project using macOS
   pool:
-    vmImage: 'macOS 10.13'  # other options 'Ubuntu 16.04', 'VS2017-Win2016'
+    vmImage: 'macOS 10.14'  # Azure will be adding the latest macOS version – Catalina or macOS-10.15 on February 3, 2020
 
   # Run the pipeline with multiple Python versions
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
 
   # Configure Build Environment to use Azure Pipelines to build Python project using macOS
   pool:
-    vmImage: 'macOS 10.14'  # Azure will be adding the latest macOS version – Catalina or macOS-10.15 on February 3, 2020
+    vmImage: 'macOS-latest'  # 10.14 Mojave, Azure will be adding Catalina or macOS-10.15 on February 3, 2020
 
   # Run the pipeline with multiple Python versions
   strategy:


### PR DESCRIPTION
Update Azure Pipelines MacOs image from 10.13 (HighSierra) to 10.14 (Mojave)

Azure Pipelines will be removing the macOS X High Sierra 10.13 images on March 23, 2020.  MacOs 10.14 images are available now and MacOs 10.15 (Catalina) images are planned to be available on Feb 3, 2020.

Fixes #855 