### PR TITLE
Fix compatibility with Python 3.5 versions prior to 3.5.4

### DIFF
--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -20,9 +20,8 @@ from . import ansi, constants, utils
 try:
     from typing import Deque
 except ImportError:
-    import collections
     import typing
-    Deque = typing._alias(collections.deque, typing.T)
+    Deque = typing._alias(deque, typing.T)
 
 # Constants
 EMPTY = ''

--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -10,11 +10,19 @@ import functools
 import io
 from collections import deque
 from enum import Enum
-from typing import Any, Deque, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 from wcwidth import wcwidth
 
 from . import ansi, constants, utils
+
+# This is needed for compatibility with early versions of Python 3.5 prior to 3.5.4
+try:
+    from typing import Deque
+except ImportError:
+    from typing import _alias, T
+    import collections
+    Deque = _alias(collections.deque, T)
 
 # Constants
 EMPTY = ''

--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -20,9 +20,9 @@ from . import ansi, constants, utils
 try:
     from typing import Deque
 except ImportError:
-    from typing import _alias, T
     import collections
-    Deque = _alias(collections.deque, T)
+    import typing
+    Deque = typing._alias(collections.deque, typing.T)
 
 # Constants
 EMPTY = ''

--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -21,6 +21,8 @@ try:
     from typing import Deque
 except ImportError:
     import typing
+
+    # noinspection PyProtectedMember, PyUnresolvedReferences
     Deque = typing._alias(deque, typing.T)
 
 # Constants

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 """
 # Import for custom theme from Read the Docs
 import sphinx_rtd_theme
+
 import cmd2
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
This closes #946 

Also:
- Ran `isort` which made a small whitespace change in one other file