### PR TITLE
do_set flag rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 * Bug Fixes
     * Corrected issue where the actual new value was not always being printed in do_set. This occurred in cases where
       the typed value differed from what the setter had converted it to.
+* Enhancements
+    * Renamed set command's `-l/--long` flag to `-v/--verbose` for consistency with help and history commands.
 
 ## 0.10.0 (February 7, 2020)
 * Enhancements

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2851,7 +2851,7 @@ class Cmd(cmd.Cmd):
                        "Call without arguments for a list of all settable parameters with their values.\n"
                        "Call with just param to view that parameter's value.")
     set_parser_parent = DEFAULT_ARGUMENT_PARSER(description=set_description, add_help=False)
-    set_parser_parent.add_argument('-l', '--long', action='store_true',
+    set_parser_parent.add_argument('-v', '--verbose', action='store_true',
                                    help='include description of parameters when viewing')
     set_parser_parent.add_argument('param', nargs=argparse.OPTIONAL, help='parameter to set or view',
                                    choices_method=_get_settable_completion_items, descriptive_header='Description')
@@ -2916,7 +2916,7 @@ class Cmd(cmd.Cmd):
         # Display the results
         for param in sorted(results, key=self.default_sort_key):
             result_str = results[param]
-            if args.long:
+            if args.verbose:
                 self.poutput('{} # {}'.format(utils.align_left(result_str, width=max_len),
                                               self.settables[param].description))
             else:

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -79,7 +79,7 @@ def test_base_argparse_help(base_app):
 
 def test_base_invalid_option(base_app):
     out, err = run_cmd(base_app, 'set -z')
-    assert err[0] == 'Usage: set [-h] [-l] [param] [value]'
+    assert err[0] == 'Usage: set [-h] [-v] [param] [value]'
     assert 'Error: unrecognized arguments: -z' in err[1]
 
 def test_base_shortcuts(base_app):
@@ -103,7 +103,7 @@ def test_base_show(base_app):
 def test_base_show_long(base_app):
     # force editor to be 'vim' so test is repeatable across platforms
     base_app.editor = 'vim'
-    out, err = run_cmd(base_app, 'set -l')
+    out, err = run_cmd(base_app, 'set -v')
     expected = normalize(SHOW_LONG)
     assert out == expected
 


### PR DESCRIPTION
Renamed set command's -l/--long flag to -v/--verbose for consistency with help and history commands