### PR TITLE
Settable attributes with original value `None` can be set to a str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.26 (TBD, 2020)
 * Enhancements
     * Changed the default help text to make `help -v` more discoverable
+    * Settable attributes with original value `None` can now be set to a string
 * Breaking changes
     * Renamed `locals_in_py` attribute of `cmd2.Cmd` to `self_in_py`
     * The following public attributes of `cmd2.Cmd` are no longer settable at runtime by default:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -93,8 +93,12 @@ def cast(current: Any, new: str) -> Any:
 
     :param current: current value for the parameter, type varies
     :param new: new value
-    :return: new value with same type as current, or the current value if there was an error casting
+    :return: new value with same type as current, or the current value if there was an error casting or original was None
     """
+    # Prevent an attempt at casting to NoneType
+    if current is None:
+        return new
+
     typ = type(current)
     orig_new = new
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -118,45 +118,6 @@ def test_base_show_readonly(base_app):
     assert out == expected
 
 
-def test_cast():
-    # Boolean
-    assert utils.cast(True, True) == True
-    assert utils.cast(True, False) == False
-    assert utils.cast(True, 0) == False
-    assert utils.cast(True, 1) == True
-    assert utils.cast(True, 'on') == True
-    assert utils.cast(True, 'off') == False
-    assert utils.cast(True, 'ON') == True
-    assert utils.cast(True, 'OFF') == False
-    assert utils.cast(True, 'y') == True
-    assert utils.cast(True, 'n') == False
-    assert utils.cast(True, 't') == True
-    assert utils.cast(True, 'f') == False
-
-    # Non-boolean same type
-    assert utils.cast(1, 5) == 5
-    assert utils.cast(3.4, 2.7) == 2.7
-    assert utils.cast('foo', 'bar') == 'bar'
-    assert utils.cast([1,2], [3,4]) == [3,4]
-
-def test_cast_problems(capsys):
-    expected = 'Problem setting parameter (now {}) to {}; incorrect type?\n'
-
-    # Boolean current, with new value not convertible to bool
-    current = True
-    new = [True, True]
-    assert utils.cast(current, new) == current
-    out, err = capsys.readouterr()
-    assert out == expected.format(current, new)
-
-    # Non-boolean current, with new value not convertible to current type
-    current = 1
-    new = 'octopus'
-    assert utils.cast(current, new) == current
-    out, err = capsys.readouterr()
-    assert out == expected.format(current, new)
-
-
 def test_base_set(base_app):
     out, err = run_cmd(base_app, 'set quiet True')
     expected = normalize("""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -531,3 +531,45 @@ def test_align_right_wide_fill_needs_padding():
     width = 6
     aligned = cu.align_right(text, fill_char=fill_char, width=width)
     assert aligned == fill_char + ' ' + text
+
+
+def test_cast():
+    # None
+    assert cu.cast(None, 'foo') == 'foo'
+
+    # Boolean
+    assert cu.cast(True, True) == True
+    assert cu.cast(True, False) == False
+    assert cu.cast(True, 0) == False
+    assert cu.cast(True, 1) == True
+    assert cu.cast(True, 'on') == True
+    assert cu.cast(True, 'off') == False
+    assert cu.cast(True, 'ON') == True
+    assert cu.cast(True, 'OFF') == False
+    assert cu.cast(True, 'y') == True
+    assert cu.cast(True, 'n') == False
+    assert cu.cast(True, 't') == True
+    assert cu.cast(True, 'f') == False
+
+    # Non-boolean same type
+    assert cu.cast(1, 5) == 5
+    assert cu.cast(3.4, 2.7) == 2.7
+    assert cu.cast('foo', 'bar') == 'bar'
+    assert cu.cast([1,2], [3,4]) == [3,4]
+
+def test_cast_problems(capsys):
+    expected = 'Problem setting parameter (now {}) to {}; incorrect type?\n'
+
+    # Boolean current, with new value not convertible to bool
+    current = True
+    new = [True, True]
+    assert cu.cast(current, new) == current
+    out, err = capsys.readouterr()
+    assert out == expected.format(current, new)
+
+    # Non-boolean current, with new value not convertible to current type
+    current = 1
+    new = 'octopus'
+    assert cu.cast(current, new) == current
+    out, err = capsys.readouterr()
+    assert out == expected.format(current, new)


### PR DESCRIPTION
Settable attributes with original value `None` can now be set to a string

Also:
- Moved unit tests of cast utility function from test_cmd2.py to test_utils.py

Closes #870 