### PR TITLE
Fixed argparse usage text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 1.0.3 (TBD, 2020)
+* Bug Fixes
+    * Fixed issue where subcommand usage text could contain a subcommand alias instead of the actual name
 * Enhancements
     * Made `ipy` consistent with `py` in the following ways
         * `ipy` returns whether any of the commands run in it returned True to stop command loop

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -87,7 +87,7 @@ def _set_parser_prog(parser: argparse.ArgumentParser, prog: str):
     is a command name and not sys.argv[0].
 
     :param parser: the parser being edited
-    :param prog: value for the current parsers prog attribute
+    :param prog: new value for the parser's prog attribute
     """
     # Set the prog value for this parser
     parser.prog = prog
@@ -95,6 +95,10 @@ def _set_parser_prog(parser: argparse.ArgumentParser, prog: str):
     # Set the prog value for the parser's subcommands
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
+            # Set the _SubParsersAction's _prog_prefix value. That way if its add_parser() method is called later,
+            # the correct prog value will be set on the parser being added.
+            action._prog_prefix = parser.prog
+
             # The keys of action.choices are subcommand names as well as subcommand aliases. The aliases point to the
             # same parser as the actual subcommand. We want to avoid placing an alias into a parser's prog value.
             # Unfortunately there is nothing about an action.choices entry which tells us it's an alias. In most cases

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -85,6 +85,7 @@ def _set_parser_prog(parser: argparse.ArgumentParser, prog: str):
     """
     Recursively set prog attribute of a parser and all of its subparsers so that the root command
     is a command name and not sys.argv[0].
+
     :param parser: the parser being edited
     :param prog: value for the current parsers prog attribute
     """
@@ -94,11 +95,25 @@ def _set_parser_prog(parser: argparse.ArgumentParser, prog: str):
     # Set the prog value for the parser's subcommands
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
+            # The keys of action.choices are subcommand names as well as subcommand aliases. The aliases point to the
+            # same parser as the actual subcommand. We want to avoid placing an alias into a parser's prog value.
+            # Unfortunately there is nothing about an action.choices entry which tells us it's an alias. In most cases
+            # we can filter out the aliases by checking the contents of action._choices_actions. This list only contains
+            # help information and names for the subcommands and not aliases. However, subcommands without help text
+            # won't show up in that list. Since dictionaries are ordered in Python 3.6 and above and argparse inserts the
+            # subcommand name into choices dictionary before aliases, we should be OK assuming the first time we see a
+            # parser, the dictionary key is a subcommand and not alias.
+            processed_parsers = []
 
-            # Set the prog value for each subcommand
-            for sub_cmd, sub_cmd_parser in action.choices.items():
-                sub_cmd_prog = parser.prog + ' ' + sub_cmd
-                _set_parser_prog(sub_cmd_parser, sub_cmd_prog)
+            # Set the prog value for each subcommand's parser
+            for subcmd_name, subcmd_parser in action.choices.items():
+                # Check if we've already edited this parser
+                if subcmd_parser in processed_parsers:
+                    continue
+
+                subcmd_prog = parser.prog + ' ' + subcmd_name
+                _set_parser_prog(subcmd_parser, subcmd_prog)
+                processed_parsers.append(subcmd_parser)
 
             # We can break since argparse only allows 1 group of subcommands per level
             break

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -333,7 +333,14 @@ def test_subcommand_help(subcommand_app):
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
-
 def test_subcommand_invalid_help(subcommand_app):
     out, err = run_cmd(subcommand_app, 'help base baz')
     assert out[0].startswith('usage: base')
+
+def test_add_another_subcommand(subcommand_app):
+    """
+    This tests makes sure _set_parser_prog() sets _prog_prefix on every _SubParsersAction so that all future calls
+    to add_parser() write the correct prog value to the parser being added.
+    """
+    new_parser = subcommand_app.base_subparsers.add_parser('new_sub', help="stuff")
+    assert new_parser.prog == "base new_sub"


### PR DESCRIPTION
Fixed issue where subcommand usage text could contain a subcommand alias instead of the actual name