### PR TITLE
Fixed broken links in Sphinx docs

### DIFF
--- a/docs/examples/first_app.rst
+++ b/docs/examples/first_app.rst
@@ -284,14 +284,14 @@ Users can access command history using two methods:
 
 - the `readline <https://docs.python.org/3/library/readline.html>`_ library
   which provides a python interface to the `GNU readline library
-  <https://tiswww.case.edu/php/chet/readline/rltop.html>`_
+  <https://en.wikipedia.org/wiki/GNU_Readline>`_
 - the ``history`` command which is built-in to ``cmd2``
 
 From the prompt in a ``cmd2``-based application, you can press ``Control-p`` to
 move to the previously entered command, and ``Control-n`` to move to the next
 command. You can also search through the command history using ``Control-r``.
 The `GNU Readline User Manual
-<https://tiswww.case.edu/php/chet/readline/rluserman.html>`_ has all the
+<http://man7.org/linux/man-pages/man3/readline.3.html>`_ has all the
 details, including all the available commands, and instructions for customizing
 the key bindings.
 

--- a/docs/features/completion.rst
+++ b/docs/features/completion.rst
@@ -60,7 +60,7 @@ displayed to help the user.
 
 .. _arg_decorators: https://github.com/python-cmd2/cmd2/blob/master/examples/arg_decorators.py
 .. _colors: https://github.com/python-cmd2/cmd2/blob/master/examples/colors.py
-.. _tab_autocompletion: https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocompletion..py
+.. _tab_autocompletion: https://github.com/python-cmd2/cmd2/blob/master/examples/tab_autocompletion.py
 
 
 CompletionItem For Providing Extra Context

--- a/docs/features/history.rst
+++ b/docs/features/history.rst
@@ -29,7 +29,7 @@ You can also search through the command history using ``Control-r``.
 Eric Johnson hosts a nice `readline cheat sheet
 <http://readline.kablamo.org/emacs.html>`_, or you can dig into the `GNU
 Readline User Manual
-<https://tiswww.case.edu/php/chet/readline/rluserman.html>`_ for all the
+<http://man7.org/linux/man-pages/man3/readline.3.html>`_ for all the
 details, including instructions for customizing the key bindings.
 
 ``cmd2`` makes a third type of history access available with the ``history``

--- a/docs/overview/alternatives.rst
+++ b/docs/overview/alternatives.rst
@@ -10,8 +10,8 @@ argparse_.
 
 .. _sys: https://docs.python.org/3/library/sys.html
 .. _argparse: https://docs.python.org/3/library/argparse.html
-.. _docopt: https://pypi.python.org/pypi/docopt
-.. _click: http://click.pocoo.org
+.. _docopt: https://pypi.org/project/docopt
+.. _click: https://click.palletsprojects.com
 
 
 The curses_ module produces applications that interact via a plaintext terminal
@@ -31,7 +31,7 @@ nonetheless. Two of the most mature and full featured are:
   * `Python Prompt Toolkit`_
   * Click_
 
-.. _`Python Prompt Toolkit`: https://github.com/jonathanslenders/python-prompt-toolkit
+.. _`Python Prompt Toolkit`: https://github.com/prompt-toolkit/python-prompt-toolkit
 
 `Python Prompt Toolkit`_ is a library for building powerful interactive command
 lines and terminal applications in Python.  It provides a lot of advanced

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -3,9 +3,9 @@ Installation Instructions
 =========================
 
 
-.. _pip: https://pypi.python.org/pypi/pip
-.. _setuptools: https://pypi.python.org/pypi/setuptools
-.. _PyPI: https://pypi.python.org/pypi
+.. _pip: https://pypi.org/project/pip
+.. _setuptools: https://pypi.org/project/setuptools
+.. _PyPI: https://pypi.org
 
 ``cmd2`` works on Linux, macOS, and Windows. It requires Python 3.5 or
 higher, pip_, and setuptools_. If you've got all that, then you can just:
@@ -129,7 +129,7 @@ environment on a Mac, detailed in the following subsections.
 gnureadline Python module
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install the `gnureadline <https://pypi.python.org/pypi/gnureadline>`_ Python module which is statically linked against a specific compatible version of GNU Readline:
+Install the `gnureadline <https://pypi.org/project/gnureadline>`_ Python module which is statically linked against a specific compatible version of GNU Readline:
 
 .. code-block:: shell
 

--- a/tasks.py
+++ b/tasks.py
@@ -45,7 +45,7 @@ namespace.add_collection(namespace_clean, 'clean')
 @invoke.task
 def pytest(context):
     "Run tests and code coverage using pytest"
-    context.run("pytest --cov=cmd2 --cov-report=term --cov-report=html")
+    context.run("pytest --cov=cmd2 --cov-report=term --cov-report=html", pty=True)
 namespace.add_task(pytest)
 
 @invoke.task
@@ -98,7 +98,7 @@ SPHINX_OPTS = '-nvWT'   # Be nitpicky, verbose, and treat warnings as errors
 def docs(context, builder='html'):
     "Build documentation using sphinx"
     cmdline = 'python -msphinx -M {} {} {} {}'.format(builder, DOCS_SRCDIR, DOCS_BUILDDIR, SPHINX_OPTS)
-    context.run(cmdline)
+    context.run(cmdline, pty=True)
 namespace.add_task(docs)
 
 @invoke.task()
@@ -113,6 +113,12 @@ def docs_clean(context):
     #pylint: disable=unused-argument
     rmrf(DOCS_BUILDDIR)
 namespace_clean.add_task(docs_clean, name='docs')
+
+@invoke.task()
+def linkcheck(context):
+    """Check external links in Sphinx documentation for integrity."""
+    context.run('cd docs && make linkcheck', pty=True)
+namespace.add_task(linkcheck)
 
 @invoke.task
 def livehtml(context):


### PR DESCRIPTION
So I just discovered that Sphinx has a built-in **linkcheck** `make` target which will automatically identify broken links.  I used this to fix broken links.  I also added an `invoke` target for doing this.  In the process I figured out how to get `invoke` to display colored text.

Also:
- Added a "linkcheck" task to the invoke tasks
- Use pseudoterminals for invoke tasks with colored output so that we can see the color when using invoke