### PR TITLE
Cleanup MANIFEST.in to reduce whats in PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
-include LICENSE
-include README.md
-include CHANGELOG.md
-include CODEOWNERS
-include CONTRIBUTING.md
-include tox.ini
+include LICENSE README.md CHANGELOG.md CONTRIBUTING.md tox.ini Pipfile
 recursive-include examples *
 recursive-include tests *
+recursive-include docs *
+recursive-exclude docs/_build *
+exclude .appveyor.yml .gitignore .travis.yml azure-pipelines.yml CODEOWNERS tasks.py

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -1,6 +1,0 @@
-Copyright
-=========
-
-The ``cmd2`` documentation is Copyright 2010-2020 by the `cmd2 contributors
-<https://github.com/python-cmd2/cmd2/graphs/contributors>`_ and is licensed
-under an `MIT License <https://github.com/python-cmd2/cmd2/blob/master/LICENSE>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,4 +87,3 @@ Meta
    :caption: Meta
 
    doc_conventions
-   copyright

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines())))  # noqa: E128
 
-SETUP_REQUIRES = ['setuptools_scm >= 3.0.0']
+SETUP_REQUIRES = ['setuptools_scm >= 3.0']
 
 INSTALL_REQUIRES = ['attrs >= 16.3.0', 'colorama >= 0.3.7', 'pyperclip >= 1.6', 'setuptools >= 34.4', 'wcwidth >= 0.1.7']
 


### PR DESCRIPTION
Cleanup MANIFEST.in to reduce what gets put in package downloadable from PyPI.  I decided to leave the `docs` directory in but to make sure that the `docs/_build` directory doesn't get included.  But it cuts out stuff from the PyPI package which shouldn't be there like configuration files for our CI systems.

Also:
- Trivial simplification in setup.py
- Removed redundant copyright.rst file from docs since everything falls under the MIT License and there is already copyright statement in docs

Closes #857 