### PR TITLE
Improve the Sphinx docs for initialization

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -272,9 +272,6 @@ class Cmd(cmd.Cmd):
         # Otherwise it will be None. Its used to know when a pipe process can be killed and/or waited upon.
         self._cur_pipe_proc_reader = None
 
-        # Used by complete() for readline tab completion
-        self.completion_matches = []
-
         # Used to keep track of whether we are redirecting or piping output
         self._redirecting = False
 
@@ -321,45 +318,6 @@ class Cmd(cmd.Cmd):
         elif transcript_files:
             self._transcript_files = transcript_files
 
-        # The default key for sorting string results. Its default value performs a case-insensitive alphabetical sort.
-        # If natural sorting is preferred, then set this to NATURAL_SORT_KEY.
-        # cmd2 uses this key for sorting:
-        #     command and category names
-        #     alias, macro, settable, and shortcut names
-        #     tab completion results when self.matches_sorted is False
-        self.default_sort_key = Cmd.ALPHABETICAL_SORT_KEY
-
-        ############################################################################################################
-        # The following variables are used by tab-completion functions. They are reset each time complete() is run
-        # in reset_completion_defaults() and it is up to completer functions to set them before returning results.
-        ############################################################################################################
-
-        # If True and a single match is returned to complete(), then a space will be appended
-        # if the match appears at the end of the line
-        self.allow_appended_space = True
-
-        # If True and a single match is returned to complete(), then a closing quote
-        # will be added if there is an unmatched opening quote
-        self.allow_closing_quote = True
-
-        # An optional header that prints above the tab-completion suggestions
-        self.completion_header = ''
-
-        # Use this list if you are completing strings that contain a common delimiter and you only want to
-        # display the final portion of the matches as the tab-completion suggestions. The full matches
-        # still must be returned from your completer function. For an example, look at path_complete()
-        # which uses this to show only the basename of paths as the suggestions. delimiter_complete() also
-        # populates this list.
-        self.display_matches = []
-
-        # Used by functions like path_complete() and delimiter_complete() to properly
-        # quote matches that are completed in a delimited fashion
-        self.matches_delimited = False
-
-        # Set to True before returning matches to complete() in cases where matches have already been sorted.
-        # If False, then complete() will sort the matches using self.default_sort_key before they are displayed.
-        self.matches_sorted = False
-
         # Set the pager(s) for use with the ppaged() method for displaying output using a pager
         if sys.platform.startswith('win'):
             self.pager = self.pager_chop = 'more'
@@ -391,6 +349,48 @@ class Cmd(cmd.Cmd):
         # If any command has been categorized, then all other commands that haven't been categorized
         # will display under this section in the help output.
         self.default_category = 'Uncategorized'
+
+        # The default key for sorting string results. Its default value performs a case-insensitive alphabetical sort.
+        # If natural sorting is preferred, then set this to NATURAL_SORT_KEY.
+        # cmd2 uses this key for sorting:
+        #     command and category names
+        #     alias, macro, settable, and shortcut names
+        #     tab completion results when self.matches_sorted is False
+        self.default_sort_key = Cmd.ALPHABETICAL_SORT_KEY
+
+        ############################################################################################################
+        # The following variables are used by tab-completion functions. They are reset each time complete() is run
+        # in _reset_completion_defaults() and it is up to completer functions to set them before returning results.
+        ############################################################################################################
+
+        # If True and a single match is returned to complete(), then a space will be appended
+        # if the match appears at the end of the line
+        self.allow_appended_space = True
+
+        # If True and a single match is returned to complete(), then a closing quote
+        # will be added if there is an unmatched opening quote
+        self.allow_closing_quote = True
+
+        # An optional header that prints above the tab-completion suggestions
+        self.completion_header = ''
+
+        # Used by complete() for readline tab completion
+        self.completion_matches = []
+
+        # Use this list if you are completing strings that contain a common delimiter and you only want to
+        # display the final portion of the matches as the tab-completion suggestions. The full matches
+        # still must be returned from your completer function. For an example, look at path_complete()
+        # which uses this to show only the basename of paths as the suggestions. delimiter_complete() also
+        # populates this list.
+        self.display_matches = []
+
+        # Used by functions like path_complete() and delimiter_complete() to properly
+        # quote matches that are completed in a delimited fashion
+        self.matches_delimited = False
+
+        # Set to True before returning matches to complete() in cases where matches have already been sorted.
+        # If False, then complete() will sort the matches using self.default_sort_key before they are displayed.
+        self.matches_sorted = False
 
     # -----  Methods related to presenting output to the user -----
 

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -108,7 +108,10 @@ override:
   support commands that are only available during specific states of the
   application. This dictionary's keys are the command names and its values are
   DisabledCommand objects.
