### PR TITLE
Load/Unload commands at runtime - Implements #943

### DIFF
--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -28,6 +28,7 @@ if cmd2_parser_module is not None:
 # Get the current value for argparse_custom.DEFAULT_ARGUMENT_PARSER
 from .argparse_custom import DEFAULT_ARGUMENT_PARSER
 from .cmd2 import Cmd
+from .command_definition import CommandSet, with_default_category, register_command
 from .constants import COMMAND_NAME, DEFAULT_SHORTCUTS
 from .decorators import with_argument_list, with_argparser, with_argparser_and_unknown_args, with_category
 from .exceptions import Cmd2ArgparseError, SkipPostcommandHooks

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -471,7 +471,7 @@ class Cmd(cmd.Cmd):
 
     def uninstall_command_set(self, cmdset: CommandSet):
         """
-        Uninstalls an CommandSet and unloads all associated commands
+        Uninstalls a CommandSet and unloads all associated commands
         :param cmdset: CommandSet to uninstall
         """
         if cmdset in self._installed_command_sets:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -264,14 +264,14 @@ class Cmd(cmd.Cmd):
         self.last_result = None
 
         # Used by run_script command to store current script dir as a LIFO queue to support _relative_run_script command
-        self._script_dir = []  # type: List[AnyStr]
+        self._script_dir = []  # type: List[str]
 
         # Context manager used to protect critical sections in the main thread from stopping due to a KeyboardInterrupt
         self.sigint_protection = utils.ContextFlag()
 
         # If the current command created a process to pipe to, then this will be a ProcReader object.
         # Otherwise it will be None. It's used to know when a pipe process can be killed and/or waited upon.
-        self._cur_pipe_proc_reader = None
+        self._cur_pipe_proc_reader = None  # type: Optional[utils.ProcReader]
 
         # Used to keep track of whether we are redirecting or piping output
         self._redirecting = False
@@ -295,7 +295,7 @@ class Cmd(cmd.Cmd):
         self.broken_pipe_warning = ''
 
         # Commands that will run at the beginning of the command loop
-        self._startup_commands = []
+        self._startup_commands = []  # type: List[str]
 
         # If a startup script is provided and exists, then execute it in the startup commands
         if startup_script:
@@ -304,7 +304,7 @@ class Cmd(cmd.Cmd):
                 self._startup_commands.append("run_script {}".format(utils.quote_string(startup_script)))
 
         # Transcript files to run instead of interactive command loop
-        self._transcript_files = None
+        self._transcript_files = None  # type: Optional[List[str]]
 
         # Check for command line args
         if allow_cli_args:
@@ -2088,7 +2088,7 @@ class Cmd(cmd.Cmd):
                                                         self._cur_pipe_proc_reader, self._redirecting)
 
         # The ProcReader for this command
-        cmd_pipe_proc_reader = None
+        cmd_pipe_proc_reader = None  # type: Optional[utils.ProcReader]
 
         if not self.allow_redirection:
             # Don't return since we set some state variables at the end of the function

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -432,7 +432,8 @@ class Cmd(cmd.Cmd):
         cmdset.on_register(self)
         methods = inspect.getmembers(
             cmdset,
-            predicate=lambda meth: inspect.ismethod(meth) and meth.__name__.startswith(COMMAND_FUNC_PREFIX))
+            predicate=lambda meth: (inspect.ismethod(meth) or isinstance(meth, Callable)) and
+                                   meth.__name__.startswith(COMMAND_FUNC_PREFIX))
 
         installed_attributes = []
         try:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -37,14 +37,17 @@ import pickle
 import re
 import sys
 import threading
+import types
 from code import InteractiveConsole
 from collections import namedtuple
 from contextlib import redirect_stdout
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Type, Union
+from typing import Any, AnyStr, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Type, Union
 
 from . import ansi, constants, plugin, utils
 from .argparse_custom import DEFAULT_ARGUMENT_PARSER, CompletionItem
 from .clipboard import can_clip, get_paste_buffer, write_to_paste_buffer
+from .command_definition import _UNBOUND_COMMANDS, CommandSet, _PartialPassthru
+from .constants import COMMAND_FUNC_PREFIX, COMPLETER_FUNC_PREFIX, HELP_FUNC_PREFIX
 from .decorators import with_argparser
 from .exceptions import Cmd2ShlexError, EmbeddedConsoleExit, EmptyStatement, RedirectionError, SkipPostcommandHooks
 from .history import History, HistoryItem
@@ -130,7 +133,8 @@ class Cmd(cmd.Cmd):
                  startup_script: str = '', use_ipython: bool = False,
                  allow_cli_args: bool = True, transcript_files: Optional[List[str]] = None,
                  allow_redirection: bool = True, multiline_commands: Optional[List[str]] = None,
