### PR TITLE
do_shell integration with pyscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (TBD, 2020)
+* Enhancements
+    * `do_shell()` now saves the return code of the command it runs in `self.last_result` for use in pyscripts
+
 ## 1.0.1 (March 13, 2020)
 * Bug Fixes
     * Fixed issue where postcmd hooks were running after an `argparse` exception in a command.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3015,6 +3015,9 @@ class Cmd(cmd.Cmd):
             proc_reader = utils.ProcReader(proc, self.stdout, sys.stderr)
             proc_reader.wait()
 
+            # Save the return code of the application for use in a pyscript
+            self.last_result = proc.returncode
+
     @staticmethod
     def _reset_py_display() -> None:
         """

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -203,6 +203,10 @@ def test_base_shell(base_app, monkeypatch):
     assert out == []
     assert m.called
 
+def test_shell_last_result(base_app):
+    base_app.last_result = None
+    run_cmd(base_app, 'shell fake')
+    assert base_app.last_result is not None
 
 def test_base_py(base_app):
     # Make sure py can't edit Cmd.py_locals. It used to be that cmd2 was passing its py_locals


### PR DESCRIPTION
`do_shell()` now saves the return code of the command it runs in `self.last_result` for use in pyscripts