-- **echo**: if ``True`` echo command issued into output (Default: ``False``)
+- **echo**: if ``True``, each command the user issues will be repeated to the
+  screen before it is executed. This is particularly useful when running
+  scripts. This behavior does not occur when a running command at the prompt.
+  (Default: ``False``)
 - **editor**: text editor program to use with *edit* command (e.g. ``vim``)
 - **exclude_from_history**: commands to exclude from the *history* command
 - **exit_code**: this determines the value returned by ``cmdloop()`` when
@@ -125,14 +128,15 @@ override:
 - **locals_in_py**: if ``True`` allow access to your application in *py*
   command via ``self`` (Default: ``False``)
 - **macros**: dictionary of macro names and their values
-- **max_completion_items**: max number of items to display during tab-
-  completion (Default: 50)
+- **max_completion_items**: max number of CompletionItems to display during
+  tab-completion (Default: 50)
 - **pager**: sets the pager command used by the ``Cmd.ppaged()`` method for
   displaying wrapped output using a pager
 - **pager_chop**: sets the pager command used by the ``Cmd.ppaged()`` method
   for displaying chopped/truncated output using a pager
 - **py_bridge_name**: name by which embedded Python environments and scripts
-  refer to the ``cmd2`` application by in order to call commands
+  refer to the ``cmd2`` application by in order to call commands (Default:
+  ``app``)
 - **py_locals**: dictionary that defines specific variables/functions available
   in Python shells and scripts (provides more fine-grained control than making
   everything available with **locals_in_py**)

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -87,8 +87,8 @@ The ``cmd2.Cmd`` class provides a large number of public instance attributes
 which allow developers to customize a ``cmd2`` application further beyond the
 options provided by the ``__init__()`` method.
 
-Common instance attributes to override
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Public instance attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 Here are instance attributes of ``cmd2.Cmd`` which developers might wish
 override:
 
@@ -148,20 +148,3 @@ override:
   are settable at runtime using the *set* command
 - **timing**: if ``True`` display execution time for each command (Default:
   ``False``)
-
-Rare instance attributes to override
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These instance attributes are used by built-in tab-completion functions.
-
-These instance attributes really are not intended for ``cmd2`` developers to
-override, but they are there for unusual circumstances where it may be
-necessary:
-
-- **sigint_protection**: context manager used to protect critical sections in
-  the main thread from stopping due to a KeyboardInterrupt
-- **statement_parser**: object which parses all command line arguments (it
-  would be extremely rare to use something other than the default for this)
-- **terminal_lock**: this lock should be acquired before doing any asynchronous
-  changes to the terminal to ensure the updates to the terminal don't interfere
-  with the input being typed or output being printed by a command.

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -64,3 +64,100 @@ capabilities which you may wish to utilize while initializing the app::
     if __name__ == '__main__':
         app = BasicApp()
         app.cmdloop()
