### PR TITLE
Appveyor fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,5 +31,8 @@ install:
   # about it being out of date.
   - "python -m pip install --upgrade pip wheel setuptools tox"
 
+  # Update conda stuff
+  - "conda update --all"
+
 test_script:
 - "tox -e %TOXENV%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,12 +27,13 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
-  - "python -m pip install --upgrade pip wheel setuptools tox"
+  # Update conda stuff to make sure pip, setuptools, wheel etc are up to date
+  - "conda update --all -y"
 
-  # Update conda stuff
-  - "conda update --all"
+  # Install tox
+  - "python -m pip install --upgrade tox"
+
+
 
 test_script:
 - "tox -e %TOXENV%"


### PR DESCRIPTION
This applies updates to the miniconda environment before trying to run the tests.

This slows things down a little but makes them more reliable.

This is just a stopgap until we investigate moving Windows testing to GitHub actions.