### PR TITLE
replace pkg_resources with importlib.metadata

### DIFF
--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -3,10 +3,15 @@
 # flake8: noqa F401
 """This simply imports certain things for backwards compatibility."""
 
-from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    # For python 3.8 and later
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # For everyone else
+    import importlib_metadata
+try:
+    __version__ = importlib_metadata.version(__name__)
+except importlib_metadata.PackageNotFoundError:
     # package is not installed
     pass
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 """
 # Import for custom theme from Read the Docs
 import sphinx_rtd_theme
-from pkg_resources import get_distribution
+import cmd2
 
 # -- General configuration -----------------------------------------------------
 
@@ -57,7 +57,7 @@ author = 'cmd2 contributors'
 # built documents.
 #
 # version will look like x.y.z
-version = get_distribution('cmd2').version
+version = cmd2.__version__
 # release will look like x.y
 release = '.'.join(version.split('.')[:2])
 

--- a/plugins/ext_test/cmd2_ext_test/__init__.py
+++ b/plugins/ext_test/cmd2_ext_test/__init__.py
@@ -5,16 +5,20 @@
 An overview of what myplugin does.
 """
 
-from pkg_resources import DistributionNotFound, get_distribution
+try:
+    # For python 3.8 and later
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # For everyone else
+    import importlib_metadata
+try:
+    __version__ = importlib_metadata.version(__name__)
+except importlib_metadata.PackageNotFoundError:
+    # package is not installed
+    __version__ = 'unknown'
 
 from .cmd2_ext_test import ExternalTestMixin
 
 __all__ = [
     'ExternalTestMixin'
 ]
-
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    __version__ = 'unknown'

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ SETUP_REQUIRES = ['setuptools_scm >= 3.0']
 INSTALL_REQUIRES = [
     'attrs >= 16.3.0',
     'colorama >= 0.3.7',
+    'importlib_metadata>=1.7.0;python_version<"3.8"',
     'pyperclip >= 1.6',
     'setuptools >= 34.4',
     'wcwidth >= 0.1.7',


### PR DESCRIPTION
Importing pkg_resources has a side-effect of scanning every installed
distribution on sys.path to load the metadata, especially the entry
points defined in the packages. This can have a significant
launch-time cost for command line applications when there are a lot of
distributions to scan.

Since cmd2 is only using pkg_resources to find the version of the
installed package, pkg_resources can be replaced with
importlib.metadata. The implementation in the new library is
significantly faster because it goes immediately to the metadata file
for the requested distribution, instead of scanning all of them. There
are also no import-time side-effects.

importlib.metadata is a new standard library module starting with
python 3.8. For earlier versions, a compatible library has been
released to PyPI as 'importlib_metadata'. This change adds the new
dependency with a qualifier so that it is only applied to older
versions of python, and then updates the places that were importing
pkg_resources to look for the different versions of the new library
instead. The documentation configuration is changed to import cmd2
itself to get its version, since the package has to be installed for
the metadata to be available anyway.