+
+
+Cmd class initializer
+---------------------
+
+A ``cmd2.Cmd`` instance or subclass instance is an interactive CLI application
+framework. There is no good reason to instantiate ``Cmd`` itself; rather, it’s
+useful as a superclass of a class you define yourself in order to inherit
+``Cmd``’s methods and encapsulate action methods.
+
+Certain things must be initialized within the ``__init__()`` method of your
+class derived from ``cmd2.Cmd``(all arguments to ``__init__()`` are optional):
+
+.. automethod:: cmd2.cmd2.Cmd.__init__
+    :noindex:
+
+Cmd instance attributes
+-----------------------
+
+The ``cmd2.Cmd`` class provides a large number of public instance attributes
+which allow developers to customize a ``cmd2`` application further beyond the
+options provided by the ``__init__()`` method.
+
+Common instance attributes to override
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Here are instance attributes of ``cmd2.Cmd`` which developers might wish
+override:
+
+- **broken_pipe_warning**: if non-empty, this string will be displayed if a
+  broken pipe error occurs
+- **continuation_prompt**: used for multiline commands on 2nd+ line of input
+- **debug**: if ``True`` show full stack trace on error (Default: ``False``)
+- **default_category**: if any command has been categorized, then all other
+  commands that haven't been categorized will display under this section in the
+  help output.
+- **default_error**: the error that prints when a non-existent command is run
+- **default_sort_key**: the default key for sorting string results. Its default
+  value performs a case-insensitive alphabetical sort.
+- **default_to_shell**: if ``True`` attempt to run unrecognized commands as
+  shell commands (Default: ``False``)
+- **disabled_commands**: commands that have been disabled from use. This is to
+  support commands that are only available during specific states of the
+  application. This dictionary's keys are the command names and its values are
+  DisabledCommand objects.
+- **echo**: if ``True`` echo command issued into output (Default: ``False``)
+- **editor**: text editor program to use with *edit* command (e.g. ``vim``)
+- **exclude_from_history**: commands to exclude from the *history* command
+- **exit_code**: this determines the value returned by ``cmdloop()`` when
+  exiting the application
+- **feedback_to_output**: if ``True`` send nonessential output to stdout, if
+  ``False`` send them to stderr (Default: ``False``)
+- **help_error**: the error that prints when no help information can be found
+- **hidden_commands**: commands to exclude from the help menu and tab
+  completion
+- **last_result**: stores results from the last command run to enable usage
+  of results in a Python script or interactive console. Built-in commands don't
+  make use of this.  It is purely there for user-defined commands and
+  convenience.
+- **locals_in_py**: if ``True`` allow access to your application in *py*
+  command via ``self`` (Default: ``False``)
+- **macros**: dictionary of macro names and their values
+- **max_completion_items**: max number of items to display during tab-
+  completion (Default: 50)
+- **pager**: sets the pager command used by the ``Cmd.ppaged()`` method for
+  displaying wrapped output using a pager
+- **pager_chop**: sets the pager command used by the ``Cmd.ppaged()`` method
+  for displaying chopped/truncated output using a pager
+- **py_bridge_name**: name by which embedded Python environments and scripts
+  refer to the ``cmd2`` application by in order to call commands
+- **py_locals**: dictionary that defines specific variables/functions available
+  in Python shells and scripts (provides more fine-grained control than making
+  everything available with **locals_in_py**)
+- **quiet**: if ``True`` then completely suppress nonessential output (Default:
+  ``False``)
+- **quit_on_sigint**: if ``True`` quit the main loop on interrupt instead of
+  just resetting prompt
+- **settable**: dictionary that controls which of these instance attributes
+  are settable at runtime using the *set* command
+- **timing**: if ``True`` display execution time for each command (Default:
+  ``False``)
+
+Rare instance attributes to override
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These instance attributes are used by built-in tab-completion functions.
+
+These instance attributes really are not intended for ``cmd2`` developers to
+override, but they are there for unusual circumstances where it may be
+necessary:
+
+- **sigint_protection**: context manager used to protect critical sections in
+  the main thread from stopping due to a KeyboardInterrupt
+- **statement_parser**: object which parses all command line arguments (it
+  would be extremely rare to use something other than the default for this)
+- **terminal_lock**: this lock should be acquired before doing any asynchronous
+  changes to the terminal to ensure the updates to the terminal don't interfere
+  with the input being typed or output being printed by a command.

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -7,15 +7,16 @@ capabilities which you may wish to utilize while initializing the app::
     #!/usr/bin/env python3
     # coding=utf-8
     """A simple example cmd2 application demonstrating the following:
-        1) Colorizing/stylizing output
-        2) Using multiline commands
-        3) Persistent history
-        4) How to run an initialization script at startup
-        5) How to group and categorize commands when displaying them in help
-        6) Opting-in to using the ipy command to run an IPython shell
-        7) Allowing access to your application in py and ipy
-        8) Displaying an intro banner upon starting your application
-        9) Using a custom prompt
+         1) Colorizing/stylizing output
+         2) Using multiline commands
+         3) Persistent history
+         4) How to run an initialization script at startup
+         5) How to group and categorize commands when displaying them in help
+         6) Opting-in to using the ipy command to run an IPython shell
+         7) Allowing access to your application in py and ipy
+         8) Displaying an intro banner upon starting your application
+         9) Using a custom prompt
+        10) How to make custom attributes settable at runtime
     """
     import cmd2
     from cmd2 import style

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -6,7 +6,7 @@ capabilities which you may wish to utilize while initializing the app::
 
     #!/usr/bin/env python3
     # coding=utf-8
-    """A simple example cmd2 appliction demonstrating the following:
+    """A simple example cmd2 application demonstrating the following:
         1) Colorizing/stylizing output
         2) Using multiline commands
         3) Persistent history
