### PR TITLE
Parsing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1 (TBD, 2020)
 * Bug Fixes
-    * Fixed issue where postcmd hooks were running after an `argparse` error.
+    * Fixed issue where postcmd hooks were running after an `argparse` exception in a command.
 
 ## 1.0.0 (March 1, 2020)
 * Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 (TBD, 2020)
+* Bug Fixes
+    * Fixed issue where postcmd hooks were running after an `argparse` error.
+
 ## 1.0.0 (March 1, 2020)
 * Enhancements
     * The documentation at [cmd2.rftd.io](https://cmd2.readthedocs.io) received a major overhaul

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -50,7 +50,7 @@ from . import utils
 from .argparse_custom import CompletionItem, DEFAULT_ARGUMENT_PARSER
 from .clipboard import can_clip, get_paste_buffer, write_to_paste_buffer
 from .decorators import with_argparser
-from .exceptions import CmdLineError, EmbeddedConsoleExit, EmptyStatement
+from .exceptions import Cmd2ArgparseException, EmbeddedConsoleExit, EmptyStatement
 from .history import History, HistoryItem
 from .parsing import StatementParser, Statement, Macro, MacroArg, shlex_split
 from .rl_utils import rl_type, RlType, rl_get_point, rl_set_prompt, vt100_support, rl_make_safe_prompt, rl_warning
@@ -1683,7 +1683,7 @@ class Cmd(cmd.Cmd):
                         # Stop saving command's stdout before command finalization hooks run
                         self.stdout.pause_storage = True
 
-        except (CmdLineError, EmptyStatement):
+        except (Cmd2ArgparseException, EmptyStatement):
             # Don't do anything, but do allow command finalization hooks to run
             pass
         except Exception as ex:

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -4,6 +4,7 @@ import argparse
 from typing import Callable, List, Optional, Union
 
 from . import constants
+from .exceptions import CmdLineError
 from .parsing import Statement
 
 
@@ -144,7 +145,7 @@ def with_argparser_and_unknown_args(parser: argparse.ArgumentParser, *,
             try:
                 args, unknown = parser.parse_known_args(parsed_arglist, namespace)
             except SystemExit:
-                return
+                raise CmdLineError
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args, unknown)
@@ -216,7 +217,7 @@ def with_argparser(parser: argparse.ArgumentParser, *,
             try:
                 args = parser.parse_args(parsed_arglist, namespace)
             except SystemExit:
-                return
+                raise CmdLineError
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args)

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -4,7 +4,7 @@ import argparse
 from typing import Callable, List, Optional, Union
 
 from . import constants
-from .exceptions import Cmd2ArgparseException
+from .exceptions import Cmd2ArgparseError
 from .parsing import Statement
 
 
@@ -145,7 +145,7 @@ def with_argparser_and_unknown_args(parser: argparse.ArgumentParser, *,
             try:
                 args, unknown = parser.parse_known_args(parsed_arglist, namespace)
             except SystemExit:
-                raise Cmd2ArgparseException
+                raise Cmd2ArgparseError
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args, unknown)
@@ -217,7 +217,7 @@ def with_argparser(parser: argparse.ArgumentParser, *,
             try:
                 args = parser.parse_args(parsed_arglist, namespace)
             except SystemExit:
-                raise Cmd2ArgparseException
+                raise Cmd2ArgparseError
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args)

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -4,7 +4,7 @@ import argparse
 from typing import Callable, List, Optional, Union
 
 from . import constants
-from .exceptions import CmdLineError
+from .exceptions import Cmd2ArgparseException
 from .parsing import Statement
 
 
@@ -145,7 +145,7 @@ def with_argparser_and_unknown_args(parser: argparse.ArgumentParser, *,
             try:
                 args, unknown = parser.parse_known_args(parsed_arglist, namespace)
             except SystemExit:
-                raise CmdLineError
+                raise Cmd2ArgparseException
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args, unknown)
@@ -217,7 +217,7 @@ def with_argparser(parser: argparse.ArgumentParser, *,
             try:
                 args = parser.parse_args(parsed_arglist, namespace)
             except SystemExit:
-                raise CmdLineError
+                raise Cmd2ArgparseException
             else:
                 setattr(args, '__statement__', statement)
                 return func(cmd2_app, args)

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -2,8 +2,8 @@
 """Custom exceptions for cmd2.  These are NOT part of the public API and are intended for internal use only."""
 
 
-class CmdLineError(Exception):
-    """Custom class for when an error occurred parsing the command line"""
+class Cmd2ArgparseException(Exception):
+    """Custom exception class for when an argparse-decorated command has an error parsing its arguments"""
     pass
 
 

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -2,8 +2,17 @@
 """Custom exceptions for cmd2.  These are NOT part of the public API and are intended for internal use only."""
 
 
-class Cmd2ArgparseException(Exception):
-    """Custom exception class for when an argparse-decorated command has an error parsing its arguments"""
+class Cmd2ArgparseError(Exception):
+    """
+    Custom exception class for when a command has an error parsing its arguments.
+    This can be raised by argparse decorators or the command functions themselves.
+    The main use of this exception is to tell cmd2 not to run Postcommand hooks.
+    """
+    pass
+
+
+class Cmd2ShlexError(Exception):
+    """Raised when shlex fails to parse a command line string in StatementParser"""
     pass
 
 

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -2,6 +2,11 @@
 """Custom exceptions for cmd2.  These are NOT part of the public API and are intended for internal use only."""
 
 
+class CmdLineError(Exception):
+    """Custom class for when an error occurred parsing the command line"""
+    pass
+
+
 class EmbeddedConsoleExit(SystemExit):
     """Custom exception class for use with the py command."""
     pass

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -10,6 +10,7 @@ import attr
 
 from . import constants
 from . import utils
+from .exceptions import Cmd2ShlexError
 
 
 def shlex_split(str_to_split: str) -> List[str]:
@@ -330,7 +331,7 @@ class StatementParser:
 
         :param line: the command line being lexed
         :return: A list of tokens
-        :raises ValueError: if there are unclosed quotation marks
+        :raises: Cmd2ShlexError if a shlex error occurs (e.g. No closing quotation)
         """
 
         # expand shortcuts and aliases
@@ -341,7 +342,10 @@ class StatementParser:
             return []
 
         # split on whitespace
-        tokens = shlex_split(line)
+        try:
+            tokens = shlex_split(line)
+        except ValueError as ex:
+            raise Cmd2ShlexError(ex)
 
         # custom lexing
         tokens = self.split_on_punctuation(tokens)
@@ -355,7 +359,7 @@ class StatementParser:
 
         :param line: the command line being parsed
         :return: a new :class:`~cmd2.Statement` object
-        :raises ValueError: if there are unclosed quotation marks
+        :raises: Cmd2ShlexError if a shlex error occurs (e.g. No closing quotation)
         """
 
         # handle the special case/hardcoded terminator of a blank line
@@ -518,8 +522,6 @@ class StatementParser:
         :param rawinput: the command line as entered by the user
         :return: a new :class:`~cmd2.Statement` object
         """
-        line = rawinput
-
         # expand shortcuts and aliases
         line = self._expand(rawinput)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -96,7 +96,7 @@ def test_tokenize(parser, line, tokens):
     assert tokens_to_test == tokens
 
 def test_tokenize_unclosed_quotes(parser):
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.Cmd2ShlexError):
         _ = parser.tokenize('command with "unclosed quotes')
 
 @pytest.mark.parametrize('tokens,command,args', [
@@ -583,7 +583,7 @@ def test_parse_redirect_to_unicode_filename(parser):
     assert statement.output_to == 'café'
 
 def test_parse_unclosed_quotes(parser):
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.Cmd2ShlexError):
         _ = parser.tokenize("command with 'unclosed quotes")
 
 def test_empty_statement_raises_exception():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -849,7 +849,7 @@ def test_cmdfinalization_hook_exception(capsys):
 
 def test_cmd2_argparse_exception(capsys):
     """
-    Verify Cmd2ArgparseExceptions raised after calling a command prevent postcmd events from
+    Verify Cmd2ArgparseErrors raised after calling a command prevent postcmd events from
     running but do not affect cmdfinalization events
     """
     app = PluggedApp()


### PR DESCRIPTION
Fixes #905 

Before we merge this, I need to update `test_debug_not_settable()` since missing a quote no longer calls `pexcept()`.

We also need a unit test to make sure postcmd hooks aren't called if `argparse` fails.

I have 2 questions:
1. Is `CmdLineError` the right name for this exception? My docstring says it's an error that occurs during parsing. But that's slightly misleading since `StatementParser` already parsed the command line. `CmdLineErrors` are raised by our `argparse` decorators which actually parse after postparsing hooks.

2. In `onecmd_plus_hooks`, should I remove "Invalid Syntax: " before the `shlex` error? I'm assuming that `ValueError` will always be a syntax error, but that may not be correct.