### PR TITLE
Making build_settables() public again

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -205,7 +205,7 @@ class Cmd(cmd.Cmd):
 
         # A dictionary mapping settable names to their Settable instance
         self.settables = dict()
-        self._build_settables()
+        self.build_settables()
 
         # Use as prompt for multiline commands on the 2nd+ line of input
         self.continuation_prompt = '> '
@@ -405,8 +405,8 @@ class Cmd(cmd.Cmd):
         except KeyError:
             raise KeyError(name + " is not a settable parameter")
 
-    def _build_settables(self):
-        """Add default settables"""
+    def build_settables(self):
+        """Create the dictionary of user-settable parameters"""
         self.add_settable(Settable('allow_style', str,
                                    'Allow ANSI text style sequences in output (valid values: '
                                    '{}, {}, {})'.format(ansi.STYLE_TERMINAL,

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -685,7 +685,7 @@ class RedirectionSavedState:
 def basic_complete(text: str, line: str, begidx: int, endidx: int, match_against: Iterable) -> List[str]:
     """
     Basic tab completion function that matches against a list of strings without considering line contents
-    or cursor position. The args required by this function are defined in the header of Pythons's cmd.py.
+    or cursor position. The args required by this function are defined in the header of Python's cmd.py.
 
     :param text: the string prefix we are attempting to match (all matches must begin with it)
     :param line: the current input line with leading whitespace removed


### PR DESCRIPTION
`build_settables()` was intended to be public. It was changed to protected during the documentation updates.