@@ -28,14 +28,26 @@ capabilities which you may wish to utilize while initializing the app::
             super().__init__(multiline_commands=['echo'], persistent_history_file='cmd2_history.dat',
                              startup_script='scripts/startup.txt', use_ipython=True)
 
+            # Prints an intro banner once upon application startup
             self.intro = style('Welcome to cmd2!', fg='red', bg='white', bold=True)
+
+            # Show this as the prompt when asking for input
             self.prompt = 'myapp> '
+
+            # Used as prompt for multiline commands after the first line
+            self.continuation_prompt = '... '
 
             # Allow access to your application in py and ipy via self
             self.locals_in_py = True
 
             # Set the default category name
             self.default_category = 'cmd2 Built-in Commands'
+
+            # Color to output text in with echo command
+            self.foreground_color = 'cyan'
+
+            # Make echo_fg settable at runtime
+            self.settable['foreground_color'] = 'Foreground color to use with echo command'
 
         @cmd2.with_category(CUSTOM_CATEGORY)
         def do_intro(self, _):
@@ -45,7 +57,7 @@ capabilities which you may wish to utilize while initializing the app::
         @cmd2.with_category(CUSTOM_CATEGORY)
         def do_echo(self, arg):
             """Example of a multiline command"""
-            self.poutput(arg)
+            self.poutput(style(arg, fg=self.foreground_color))
 
 
     if __name__ == '__main__':

--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -69,9 +69,9 @@ trace will be printed.
 echo
 ~~~~
 
-If ``True``, each command the user issues will be repeated to the screen before
-it is executed.  This is particularly useful when running scripts. This
-behavior does not occur when a running command at the prompt.
+If ``True``, each command the user issues will be repeated to the screen
+before it is executed. This is particularly useful when running scripts.
+This behavior does not occur when a running command at the prompt.
 
 
 editor

--- a/examples/initialization.py
+++ b/examples/initialization.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# coding=utf-8
+"""A simple example cmd2 application demonstrating the following:
+     1) Colorizing/stylizing output
+     2) Using multiline commands
+     3) Persistent history
+     4) How to run an initialization script at startup
+     5) How to group and categorize commands when displaying them in help
+     6) Opting-in to using the ipy command to run an IPython shell
+     7) Allowing access to your application in py and ipy
+     8) Displaying an intro banner upon starting your application
+     9) Using a custom prompt
+    10) How to make custom attributes settable at runtime
+"""
+import cmd2
+from cmd2 import style
+
+
+class BasicApp(cmd2.Cmd):
+    CUSTOM_CATEGORY = 'My Custom Commands'
+
+    def __init__(self):
+        super().__init__(multiline_commands=['echo'], persistent_history_file='cmd2_history.dat',
+                         startup_script='scripts/startup.txt', use_ipython=True)
+
+        # Prints an intro banner once upon application startup
+        self.intro = style('Welcome to cmd2!', fg='red', bg='white', bold=True)
+
+        # Show this as the prompt when asking for input
+        self.prompt = 'myapp> '
+
+        # Used as prompt for multiline commands after the first line
+        self.continuation_prompt = '... '
+
+        # Allow access to your application in py and ipy via self
+        self.locals_in_py = True
+
+        # Set the default category name
+        self.default_category = 'cmd2 Built-in Commands'
+
+        # Color to output text in with echo command
+        self.foreground_color = 'cyan'
+
+        # Make echo_fg settable at runtime
+        self.settable['foreground_color'] = 'Foreground color to use with echo command'
+
+    @cmd2.with_category(CUSTOM_CATEGORY)
+    def do_intro(self, _):
+        """Display the intro banner"""
+        self.poutput(self.intro)
+
+    @cmd2.with_category(CUSTOM_CATEGORY)
+    def do_echo(self, arg):
+        """Example of a multiline command"""
+        self.poutput(style(arg, fg=self.foreground_color))
+
+
+if __name__ == '__main__':
+    app = BasicApp()
+    app.cmdloop()


### PR DESCRIPTION
Improved the Sphinx docs for initialization:
- Improved existing example
- Added this example under the *examples* directory as **initializaiton.py**
- Added documentation for public instance attributes that can be set/initialized to customize a `cmd2` application
  - Broke these down into ones set in `__init__()` and other public instance attributes


Also:
- Did some minor reorganization of instance attributes in `cmd2.Cmd` to make it clear that they were not used by tab-completion functions

This partially addresses #765