### PR TITLE
Fix a dependency version requirement which was too restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1 (July TBD, 2020)
+* Bug Fixes
+    * Relax minimum version `importlib-metadata` to >= 1.6.0 when using Python < 3.8
+
 ## 1.2.0 (July 13, 2020)
 * Bug Fixes
     * Fixed `typing` module compatibility issue with Python 3.5 prior to 3.5.4 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ SETUP_REQUIRES = ['setuptools_scm >= 3.0']
 INSTALL_REQUIRES = [
     'attrs >= 16.3.0',
     'colorama >= 0.3.7',
-    'importlib_metadata>=1.7.0;python_version<"3.8"',
+    'importlib_metadata>=1.6.0;python_version<"3.8"',
     'pyperclip >= 1.6',
     'setuptools >= 34.4',
     'wcwidth >= 0.1.7',


### PR DESCRIPTION
Fix a dependency version requirement which was too restrictive and required bleeding edge for no good reason.

The 1.2.0 release was put out with a dependency on version 1.7.0 or newer of `importlib-metadata` when running on versions of Python earlier than 3.8.  However, that version was only released on June 26, 2020 which makes it extremely bleeding edge: https://pypi.org/project/importlib-metadata/#history

This PR relaxes the dependency to >= 1.6.0 which was released on March 27, 2020 so it is still rather new, but not as painfully bleeding-edge.  The point of this is to ease compatibility issues with recent Linux distros and such.

