### PR TITLE
The continuation_prompt attribute was declared twice in cmd.rst

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf-8
 """Variant on standard library's cmd with extra features.
 

--- a/docs/api/cmd.rst
+++ b/docs/api/cmd.rst
@@ -6,11 +6,6 @@ cmd2.Cmd
 
     .. automethod:: __init__
 
-    .. attribute:: continuation_prompt
-
-      Use as prompt for multiline commands on the 2nd+ line of input.
-      Default: ``>``.
-
     .. attribute:: default_error
 
       The error message displayed when a non-existent command is run.
@@ -31,6 +26,7 @@ cmd2.Cmd
 
       The prompt issued to solicit input for the 2nd and subsequent lines
       of a :ref:`multiline command <features/multiline_commands:Multiline Commands>`
+      Default: ``>``.
 
     .. attribute:: echo
 


### PR DESCRIPTION
Fix a problem with the documentation build test caused by `continuation_prompt` being declared twice within the docs for the same class/file.