### PR TITLE
Removed remaining usages and examples with tox. 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.md CHANGELOG.md CONTRIBUTING.md tox.ini noxfile.py Pipfile
+include LICENSE README.md CHANGELOG.md CONTRIBUTING.md noxfile.py Pipfile
 recursive-include examples *
 recursive-include tests *
 recursive-include docs *

--- a/plugins/ext_test/noxfile.py
+++ b/plugins/ext_test/noxfile.py
@@ -1,0 +1,7 @@
+import nox
+
+
+@nox.session(python=['3.5', '3.6', '3.7', '3.8', '3.9'])
+def tests(session):
+    session.install('invoke', './[test]')
+    session.run('invoke', 'pytest', '--junit', '--no-pty')

--- a/plugins/ext_test/tasks.py
+++ b/plugins/ext_test/tasks.py
@@ -41,7 +41,7 @@ namespace.add_collection(namespace_clean, 'clean')
 
 #####
 #
-# pytest, tox, pylint, and codecov
+# pytest, pylint, and codecov
 #
 #####
 

--- a/plugins/tasks.py
+++ b/plugins/tasks.py
@@ -22,7 +22,7 @@ namespace.add_collection(namespace_clean, 'clean')
 
 #####
 #
-# pytest, tox, pylint, and codecov
+# pytest, pylint, and codecov
 #
 #####
 

--- a/plugins/template/README.md
+++ b/plugins/template/README.md
@@ -208,7 +208,7 @@ python supported by cmd2, and all supported platforms. cmd2 uses a three
 tiered testing strategy to accomplish this objective.
 
 - [pytest](https://pytest.org) runs the unit tests
-- [tox](https://tox.readthedocs.io/) runs the unit tests on multiple versions
+- [nox](https://nox.thea.codes/en/stable/) runs the unit tests on multiple versions
   of python
 - [AppVeyor](https://www.appveyor.com/) and [TravisCI](https://travis-ci.com)
   run the tests on the various supported platforms
@@ -218,7 +218,7 @@ This plugin template is set up to use the same strategy.
 
 ### Create python environments
 
-This project uses [tox](https://tox.readthedocs.io/en/latest/) to run the test
+This project uses [nox](https://nox.thea.codes/en/stable/) to run the test
 suite against multiple python versions. I recommend
 [pyenv](https://github.com/pyenv/pyenv) with the
 [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv>) plugin to manage
@@ -296,12 +296,12 @@ Run `invoke pytest` from the top level directory of your plugin to run all the
 unit tests found in the `tests` directory.
 
 
-### Use tox to run unit tests in multiple versions of python
+### Use nox to run unit tests in multiple versions of python
 
-The included `tox.ini` is setup to run the unit tests in python 3.4, 3.5, 3.6,
+The included `noxfile.py` is setup to run the unit tests in python 3.4, 3.5, 3.6,
 and 3.7. You can run your unit tests in all of these versions of python by:
 ```
-$ invoke tox
+$ nox
 ```
 
 

--- a/plugins/template/noxfile.py
+++ b/plugins/template/noxfile.py
@@ -1,0 +1,7 @@
+import nox
+
+
+@nox.session(python=['3.5', '3.6', '3.7', '3.8', '3.9'])
+def tests(session):
+    session.install('invoke', './[test]')
+    session.run('invoke', 'pytest', '--junit', '--no-pty')

--- a/plugins/template/tasks.py
+++ b/plugins/template/tasks.py
@@ -36,7 +36,7 @@ namespace.add_collection(namespace_clean, 'clean')
 
 #####
 #
-# pytest, tox, pylint, and codecov
+# pytest, pylint, and codecov
 #
 #####
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS_REQUIRE = {
     ":sys_platform=='win32'": ['pyreadline'],
     # Extra dependencies for running unit tests
     'test': [
-        "gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in tox env
+        "gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in nox env
         "mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
         'codecov',
         'coverage',
@@ -57,7 +57,7 @@ EXTRAS_REQUIRE = {
     ],
     # development only dependencies:  install with 'pip install -e .[dev]'
     'dev': ["mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
-            'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'tox', 'nox', 'flake8',
+            'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'nox', 'flake8',
             'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'doc8',
             'invoke', 'twine>=1.11',
             ]

--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,7 @@ namespace.add_collection(namespace_clean, 'clean')
 
 #####
 #
-# pytest, tox, nox, pylint, and codecov
+# pytest, nox, pylint, and codecov
 #
 #####
 
@@ -112,27 +112,6 @@ def mypy_clean(context):
 
 
 namespace_clean.add_task(mypy_clean, 'mypy')
-
-
-@invoke.task
-def tox(context):
-    """Run unit and integration tests on multiple python versions using tox"""
-    with context.cd(TASK_ROOT_STR):
-        context.run("tox")
-
-
-namespace.add_task(tox)
-
-
-@invoke.task
-def tox_clean(context):
-    """Remove tox virtualenvs and logs"""
-    # pylint: disable=unused-argument
-    with context.cd(TASK_ROOT_STR):
-        rmrf('.tox')
-
-
-namespace_clean.add_task(tox_clean, 'tox')
 
 
 @invoke.task


### PR DESCRIPTION
Removed all references to tox and replaced with references to nox as it made sense. Updated examples.

Resolves #950 