-                 terminators: Optional[List[str]] = None, shortcuts: Optional[Dict[str, str]] = None) -> None:
+                 terminators: Optional[List[str]] = None, shortcuts: Optional[Dict[str, str]] = None,
+                 command_sets: Optional[Iterable[CommandSet]] = None) -> None:
         """An easy but powerful framework for writing line-oriented command
         interpreters. Extends Python's cmd package.
 
@@ -200,7 +204,7 @@ class Cmd(cmd.Cmd):
         self.max_completion_items = 50
 
         # A dictionary mapping settable names to their Settable instance
-        self.settables = dict()
+        self.settables = dict()  # type: Dict[str, Settable]
         self.build_settables()
 
         # Use as prompt for multiline commands on the 2nd+ line of input
@@ -220,7 +224,7 @@ class Cmd(cmd.Cmd):
         self.exclude_from_history = ['eof', 'history']
 
         # Dictionary of macro names and their values
-        self.macros = dict()
+        self.macros = dict()  # type: Dict[str, Macro]
 
         # Keeps track of typed command history in the Python shell
         self._py_history = []
@@ -249,7 +253,7 @@ class Cmd(cmd.Cmd):
         self.last_result = None
 
         # Used by run_script command to store current script dir as a LIFO queue to support _relative_run_script command
-        self._script_dir = []
+        self._script_dir = []  # type: List[AnyStr]
 
         # Context manager used to protect critical sections in the main thread from stopping due to a KeyboardInterrupt
         self.sigint_protection = utils.ContextFlag()
@@ -333,7 +337,7 @@ class Cmd(cmd.Cmd):
         # Commands that have been disabled from use. This is to support commands that are only available
         # during specific states of the application. This dictionary's keys are the command names and its
         # values are DisabledCommand objects.
-        self.disabled_commands = dict()
+        self.disabled_commands = dict()  # type: Dict[str, DisabledCommand]
 
         # If any command has been categorized, then all other commands that haven't been categorized
         # will display under this section in the help output.
@@ -380,6 +384,64 @@ class Cmd(cmd.Cmd):
         # Set to True before returning matches to complete() in cases where matches have already been sorted.
         # If False, then complete() will sort the matches using self.default_sort_key before they are displayed.
         self.matches_sorted = False
+
+        # Load modular commands
+        self._command_sets = command_sets if command_sets is not None else []
+        self._load_modular_commands()
+
+    def _load_modular_commands(self) -> None:
+        """
+        Load modular command definitions.
+        :return: None
+        """
+
+        # start by loading registered functions as commands
+        for cmd_name, cmd_func, cmd_completer, cmd_help in _UNBOUND_COMMANDS:
+            assert getattr(self, cmd_func.__name__, None) is None, 'Duplicate command function registered: ' + cmd_name
+            setattr(self, cmd_func.__name__, types.MethodType(cmd_func, self))
+            if cmd_completer is not None:
+                assert getattr(self, cmd_completer.__name__, None) is None, \
+                    'Duplicate command completer registered: ' + cmd_completer.__name__
+                setattr(self, cmd_completer.__name__, types.MethodType(cmd_completer, self))
+            if cmd_help is not None:
+                assert getattr(self, cmd_help.__name__, None) is None, \
+                    'Duplicate command help registered: ' + cmd_help.__name__
+                setattr(self, cmd_help.__name__, types.MethodType(cmd_help, self))
+
+        # Search for all subclasses of CommandSet, instantiate them if they weren't provided in the constructor
+        all_commandset_defs = CommandSet.__subclasses__()
+        existing_commandset_types = [type(command_set) for command_set in self._command_sets]
+        for cmdset_type in all_commandset_defs:
+            init_sig = inspect.signature(cmdset_type.__init__)
+            if cmdset_type in existing_commandset_types or len(init_sig.parameters) != 1 or 'self' not in init_sig.parameters:
+                continue
+            cmdset = cmdset_type()
+            self._command_sets.append(cmdset)
+
+        # initialize each CommandSet and register all matching functions as command, helper, completer functions
+        for cmdset in self._command_sets:
+            cmdset.on_register(self)
+            methods = inspect.getmembers(cmdset, predicate=lambda meth: inspect.ismethod(
+                meth) and meth.__name__.startswith(COMMAND_FUNC_PREFIX))
+
+            for method in methods:
+                assert getattr(self, method[0], None) is None, \
+                    'In {}: Duplicate command function: {}'.format(cmdset_type.__name__, method[0])
+
+                command_wrapper = _PartialPassthru(method[1], self)
+                setattr(self, method[0], command_wrapper)
+
+                command = method[0][len(COMMAND_FUNC_PREFIX):]
+
+                completer_func_name = COMPLETER_FUNC_PREFIX + command
+                cmd_completer = getattr(cmdset, completer_func_name, None)
+                if cmd_completer and not getattr(self, completer_func_name, None):
+                    completer_wrapper = _PartialPassthru(cmd_completer, self)
+                    setattr(self, completer_func_name, completer_wrapper)
+                cmd_help = getattr(cmdset, HELP_FUNC_PREFIX + command, None)
+                if cmd_help and not getattr(self, HELP_FUNC_PREFIX + command, None):
+                    help_wrapper = _PartialPassthru(cmd_help, self)
+                    setattr(self, HELP_FUNC_PREFIX + command, help_wrapper)
 
     def add_settable(self, settable: Settable) -> None:
         """

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -3,13 +3,8 @@
 Supports the definition of commands in separate classes to be composed into cmd2.Cmd
 """
 import functools
-from typing import (
-    Callable,
-    Dict,
-    Iterable,
-    Optional,
-    Type,
-)
+from typing import Callable, Dict, Iterable, Optional, Type
+
 from .constants import COMMAND_FUNC_PREFIX
 
 # Allows IDEs to resolve types without impacting imports at runtime, breaking circular dependency issues

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -9,7 +9,6 @@ from typing import (
     Iterable,
     Optional,
     Type,
-    Union,
 )
 from .constants import COMMAND_FUNC_PREFIX
 
@@ -17,14 +16,14 @@ from .constants import COMMAND_FUNC_PREFIX
 try:  # pragma: no cover
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from .cmd2 import Cmd, Statement
-        import argparse
+        import cmd2
+
 except ImportError:   # pragma: no cover
     pass
 
 _REGISTERED_COMMANDS = {}  # type: Dict[str, Callable]
 """
