### PR TITLE
Exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3 (TBD, 2020)
+## 1.1.0 (TBD, 2020)
 * Bug Fixes
     * Fixed issue where subcommand usage text could contain a subcommand alias instead of the actual name
 * Enhancements
@@ -14,6 +14,15 @@
           documentation for an overview.
         * See [table_creation.py](https://github.com/python-cmd2/cmd2/blob/master/examples/table_creation.py)
           for an example.
+    * Added the following exceptions to the public API
+        * `SkipPostcommandHooks` - Custom exception class for when a command has a failure bad enough to skip
+          post command hooks, but not bad enough to print the exception to the user.
+        * `Cmd2ArgparseError` - A `SkipPostcommandHooks` exception for when a command fails to parse its arguments.
+          Normally argparse raises a `SystemExit` exception in these cases. To avoid stopping the command
+          loop, catch the `SystemExit` and raise this instead. If you still need to run post command hooks
+          after parsing fails, just return instead of raising an exception.
+    * Added explicit handling of `SystemExit`. If a command raises this exception, the command loop will be
+      gracefully stopped.
     
 ## 1.0.2 (April 06, 2020)
 * Bug Fixes

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -25,6 +25,7 @@ from .argparse_custom import DEFAULT_ARGUMENT_PARSER
 from .cmd2 import Cmd
 from .constants import COMMAND_NAME, DEFAULT_SHORTCUTS
 from .decorators import with_argument_list, with_argparser, with_argparser_and_unknown_args, with_category
+from .exceptions import Cmd2ArgparseError, SkipPostcommandHooks
 from .parsing import Statement
 from .py_bridge import CommandResult
 from .utils import categorize, CompletionError, Settable

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1678,7 +1678,6 @@ class Cmd(cmd.Cmd):
             if raise_keyboard_interrupt and not stop:
                 raise ex
         except SystemExit:
-            self.pwarning("Caught SystemExit. Attempting to stop command loop...")
             stop = True
         except Exception as ex:
             self.pexcept(ex)
@@ -1689,7 +1688,6 @@ class Cmd(cmd.Cmd):
                 if raise_keyboard_interrupt and not stop:
                     raise ex
             except SystemExit:
-                self.pwarning("Caught SystemExit. Attempting to stop command loop...")
                 stop = True
             except Exception as ex:
                 self.pexcept(ex)

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -16,10 +16,10 @@ class SkipPostcommandHooks(Exception):
 
 class Cmd2ArgparseError(SkipPostcommandHooks):
     """
-    A ``SkipPostcommandHooks`` exception for when a command fails parsing its arguments.
-    This is raised by argparse decorators but can also be raised by command functions.
-    If a command function still needs to run post command hooks when parsing fails,
-    just return instead of raising an exception.
+    A ``SkipPostcommandHooks`` exception for when a command fails to parse its arguments.
+    Normally argparse raises a SystemExit exception in these cases. To avoid stopping the command
+    loop, catch the SystemExit and raise this instead. If you still need to run post command hooks
+    after parsing fails, just return instead of raising an exception.
     """
     pass
 

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -1,15 +1,32 @@
 # coding=utf-8
-"""Custom exceptions for cmd2.  These are NOT part of the public API and are intended for internal use only."""
+"""Custom exceptions for cmd2"""
 
 
-class Cmd2ArgparseError(Exception):
+############################################################################################################
+# The following exceptions are part of the public API
+############################################################################################################
+
+class SkipPostcommandHooks(Exception):
     """
-    Custom exception class for when a command has an error parsing its arguments.
-    This can be raised by argparse decorators or the command functions themselves.
-    The main use of this exception is to tell cmd2 not to run Postcommand hooks.
+    Custom exception class for when a command has a failure bad enough to skip post command
+    hooks, but not bad enough to print the exception to the user.
     """
     pass
 
+
+class Cmd2ArgparseError(SkipPostcommandHooks):
+    """
+    A ``SkipPostcommandHooks`` exception for when a command fails parsing its arguments.
+    This is raised by argparse decorators but can also be raised by command functions.
+    If a command function still needs to run post command hooks when parsing fails,
+    just return instead of raising an exception.
+    """
+    pass
+
+
+############################################################################################################
+# The following exceptions are NOT part of the public API and are intended for internal use only.
+############################################################################################################
 
 class Cmd2ShlexError(Exception):
     """Raised when shlex fails to parse a command line string in StatementParser"""

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -1,0 +1,11 @@
+cmd2.exceptions
+===============
+
+Custom cmd2 exceptions
+
+
+.. autoclass:: cmd2.exceptions.SkipPostcommandHooks
+    :members:
+
+.. autoclass:: cmd2.exceptions.Cmd2ArgparseError
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -19,37 +19,39 @@ This documentation is for ``cmd2`` version |version|.
    :hidden:
 
    cmd
-   decorators
-   parsing
+   ansi
    argparse_completer
    argparse_custom
-   ansi
-   utils
+   constants
+   decorators
+   exceptions
    history
+   parsing
    plugin
    py_bridge
    table_creator
-   constants
+   utils
 
 **Modules**
 
 - :ref:`api/cmd:cmd2.Cmd` - functions and attributes of the main
   class in this library
-- :ref:`api/decorators:cmd2.decorators` - decorators for ``cmd2``
-  commands
-- :ref:`api/parsing:cmd2.parsing` - classes for parsing and storing
-  user input
+- :ref:`api/ansi:cmd2.ansi` - convenience classes and functions for generating
+  ANSI escape sequences to style text in the terminal
 - :ref:`api/argparse_completer:cmd2.argparse_completer` - classes for
   ``argparse``-based tab completion
 - :ref:`api/argparse_custom:cmd2.argparse_custom` - classes and functions
   for extending ``argparse``
-- :ref:`api/ansi:cmd2.ansi` - convenience classes and functions for generating
-  ANSI escape sequences to style text in the terminal
-- :ref:`api/utils:cmd2.utils` - various utility classes and functions
+- :ref:`api/constants:cmd2.constants` - just like it says on the tin
+- :ref:`api/decorators:cmd2.decorators` - decorators for ``cmd2``
+  commands
+- :ref:`api/exceptions:cmd2.exceptions` - custom ``cmd2`` exceptions
 - :ref:`api/history:cmd2.history` - classes for storing the history
   of previously entered commands
+- :ref:`api/parsing:cmd2.parsing` - classes for parsing and storing
+  user input
 - :ref:`api/plugin:cmd2.plugin` - data classes for hook methods
 - :ref:`api/py_bridge:cmd2.py_bridge` - classes for bridging calls from the
   embedded python environment to the host app
 - :ref:`api/table_creator:cmd2.table_creator` - table creation module
-- :ref:`api/constants:cmd2.constants` - just like it says on the tin
+- :ref:`api/utils:cmd2.utils` - various utility classes and functions

--- a/docs/features/commands.rst
+++ b/docs/features/commands.rst
@@ -129,7 +129,7 @@ it should stop prompting for user input and cleanly exit. ``cmd2`` already
 includes a ``quit`` command, but if you wanted to make another one called
 ``finis`` you could::
 
-    def do_finis(self, line):
+    def do_finish(self, line):
         """Exit the application"""
         return True
 
@@ -186,6 +186,19 @@ catch it and display it for you. The `debug` :ref:`setting
 name and message. If `debug` is `true`, ``cmd2`` will display a traceback, and
 then display the exception name and message.
 
+There are a few exceptions which commands can raise that do not print as
+described above:
+
+- :attr:`cmd2.exceptions.SkipPostcommandHooks` - all postcommand hooks are
+  skipped and no exception prints
+- :attr:`cmd2.exceptions.Cmd2ArgparseError` - behaves like
+  ``SkipPostcommandHooks``
+- ``SystemExit`` - ``stop`` will be set to ``True`` in an attempt to stop the
+  command loop
+- ``KeyboardInterrupt`` - raised if running in a text script and ``stop`` isn't
+  already True to stop the script
+
+All other ``BaseExceptions`` are not caught by ``cmd2`` and will be raised
 
 Disabling or Hiding Commands
 ----------------------------

--- a/docs/features/hooks.rst
+++ b/docs/features/hooks.rst
@@ -291,6 +291,12 @@ blindly returns ``False``, a prior hook's requst to exit the application will
 not be honored. It's best to return the value you were passed unless you have a
 compelling reason to do otherwise.
 
+To purposefully and silently skip postcommand hooks, commands can raise any of
+of the following exceptions.
+
+- :attr:`cmd2.exceptions.SkipPostcommandHooks`
+- :attr:`cmd2.exceptions.Cmd2ArgparseError`
+
 
 Command Finalization Hooks
 --------------------------

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -466,6 +466,17 @@ def test_in_script(request):
 
     assert "WE ARE IN SCRIPT" in out[-1]
 
+def test_system_exit_in_command(base_app, capsys):
+    """Test raising SystemExit from a command"""
+    import types
+
+    def do_system_exit(self, _):
+        raise SystemExit
+    setattr(base_app, 'do_system_exit', types.MethodType(do_system_exit, base_app))
+
+    stop = base_app.onecmd_plus_hooks('system_exit')
+    assert stop
+
 def test_output_redirection(base_app):
     fd, filename = tempfile.mkstemp(prefix='cmd2_test', suffix='.txt')
     os.close(fd)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -256,6 +256,10 @@ class PluggedApp(Plugin, cmd2.Cmd):
         """Repeat back the arguments"""
         self.poutput(statement)
 
+    def do_skip_postcmd_hooks(self, _):
+        self.poutput("In do_skip_postcmd_hooks")
+        raise exceptions.SkipPostcommandHooks
+
     parser = Cmd2ArgumentParser(description="Test parser")
     parser.add_argument("my_arg", help="some help text")
 
@@ -847,6 +851,17 @@ def test_cmdfinalization_hook_exception(capsys):
     assert err
     assert app.called_cmdfinalization == 1
 
+def test_skip_postcmd_hooks(capsys):
+    app = PluggedApp()
+    app.register_postcmd_hook(app.postcmd_hook)
+    app.register_cmdfinalization_hook(app.cmdfinalization_hook)
+
+    # Cause a SkipPostcommandHooks exception and verify no postcmd stuff runs but cmdfinalization_hook still does
+    app.onecmd_plus_hooks('skip_postcmd_hooks')
+    out, err = capsys.readouterr()
+    assert "In do_skip_postcmd_hooks" in out
+    assert app.called_postcmd == 0
+    assert app.called_cmdfinalization == 1
 
 def test_cmd2_argparse_exception(capsys):
     """


### PR DESCRIPTION
This is my attempt to address #932 
If everyone agrees, then I'll finish writing unit tests and update the change log.

The question remains about what we do with a `SystemExit`. This PR prints to the user and sets `stop` to True. I'm also OK if it behaves like all other exceptions. In that case, we would change our except statement from:

`except Exception` to `except BaseException`

That would be consistent with the documentation @kotfu pointed to:

> If the command method raises an exception, cmd2 will catch it and display it for you

It also preserves exactly 1 method to exit the command loop (i.e. return True from a command)

Closes #932 