-Registered command tuples. (command, do_ function, complete_ function, help_ function
+Registered command tuples. (command, ``do_`` function)
 """
 
 
@@ -58,12 +57,13 @@ def _partial_passthru(func: Callable, *args, **kwargs) -> functools.partial:
     return passthru_type(func, *args, **kwargs)
 
 
-def register_command(cmd_func: Callable[['Cmd', Union['Statement', 'argparse.Namespace']], None]):
+def register_command(cmd_func: Callable):
     """
     Decorator that allows an arbitrary function to be automatically registered as a command.
     If there is a ``help_`` or ``complete_`` function that matches this command, that will also be registered.
 
     :param cmd_func: Function to register as a cmd2 command
+    :type cmd_func: Callable[[cmd2.Cmd, Union[Statement, argparse.Namespace]], None]
     :return:
     """
     assert cmd_func.__name__.startswith(COMMAND_FUNC_PREFIX), 'Command functions must start with `do_`'
@@ -112,20 +112,23 @@ class CommandSet(object):
     """
 
     def __init__(self):
-        self._cmd = None  # type: Optional[Cmd]
+        self._cmd = None  # type: Optional[cmd2.Cmd]
 
-    def on_register(self, cmd: 'Cmd'):
+    def on_register(self, cmd):
         """
         Called by cmd2.Cmd when a CommandSet is registered. Subclasses can override this
         to perform an initialization requiring access to the Cmd object.
 
         :param cmd: The cmd2 main application
+        :type cmd: cmd2.Cmd
         """
         self._cmd = cmd
 
-    def on_unregister(self, cmd: 'Cmd'):
+    def on_unregister(self, cmd):
         """
         Called by ``cmd2.Cmd`` when a CommandSet is unregistered and removed.
+
         :param cmd:
+        :type cmd: cmd2.Cmd
         """
         self._cmd = None

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+"""
+Supports the definition of commands in separate classes to be composed into cmd2.Cmd
+"""
+import functools
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+from .constants import COMMAND_FUNC_PREFIX, HELP_FUNC_PREFIX, COMPLETER_FUNC_PREFIX
+
+# Allows IDEs to resolve types without impacting imports at runtime, breaking circular dependency issues
+try:
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from .cmd2 import Cmd, Statement
+        import argparse
+except ImportError:
+    pass
+
+_UNBOUND_COMMANDS = []  # type: List[Tuple[str, Callable, Optional[Callable], Optional[Callable]]]
+"""
+Registered command tuples. (command, do_ function, complete_ function, help_ function
+"""
+
+
+class _PartialPassthru(functools.partial):
+    """
+    Wrapper around partial function that passes through getattr, setattr, and dir to the wrapped function.
+    This allows for CommandSet functions to be wrapped while maintaining the decorated properties
+    """
+    def __getattr__(self, item):
+        return getattr(self.func, item)
+
+    def __setattr__(self, key, value):
+        return setattr(self.func, key, value)
+
+    def __dir__(self) -> Iterable[str]:
+        return dir(self.func)
+
+
+def register_command(cmd_func: Callable[['Cmd', Union['Statement', 'argparse.Namespace']], None]):
+    """
+    Decorator that allows an arbitrary function to be automatically registered as a command.
+    If there is a help_ or complete_ function that matches this command, that will also be registered.
+
+    :param cmd_func: Function to register as a cmd2 command
+    :return:
+    """
+    assert cmd_func.__name__.startswith(COMMAND_FUNC_PREFIX), 'Command functions must start with `do_`'
+
+    import inspect
+
+    cmd_name = cmd_func.__name__[len(COMMAND_FUNC_PREFIX):]
+    cmd_completer = None
+    cmd_help = None
+
+    module = inspect.getmodule(cmd_func)
+
+    module_funcs = [mf for mf in inspect.getmembers(module) if inspect.isfunction(mf[1])]
+    for mf in module_funcs:
+        if mf[0] == COMPLETER_FUNC_PREFIX + cmd_name:
+            cmd_completer = mf[1]
+        elif mf[0] == HELP_FUNC_PREFIX + cmd_name:
+            cmd_help = mf[1]
+        if cmd_completer is not None and cmd_help is not None:
+            break
+
+    _UNBOUND_COMMANDS.append((cmd_name, cmd_func, cmd_completer, cmd_help))
+
+
+def with_default_category(category: str):
+    """
+    Decorator that applies a category to all ``do_*`` command methods in a class that do not already
+    have a category specified.
+
+    :param category: category to put all uncategorized commands in
+    :return: decorator function
+    """
+
+    def decorate_class(cls: Type[CommandSet]):
+        from .constants import CMD_ATTR_HELP_CATEGORY
+        import inspect
+        from .decorators import with_category
+        methods = inspect.getmembers(
+            cls,
+            predicate=lambda meth: inspect.isfunction(meth) and meth.__name__.startswith(COMMAND_FUNC_PREFIX))
+        category_decorator = with_category(category)
+        for method in methods:
+            if not hasattr(method[1], CMD_ATTR_HELP_CATEGORY):
+                setattr(cls, method[0], category_decorator(method[1]))
+        return cls
+    return decorate_class
+
+
+class CommandSet(object):
+    """
+    Base class for defining sets of commands to load in cmd2.
+
+    ``with_default_category`` can be used to apply a default category to all commands in the CommandSet.
+
+    ``do_``, ``help_``, and ``complete_`` functions differ only in that they're now required to accept
+    a reference to ``cmd2.Cmd`` as the first argument after self.
+    """
+
+    def __init__(self):
+        self._cmd = None  # type: Optional[Cmd]
+
+    def on_register(self, cmd: 'Cmd'):
+        """
+        Called by cmd2.Cmd when a CommandSet is registered. Subclasses can override this
+        to perform an initialization requiring access to the Cmd object.
+
+        :param cmd: The cmd2 main application
+        :return: None
+        """
+        self._cmd = cmd

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -19,7 +19,7 @@ try:  # pragma: no cover
     if TYPE_CHECKING:
         from .cmd2 import Cmd, Statement
         import argparse
-except ImportError:
+except ImportError:   # pragma: no cover
     pass
 
 _REGISTERED_COMMANDS = {}  # type: Dict[str, Callable]

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -87,6 +87,7 @@ def register_command(cmd_func: Callable[['Cmd', Union['Statement', 'argparse.Nam
             break
 
     _UNBOUND_COMMANDS.append((cmd_name, cmd_func, cmd_completer, cmd_help))
+    return cmd_func
 
 
 def with_default_category(category: str):
@@ -132,6 +133,12 @@ class CommandSet(object):
         to perform an initialization requiring access to the Cmd object.
 
         :param cmd: The cmd2 main application
-        :return: None
         """
         self._cmd = cmd
+
+    def on_unregister(self, cmd: 'Cmd'):
+        """
+        Called by ``cmd2.Cmd`` when a CommandSet is unregistered and removed.
+        :param cmd:
+        """
+        self._cmd = None

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -61,7 +61,7 @@ def _partial_passthru(func: Callable, *args, **kwargs) -> functools.partial:
 def register_command(cmd_func: Callable[['Cmd', Union['Statement', 'argparse.Namespace']], None]):
     """
     Decorator that allows an arbitrary function to be automatically registered as a command.
-    If there is a help_ or complete_ function that matches this command, that will also be registered.
+    If there is a ``help_`` or ``complete_`` function that matches this command, that will also be registered.
 
     :param cmd_func: Function to register as a cmd2 command
     :return:

--- a/docs/api/command_definition.rst
+++ b/docs/api/command_definition.rst
@@ -1,0 +1,5 @@
+cmd2.command_definition
+=======================
+
+.. automodule:: cmd2.command_definition
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -23,6 +23,7 @@ This documentation is for ``cmd2`` version |version|.
    argparse_completer
    argparse_custom
    constants
+   command_definition
    decorators
    exceptions
    history

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -4,7 +4,7 @@ A simple example demonstrating a loadable command set
 """
 from typing import List
 
-from cmd2 import Cmd, Statement, with_category, CommandSet, with_default_category, register_command
+from cmd2 import Cmd, CommandSet, Statement, register_command, with_category, with_default_category
 from cmd2.utils import CompletionError
 
 

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -1,0 +1,105 @@
+# coding=utf-8
+"""
+A simple example demonstrating a loadable command set
+"""
+from typing import List
+
+from cmd2 import Cmd, Statement, with_category
+from cmd2.command_definition import CommandSet, with_default_category, register_command
+from cmd2.utils import CompletionError
+
+
+@register_command
+@with_category("AAA")
+def do_unbound(cmd: Cmd, statement: Statement):
+    """
+    This is an example of registering an unbound function
+    :param cmd:
+    :param statement:
+    :return:
+    """
+    cmd.poutput('Unbound Command: {}'.format(statement.args))
+
+
+@with_default_category('Basic Completion')
+class BasicCompletionCommandSet(CommandSet):
+    # List of strings used with completion functions
+    food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
+    sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
+
+    # This data is used to demonstrate delimiter_complete
+    file_strs = \
+        [
+            '/home/user/file.db',
+            '/home/user/file space.db',
+            '/home/user/another.db',
+            '/home/other user/maps.db',
+            '/home/other user/tests.db'
+        ]
+
+    def do_flag_based(self, cmd: Cmd, statement: Statement):
+        """Tab completes arguments based on a preceding flag using flag_based_complete
+        -f, --food [completes food items]
+        -s, --sport [completes sports]
+        -p, --path [completes local file system paths]
+        """
+        cmd.poutput("Args: {}".format(statement.args))
+
+    def complete_flag_based(self, cmd: Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Completion function for do_flag_based"""
+        flag_dict = \
+            {
+                # Tab complete food items after -f and --food flags in command line
+                '-f': self.food_item_strs,
+                '--food': self.food_item_strs,
+
+                # Tab complete sport items after -s and --sport flags in command line
+                '-s': self.sport_item_strs,
+                '--sport': self.sport_item_strs,
+
+                # Tab complete using path_complete function after -p and --path flags in command line
+                '-p': cmd.path_complete,
+                '--path': cmd.path_complete,
+            }
+
+        return cmd.flag_based_complete(text, line, begidx, endidx, flag_dict=flag_dict)
+
+    def do_index_based(self, cmd: Cmd, statement: Statement):
+        """Tab completes first 3 arguments using index_based_complete"""
+        cmd.poutput("Args: {}".format(statement.args))
+
+    def complete_index_based(self, cmd: Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Completion function for do_index_based"""
+        index_dict = \
+            {
+                1: self.food_item_strs,  # Tab complete food items at index 1 in command line
+                2: self.sport_item_strs,  # Tab complete sport items at index 2 in command line
+                3: cmd.path_complete,  # Tab complete using path_complete function at index 3 in command line
+            }
+
+        return cmd.index_based_complete(text, line, begidx, endidx, index_dict=index_dict)
+
+    def do_delimiter_complete(self, cmd: Cmd, statement: Statement):
+        """Tab completes files from a list using delimiter_complete"""
+        cmd.poutput("Args: {}".format(statement.args))
+
+    def complete_delimiter_complete(self, cmd: Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        return cmd.delimiter_complete(text, line, begidx, endidx, match_against=self.file_strs, delimiter='/')
+
+    def do_raise_error(self, cmd: Cmd, statement: Statement):
+        """Demonstrates effect of raising CompletionError"""
+        cmd.poutput("Args: {}".format(statement.args))
+
+    def complete_raise_error(self, cmd: Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """
+        CompletionErrors can be raised if an error occurs while tab completing.
+
+        Example use cases
+            - Reading a database to retrieve a tab completion data set failed
+            - A previous command line argument that determines the data set being completed is invalid
+        """
+        raise CompletionError("This is how a CompletionError behaves")
+
+    @with_category('Not Basic Completion')
+    def do_custom_category(self, cmd: Cmd, statement: Statement):
+        cmd.poutput('Demonstrates a command that bypasses the default category')

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -4,8 +4,7 @@ A simple example demonstrating a loadable command set
 """
 from typing import List
 
-from cmd2 import Cmd, Statement, with_category
-from cmd2.command_definition import CommandSet, with_default_category, register_command
+from cmd2 import Cmd, Statement, with_category, CommandSet, with_default_category, register_command
 from cmd2.utils import CompletionError
 
 

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -11,13 +11,30 @@ from cmd2.utils import CompletionError
 @register_command
 @with_category("AAA")
 def do_unbound(cmd: Cmd, statement: Statement):
-    """
-    This is an example of registering an unbound function
+    """This is an example of registering an unbound function
+
     :param cmd:
     :param statement:
     :return:
     """
     cmd.poutput('Unbound Command: {}'.format(statement.args))
+
+
+@register_command
+@with_category("AAA")
+def do_func_with_help(cmd: Cmd, statement: Statement):
+    """
+    This is an example of registering an unbound function
+
+    :param cmd:
+    :param statement:
+    :return:
+    """
+    cmd.poutput('Unbound Command: {}'.format(statement.args))
+
+
+def help_func_with_help(cmd: Cmd):
+    cmd.poutput('Help for func_with_help')
 
 
 @with_default_category('Basic Completion')

--- a/examples/modular_commands/commandset_custominit.py
+++ b/examples/modular_commands/commandset_custominit.py
@@ -2,7 +2,7 @@
 """
 A simple example demonstrating a loadable command set
 """
-from cmd2 import Cmd, Statement, with_category, CommandSet, with_default_category, register_command
+from cmd2 import Cmd, CommandSet, Statement, register_command, with_category, with_default_category
 
 
 @register_command

--- a/examples/modular_commands/commandset_custominit.py
+++ b/examples/modular_commands/commandset_custominit.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+"""
+A simple example demonstrating a loadable command set
+"""
+from cmd2 import Cmd, Statement, with_category
+from cmd2.command_definition import CommandSet, with_default_category, register_command
+
+
+@register_command
+@with_category("AAA")
+def do_another_command(cmd: Cmd, statement: Statement):
+    """
+    This is an example of registering an unbound function
+    :param cmd:
+    :param statement:
+    :return:
+    """
+    cmd.poutput('Another Unbound Command: {}'.format(statement.args))
+
+
+@with_default_category('Custom Init')
+class CustomInitCommandSet(CommandSet):
+    def __init__(self, arg1, arg2):
+        super().__init__()
+
+        self._arg1 = arg1
+        self._arg2 = arg2
+
+    def do_show_arg1(self, cmd: Cmd, _: Statement):
+        cmd.poutput('Arg1: ' + self._arg1)
+
+    def do_show_arg2(self, cmd: Cmd, _: Statement):
+        cmd.poutput('Arg2: ' + self._arg2)

--- a/examples/modular_commands/commandset_custominit.py
+++ b/examples/modular_commands/commandset_custominit.py
@@ -2,8 +2,7 @@
 """
 A simple example demonstrating a loadable command set
 """
-from cmd2 import Cmd, Statement, with_category
-from cmd2.command_definition import CommandSet, with_default_category, register_command
+from cmd2 import Cmd, Statement, with_category, CommandSet, with_default_category, register_command
 
 
 @register_command

--- a/examples/modular_commands_main.py
+++ b/examples/modular_commands_main.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""
+A simple example demonstrating how to integrate tab completion with argparse-based commands.
+"""
+import argparse
+from typing import Dict, List
+
+from cmd2 import Cmd, Cmd2ArgumentParser, CompletionItem, with_argparser
+from cmd2.utils import CompletionError, basic_complete
+from modular_commands.commandset_basic import BasicCompletionCommandSet  # noqa: F401
+from modular_commands.commandset_custominit import CustomInitCommandSet
+
+# Data source for argparse.choices
+food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
+
+
+def choices_function() -> List[str]:
+    """Choices functions are useful when the choice list is dynamically generated (e.g. from data in a database)"""
+    return ['a', 'dynamic', 'list', 'goes', 'here']
+
+
+def completer_function(text: str, line: str, begidx: int, endidx: int) -> List[str]:
+    """
+    A tab completion function not dependent on instance data. Since custom tab completion operations commonly
+    need to modify cmd2's instance variables related to tab completion, it will be rare to need a completer
+    function. completer_method should be used in those cases.
+    """
+    match_against = ['a', 'dynamic', 'list', 'goes', 'here']
+    return basic_complete(text, line, begidx, endidx, match_against)
+
+
+def choices_completion_item() -> List[CompletionItem]:
+    """Return CompletionItem instead of strings. These give more context to what's being tab completed."""
+    items = \
+        {
+            1: "My item",
+            2: "Another item",
+            3: "Yet another item"
+        }
+    return [CompletionItem(item_id, description) for item_id, description in items.items()]
+
+
+def choices_arg_tokens(arg_tokens: Dict[str, List[str]]) -> List[str]:
+    """
+    If a choices or completer function/method takes a value called arg_tokens, then it will be
+    passed a dictionary that maps the command line tokens up through the one being completed
+    to their argparse argument name.  All values of the arg_tokens dictionary are lists, even if
+    a particular argument expects only 1 token.
+    """
+    # Check if choices_function flag has appeared
+    values = ['choices_function', 'flag']
+    if 'choices_function' in arg_tokens:
+        values.append('is {}'.format(arg_tokens['choices_function'][0]))
+    else:
+        values.append('not supplied')
+    return values
+
+
+class WithCommandSets(Cmd):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
+
+    def choices_method(self) -> List[str]:
+        """Choices methods are useful when the choice list is based on instance data of your application"""
+        return self.sport_item_strs
+
+    def choices_completion_error(self) -> List[str]:
+        """
+        CompletionErrors can be raised if an error occurs while tab completing.
+
+        Example use cases
+            - Reading a database to retrieve a tab completion data set failed
+            - A previous command line argument that determines the data set being completed is invalid
+        """
+        if self.debug:
+            return self.sport_item_strs
+        raise CompletionError("debug must be true")
+
+    # Parser for example command
+    example_parser = Cmd2ArgumentParser(description="Command demonstrating tab completion with argparse\n"
+                                                    "Notice even the flags of this command tab complete")
+
+    # Tab complete from a list using argparse choices. Set metavar if you don't
+    # want the entire choices list showing in the usage text for this command.
+    example_parser.add_argument('--choices', choices=food_item_strs, metavar="CHOICE",
+                                help="tab complete using choices")
+
+    # Tab complete from choices provided by a choices function and choices method
+    example_parser.add_argument('--choices_function', choices_function=choices_function,
+                                help="tab complete using a choices_function")
+    example_parser.add_argument('--choices_method', choices_method=choices_method,
+                                help="tab complete using a choices_method")
+
+    # Tab complete using a completer function and completer method
+    example_parser.add_argument('--completer_function', completer_function=completer_function,
+                                help="tab complete using a completer_function")
+    example_parser.add_argument('--completer_method', completer_method=Cmd.path_complete,
+                                help="tab complete using a completer_method")
+
+    # Demonstrate raising a CompletionError while tab completing
+    example_parser.add_argument('--completion_error', choices_method=choices_completion_error,
+                                help="raise a CompletionError while tab completing if debug is False")
+
+    # Demonstrate returning CompletionItems instead of strings
+    example_parser.add_argument('--completion_item', choices_function=choices_completion_item, metavar="ITEM_ID",
+                                descriptive_header="Description",
+                                help="demonstrate use of CompletionItems")
+
+    # Demonstrate use of arg_tokens dictionary
+    example_parser.add_argument('--arg_tokens', choices_function=choices_arg_tokens,
+                                help="demonstrate use of arg_tokens dictionary")
+
+    @with_argparser(example_parser)
+    def do_example(self, _: argparse.Namespace) -> None:
+        """The example command"""
+        self.poutput("I do nothing")
+
+
+if __name__ == '__main__':
+    import sys
+
+    print("Starting")
+    command_sets = [CustomInitCommandSet('First argument', 'Second argument')]
+    app = WithCommandSets(command_sets=command_sets)
+    sys.exit(app.cmdloop())

--- a/examples/modular_commands_main.py
+++ b/examples/modular_commands_main.py
@@ -4,12 +4,12 @@
 A simple example demonstrating how to integrate tab completion with argparse-based commands.
 """
 import argparse
-from typing import Dict, List
+from typing import Dict, Iterable, List, Optional
 
-from cmd2 import Cmd, Cmd2ArgumentParser, CompletionItem, with_argparser
+from cmd2 import Cmd, Cmd2ArgumentParser, CommandSet, CompletionItem, with_argparser
 from cmd2.utils import CompletionError, basic_complete
 from modular_commands.commandset_basic import BasicCompletionCommandSet  # noqa: F401
-from modular_commands.commandset_custominit import CustomInitCommandSet
+from modular_commands.commandset_custominit import CustomInitCommandSet  # noqa: F401
 
 # Data source for argparse.choices
 food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
@@ -58,8 +58,8 @@ def choices_arg_tokens(arg_tokens: Dict[str, List[str]]) -> List[str]:
 
 
 class WithCommandSets(Cmd):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, command_sets: Optional[Iterable[CommandSet]] = None):
+        super().__init__(command_sets=command_sets)
         self.sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
     def choices_method(self) -> List[str]:
@@ -122,6 +122,6 @@ if __name__ == '__main__':
     import sys
 
     print("Starting")
-    command_sets = [CustomInitCommandSet('First argument', 'Second argument')]
-    app = WithCommandSets(command_sets=command_sets)
+    my_sets = [CustomInitCommandSet('First argument', 'Second argument')]
+    app = WithCommandSets(command_sets=my_sets)
     sys.exit(app.cmdloop())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,7 +153,7 @@ def run_cmd(app, cmd):
 
 @fixture
 def base_app():
-    return cmd2.Cmd()
+    return cmd2.Cmd(auto_load_commands=False)
 
 
 # These are odd file names for testing quoting of them

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,13 @@ Cmd2 unit/functional testing
 """
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 from unittest import mock
 
 from pytest import fixture
 
 import cmd2
 from cmd2.utils import StdSim
-from cmd2.constants import COMMAND_FUNC_PREFIX, CMD_ATTR_HELP_CATEGORY
 
 # Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,14 @@ Cmd2 unit/functional testing
 """
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 from unittest import mock
 
 from pytest import fixture
 
 import cmd2
 from cmd2.utils import StdSim
+from cmd2.constants import COMMAND_FUNC_PREFIX, CMD_ATTR_HELP_CATEGORY
 
 # Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
 try:
@@ -25,11 +26,14 @@ except ImportError:
         pass
 
 
-def verify_help_text(cmd2_app: cmd2.Cmd, help_output: Union[str, List[str]]) -> None:
+def verify_help_text(cmd2_app: cmd2.Cmd,
+                     help_output: Union[str, List[str]],
+                     verbose_strings: Optional[List[str]] = None) -> None:
     """This function verifies that all expected commands are present in the help text.
 
     :param cmd2_app: instance of cmd2.Cmd
     :param help_output: output of help, either as a string or list of strings
+    :param verbose_strings: optional list of verbose strings to search for
     """
     if isinstance(help_output, str):
         help_text = help_output
@@ -39,7 +43,9 @@ def verify_help_text(cmd2_app: cmd2.Cmd, help_output: Union[str, List[str]]) -> 
     for command in commands:
         assert command in help_text
 
-    # TODO: Consider adding checks for categories and for verbose history
+    if verbose_strings:
+        for verbose_string in verbose_strings:
+            assert verbose_string in help_text
 
 
 # Help text for the history command

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -28,7 +28,7 @@ except ImportError:
 class ArgparseApp(cmd2.Cmd):
     def __init__(self):
         self.maxrepeats = 3
-        cmd2.Cmd.__init__(self)
+        cmd2.Cmd.__init__(self, auto_load_commands=False)
 
     def namespace_provider(self) -> argparse.Namespace:
         ns = argparse.Namespace()
@@ -223,7 +223,7 @@ class SubcommandApp(cmd2.Cmd):
     """ Example cmd2 application where we a base command which has a couple subcommands."""
 
     def __init__(self):
-        cmd2.Cmd.__init__(self)
+        cmd2.Cmd.__init__(self, auto_load_commands=False)
 
     # subcommand functions for the base command
     def base_foo(self, args):

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -58,7 +58,7 @@ def completer_takes_arg_tokens(text: str, line: str, begidx: int, endidx: int,
 class AutoCompleteTester(cmd2.Cmd):
     """Cmd2 app that exercises ArgparseCompleter class"""
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, auto_load_commands=False, **kwargs)
 
     ############################################################################################################
     # Begin code related to help and command name completion

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -33,7 +33,7 @@ class ApCustomTestApp(cmd2.Cmd):
 
 @pytest.fixture
 def cust_app():
-    return ApCustomTestApp()
+    return ApCustomTestApp(auto_load_commands=False)
 
 
 def fake_func():

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 def CreateOutsimApp():
-    c = cmd2.Cmd()
+    c = cmd2.Cmd(auto_load_commands=False)
     c.stdout = utils.StdSim(c.stdout)
     return c
 
@@ -925,7 +925,7 @@ def test_ansi_prompt_not_esacped(base_app):
 
 def test_ansi_prompt_escaped():
     from cmd2.rl_utils import rl_make_safe_prompt
-    app = cmd2.Cmd()
+    app = cmd2.Cmd(auto_load_commands=False)
     color = 'cyan'
     prompt = 'InColor'
     color_prompt = ansi.style(prompt, fg=color)
@@ -1025,13 +1025,31 @@ def helpcat_app():
     app = HelpCategoriesApp()
     return app
 
+
 def test_help_cat_base(helpcat_app):
     out, err = run_cmd(helpcat_app, 'help')
     verify_help_text(helpcat_app, out)
 
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = helpcat_app._build_command_info()
+    assert 'Some Category' in cmds_cats
+    assert 'diddly' in cmds_cats['Some Category']
+    assert 'cat_nodoc' in cmds_cats['Some Category']
+    assert 'Custom Category' in cmds_cats
+    assert 'squat' in cmds_cats['Custom Category']
+    assert 'edit' in cmds_cats['Custom Category']
+    assert 'undoc' in cmds_undoc
+    assert 'Fake Category' not in cmds_cats
+
+    help_text = ''.join(out)
+    assert 'This command does diddly squat...' not in help_text
+
+
 def test_help_cat_verbose(helpcat_app):
     out, err = run_cmd(helpcat_app, 'help --verbose')
     verify_help_text(helpcat_app, out)
+
+    help_text = ''.join(out)
+    assert 'This command does diddly squat...' in help_text
 
 
 class SelectApp(cmd2.Cmd):
@@ -1396,7 +1414,7 @@ def test_eof(base_app):
     assert base_app.do_eof('')
 
 def test_echo(capsys):
-    app = cmd2.Cmd()
+    app = cmd2.Cmd(auto_load_commands=False)
     app.echo = True
     commands = ['help history']
 
@@ -1409,7 +1427,7 @@ def test_read_input_rawinput_true(capsys, monkeypatch):
     prompt_str = 'the_prompt'
     input_str = 'some input'
 
-    app = cmd2.Cmd()
+    app = cmd2.Cmd(auto_load_commands=False)
     app.use_rawinput = True
 
     # Mock out input() to return input_str

--- a/tests/test_commandset.py
+++ b/tests/test_commandset.py
@@ -31,8 +31,40 @@ def do_unbound(cmd: cmd2.Cmd, statement: cmd2.Statement):
     cmd.poutput('Unbound Command: {}'.format(statement.args))
 
 
+@cmd2.register_command
+@cmd2.with_category("AAA")
+def do_command_with_support(cmd: cmd2.Cmd, statement: cmd2.Statement):
+    """
+    This is an example of registering an unbound function
+
+    :param cmd:
+    :param statement:
+    :return:
+    """
+    cmd.poutput('Unbound Command: {}'.format(statement.args))
+
+
+def help_command_with_support(cmd: cmd2.Cmd):
+    cmd.poutput('Help for command_with_support')
+
+
+def complete_command_with_support(self, cmd: cmd2.Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+    """Completion function for do_index_based"""
+    food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
+    sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
+
+    index_dict = \
+        {
+            1: food_item_strs,  # Tab complete food items at index 1 in command line
+            2: sport_item_strs,  # Tab complete sport items at index 2 in command line
+            3: cmd.path_complete,  # Tab complete using path_complete function at index 3 in command line
+        }
+
+    return cmd.index_based_complete(text, line, begidx, endidx, index_dict=index_dict)
+
+
 @cmd2.with_default_category('Command Set')
-class TestCommandSet(cmd2.CommandSet):
+class CommandSetA(cmd2.CommandSet):
     def do_apple(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
         cmd.poutput('Apple!')
 
@@ -69,6 +101,11 @@ def command_sets_app():
     app = WithCommandSets()
     return app
 
+@pytest.fixture()
+def command_sets_manual():
+    app = WithCommandSets(auto_load_commands=False)
+    return app
+
 
 def test_autoload_commands(command_sets_app):
     cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_app._build_command_info()
@@ -83,4 +120,59 @@ def test_autoload_commands(command_sets_app):
     assert 'cranberry' in cmds_cats['Command Set']
 
 
+def test_load_commands(command_sets_manual):
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
 
+    assert 'AAA' not in cmds_cats
+
+    assert 'Alone' not in cmds_cats
+
+    assert 'Command Set' not in cmds_cats
+
+    command_sets_manual.install_command_function('unbound', do_unbound, None, None)
+
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+
+    assert 'AAA' in cmds_cats
+    assert 'unbound' in cmds_cats['AAA']
+
+    assert 'Alone' not in cmds_cats
+
+    assert 'Command Set' not in cmds_cats
+
+    cmd_set = CommandSetA()
+
+    command_sets_manual.install_command_set(cmd_set)
+
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+
+    assert 'AAA' in cmds_cats
+    assert 'unbound' in cmds_cats['AAA']
+
+    assert 'Alone' in cmds_cats
+    assert 'elderberry' in cmds_cats['Alone']
+
+    assert 'Command Set' in cmds_cats
+    assert 'cranberry' in cmds_cats['Command Set']
+
+    command_sets_manual.uninstall_command('unbound')
+
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+
+    assert 'AAA' not in cmds_cats
+
+    assert 'Alone' in cmds_cats
+    assert 'elderberry' in cmds_cats['Alone']
+
+    assert 'Command Set' in cmds_cats
+    assert 'cranberry' in cmds_cats['Command Set']
+
+    command_sets_manual.uninstall_command_set(cmd_set)
+
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+
+    assert 'AAA' not in cmds_cats
+
+    assert 'Alone' not in cmds_cats
+
+    assert 'Command Set' not in cmds_cats

--- a/tests/test_commandset.py
+++ b/tests/test_commandset.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+# flake8: noqa E302
+"""
+Test CommandSet
+"""
+
+from typing import List
+import pytest
+
+import cmd2
+from cmd2 import utils
+
+
+# Python 3.5 had some regressions in the unitest.mock module, so use 3rd party mock if available
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+@cmd2.register_command
+@cmd2.with_category("AAA")
+def do_unbound(cmd: cmd2.Cmd, statement: cmd2.Statement):
+    """
+    This is an example of registering an unbound function
+
+    :param cmd:
+    :param statement:
+    :return:
+    """
+    cmd.poutput('Unbound Command: {}'.format(statement.args))
+
+
+@cmd2.with_default_category('Command Set')
+class TestCommandSet(cmd2.CommandSet):
+    def do_apple(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
+        cmd.poutput('Apple!')
+
+    def do_banana(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
+        """Banana Command"""
+        cmd.poutput('Banana!!')
+
+    def do_cranberry(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
+        cmd.poutput('Cranberry!!')
+
+    def help_cranberry(self, cmd: cmd2.Cmd):
+        cmd.stdout.write('This command does diddly squat...\n')
+
+    def do_durian(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
+        """Durian Command"""
+        cmd.poutput('Durian!!')
+
+    def complete_durian(self, cmd: cmd2.Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        return utils.basic_complete(text, line, begidx, endidx, ['stinks', 'smells', 'disgusting'])
+
+    @cmd2.with_category('Alone')
+    def do_elderberry(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
+        cmd.poutput('Elderberry!!')
+
+
+class WithCommandSets(cmd2.Cmd):
+    """Class for testing custom help_* methods which override docstring help."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture
+def command_sets_app():
+    app = WithCommandSets()
+    return app
+
+
+def test_autoload_commands(command_sets_app):
+    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_app._build_command_info()
+
+    assert 'AAA' in cmds_cats
+    assert 'unbound' in cmds_cats['AAA']
+
+    assert 'Alone' in cmds_cats
+    assert 'elderberry' in cmds_cats['Alone']
+
+    assert 'Command Set' in cmds_cats
+    assert 'cranberry' in cmds_cats['Command Set']
+
+
+

--- a/tests/test_commandset.py
+++ b/tests/test_commandset.py
@@ -5,16 +5,13 @@ Test CommandSet
 """
 
 from typing import List
+
 import pytest
 
 import cmd2
 from cmd2 import utils
 
-from .conftest import (
-    complete_tester,
-    normalize,
-    run_cmd,
-)
+from .conftest import complete_tester, normalize, run_cmd
 
 
 @cmd2.register_command

--- a/tests/test_commandset.py
+++ b/tests/test_commandset.py
@@ -302,3 +302,27 @@ def test_command_functions(command_sets_manual):
     first_match = complete_tester(text, line, begidx, endidx, command_sets_manual)
     assert first_match is None
 
+
+def test_partial_with_passthru():
+
+    def test_func(arg1, arg2):
+        """Documentation Comment"""
+        print('Do stuff {} - {}'.format(arg1, arg2))
+
+    my_partial = cmd2.command_definition._partial_passthru(test_func, 1)
+
+    setattr(test_func, 'Foo', 5)
+
+    assert hasattr(my_partial, 'Foo')
+
+    assert getattr(my_partial, 'Foo', None) == 5
+
+    a = dir(test_func)
+    b = dir(my_partial)
+    assert a == b
+
+    assert not hasattr(test_func, 'Bar')
+    setattr(my_partial, 'Bar', 6)
+    assert hasattr(test_func, 'Bar')
+
+    assert getattr(test_func, 'Bar', None) == 6

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1098,7 +1098,7 @@ class SubcommandsWithUnknownExample(cmd2.Cmd):
     """
 
     def __init__(self):
-        cmd2.Cmd.__init__(self)
+        cmd2.Cmd.__init__(self, auto_load_commands=False)
 
     # subcommand functions for the base command
     def base_foo(self, args):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -588,7 +588,7 @@ def test_parse_unclosed_quotes(parser):
         _ = parser.tokenize("command with 'unclosed quotes")
 
 def test_empty_statement_raises_exception():
-    app = cmd2.Cmd()
+    app = cmd2.Cmd(auto_load_commands=False)
     with pytest.raises(exceptions.EmptyStatement):
         app._complete_statement('')
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -263,7 +263,7 @@ class Plugin:
 class PluggedApp(Plugin, cmd2.Cmd):
     """A sample app with a plugin mixed in"""
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, auto_load_commands=False, **kwargs)
 
     def do_say(self, statement):
         """Repeat back the arguments"""

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -29,7 +29,7 @@ class CmdLineApp(cmd2.Cmd):
     def __init__(self, *args, **kwargs):
         self.maxrepeats = 3
 
-        super().__init__(*args, multiline_commands=['orate'], **kwargs)
+        super().__init__(*args, multiline_commands=['orate'], auto_load_commands=False, **kwargs)
 
         # Make maxrepeats settable at runtime
         self.add_settable(Settable('maxrepeats', int, 'Max number of `--repeat`s allowed'))


### PR DESCRIPTION
- Group commands in CommandSets to be installed/uninstalled as a batch. Commands within a CommandSet can be optionally tagged with at default category. Individual commands may override the default category.
- Install/Uninstall individual command functions at runtime
- Tag command functions for automatic discovery and load
- Automatic discovery of complete_ and help_ functions that are contained in the same module as command functions.
- Automatic discovery and load of CommandSets and registered command functions that can be disabled in the constructor