### PR TITLE
Subcmd fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## 1.3.2 (August 7, 2020)
+* Bug Fixes
+    * Fixed `prog` value of subcommands added with `as_subcommand_to()` decorator.
+    * Fixed missing settings in subcommand parsers created with `as_subcommand_to()` decorator. These settings
+      include things like description and epilog text.
+
 ## 1.3.1 (August 6, 2020)
 * Bug Fixes
     * Fixed issue determining whether an argparse completer function required a reference to a containing
-       CommandSet. Also resolves issues determining the correct CommandSet instance when calling the argparse 
-       argument completer function.  Manifested as a TypeError when using `cmd2.Cmd.path_complete` as a completer 
-       for an argparse-based command defined in a CommandSet
+      CommandSet. Also resolves issues determining the correct CommandSet instance when calling the argparse 
+      argument completer function.  Manifested as a TypeError when using `cmd2.Cmd.path_complete` as a completer 
+      for an argparse-based command defined in a CommandSet
 
 ## 1.3.0 (August 4, 2020)
 * Enhancements

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,14 +16,19 @@
 # cmd2 code
 cmd2/__init__.py           @tleonhardt @kotfu
 cmd2/ansi.py               @kmvanbrunt @tleonhardt
-cmd2/argparse_*.py         @kmvanbrunt
+cmd2/argparse_*.py         @kmvanbrunt @anselor
 cmd2/clipboard.py          @tleonhardt
 cmd2/cmd2.py               @tleonhardt @kmvanbrunt @kotfu
+cmd2/command_definition.py @anselor
 cmd2/constants.py          @kotfu
+cmd2/decorators.py         @kotfu @kmvanbrunt @anselor
+cmd2/exceptions.py         @kmvanbrunt @anselor
+cmd2/history.py            @kotfu @tleonhardt
 cmd2/parsing.py            @kotfu @kmvanbrunt
 cmd2/plugin.py             @kotfu
-cmd2/pyscript_bridge.py    @kmvanbrunt
+cmd2/py_bridge.py          @kmvanbrunt
 cmd2/rl_utils.py           @kmvanbrunt
+cmd2/table_creator.py      @kmvanbrunt
 cmd2/transcript.py         @kotfu
 cmd2/utils.py              @tleonhardt @kotfu @kmvanbrunt
 
@@ -34,6 +39,11 @@ docs/*                  @tleonhardt @kotfu
 examples/async_printing.py  @kmvanbrunt
 examples/environment.py     @kotfu
 examples/tab_*.py           @kmvanbrunt
+examples/modular_*.py       @anselor
+examples/modular_commands/* @anselor
+
+plugins/template/*          @kotfu
+plugins/ext_test/*          @anselor
 
 # Unit Tests
 tests/pyscript/*              @kmvanbrunt
@@ -46,6 +56,8 @@ tests/test_comp*.py           @kmvanbrunt
 tests/test_pars*.py           @kotfu
 tests/test_run_pyscript.py    @kmvanbrunt
 tests/test_transcript.py      @kotfu
+
+tests_isolated/test_commandset/*    @anselor
 
 # Top-level project stuff
 CONTRIBUTING.md         @tleonhardt @kotfu

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2623,6 +2623,10 @@ class Cmd(cmd.Cmd):
                 if saved_readline_settings is not None:
                     self._restore_readline(saved_readline_settings)
 
+    #############################################################
+    # Parsers and functions for alias command and subcommands
+    #############################################################
+
     # Top-level parser for alias
     alias_description = ("Manage aliases\n"
                          "\n"
@@ -2640,10 +2644,6 @@ class Cmd(cmd.Cmd):
         # Call handler for whatever subcommand was selected
         handler = args.get_handler()
         handler(args)
-
-    ############################################
-    # Add subcommands to alias
-    ############################################
 
     # alias -> create
     alias_create_description = "Create or overwrite an alias"
@@ -2750,6 +2750,10 @@ class Cmd(cmd.Cmd):
             for cur_alias in sorted(self.aliases, key=self.default_sort_key):
                 self.poutput("alias create {} {}".format(cur_alias, self.aliases[cur_alias]))
 
+    #############################################################
+    # Parsers and functions for macro command and subcommands
+    #############################################################
+
     # Top-level parser for macro
     macro_description = ("Manage macros\n"
                          "\n"
@@ -2767,10 +2771,6 @@ class Cmd(cmd.Cmd):
         # Call handler for whatever subcommand was selected
         handler = args.get_handler()
         handler(args)
-
-    ############################################
-    # Add subcommands to macro
-    ############################################
 
     # macro -> create
     macro_create_help = "create or overwrite a macro"

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2660,7 +2660,7 @@ class Cmd(cmd.Cmd):
                            "  alias create show_log !cat \"log file.txt\"\n"
                            "  alias create save_results print_results \">\" out.txt\n")
 
-    alias_create_parser = DEFAULT_ARGUMENT_PARSER('create', add_help=False, description=alias_create_description,
+    alias_create_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=alias_create_description,
                                                   epilog=alias_create_epilog)
     alias_create_parser.add_argument('name', help='name of this alias')
     alias_create_parser.add_argument('command', help='what the alias resolves to',
@@ -2705,7 +2705,7 @@ class Cmd(cmd.Cmd):
     alias_delete_help = "delete aliases"
     alias_delete_description = "Delete specified aliases or all aliases if --all is used"
 
-    alias_delete_parser = DEFAULT_ARGUMENT_PARSER('delete', add_help=False, description=alias_delete_description)
+    alias_delete_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=alias_delete_description)
     alias_delete_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='alias(es) to delete',
                                      choices_method=_get_alias_completion_items, descriptive_header='Value')
     alias_delete_parser.add_argument('-a', '--all', action='store_true', help="delete all aliases")
@@ -2733,7 +2733,7 @@ class Cmd(cmd.Cmd):
                               "\n"
                               "Without arguments, all aliases will be listed.")
 
-    alias_list_parser = DEFAULT_ARGUMENT_PARSER('list', add_help=False, description=alias_list_description)
+    alias_list_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=alias_list_description)
     alias_list_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='alias(es) to list',
                                    choices_method=_get_alias_completion_items, descriptive_header='Value')
 
@@ -2811,7 +2811,7 @@ class Cmd(cmd.Cmd):
                            "  Because macros do not resolve until after hitting Enter, tab completion\n"
                            "  will only complete paths while typing a macro.")
 
-    macro_create_parser = DEFAULT_ARGUMENT_PARSER('create', add_help=False, description=macro_create_description,
+    macro_create_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=macro_create_description,
                                                   epilog=macro_create_epilog)
     macro_create_parser.add_argument('name', help='name of this macro')
     macro_create_parser.add_argument('command', help='what the macro resolves to',
@@ -2902,7 +2902,7 @@ class Cmd(cmd.Cmd):
     # macro -> delete
     macro_delete_help = "delete macros"
     macro_delete_description = "Delete specified macros or all macros if --all is used"
-    macro_delete_parser = DEFAULT_ARGUMENT_PARSER('delete', add_help=False, description=macro_delete_description)
+    macro_delete_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=macro_delete_description)
     macro_delete_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='macro(s) to delete',
                                      choices_method=_get_macro_completion_items, descriptive_header='Value')
     macro_delete_parser.add_argument('-a', '--all', action='store_true', help="delete all macros")
@@ -2930,7 +2930,7 @@ class Cmd(cmd.Cmd):
                               "\n"
                               "Without arguments, all macros will be listed.")
 
-    macro_list_parser = DEFAULT_ARGUMENT_PARSER('list', add_help=False, description=macro_list_description)
+    macro_list_parser = DEFAULT_ARGUMENT_PARSER(add_help=False, description=macro_list_description)
     macro_list_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='macro(s) to list',
                                    choices_method=_get_macro_completion_items, descriptive_header='Value')
 

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -56,7 +56,7 @@ SUBCMD_HANDLER = 'cmd2_handler'
 # subcommand attributes for the base command name and the subcommand name
 SUBCMD_ATTR_COMMAND = 'parent_command'
 SUBCMD_ATTR_NAME = 'subcommand_name'
-SUBCMD_ATTR_PARSER_ARGS = 'subcommand_parser_args'
+SUBCMD_ATTR_ADD_PARSER_KWARGS = 'subcommand_add_parser_kwargs'
 
 # arpparse attribute linking to command set instance
 PARSER_ATTR_COMMANDSET = 'command_set'

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -352,32 +352,14 @@ def as_subcommand_to(command: str,
         setattr(func, constants.CMD_ATTR_ARGPARSER, parser)
         setattr(func, constants.SUBCMD_ATTR_NAME, subcommand)
 
-        # Dictionary of arguments which will be passed to ArgumentParser.add_subparser()
-        parser_args = dict()
-
-        # parser is set as the parent to the one being created by ArgumentParser.add_parser().
-        # argparse only copies actions (arguments) from a parent and not the following settings.
-        # To retain these settings, we will copy them from parser and pass them as ArgumentParser
-        # constructor arguments to add_parser().
-        parser_args['prog'] = parser.prog
-        parser_args['usage'] = parser.usage
-        parser_args['description'] = parser.description
-        parser_args['epilog'] = parser.epilog
-        parser_args['formatter_class'] = parser.formatter_class
-        parser_args['prefix_chars'] = parser.prefix_chars
-        parser_args['fromfile_prefix_chars'] = parser.fromfile_prefix_chars
-        parser_args['argument_default'] = parser.argument_default
-        parser_args['conflict_handler'] = parser.conflict_handler
-        parser_args['add_help'] = parser.add_help
-        parser_args['allow_abbrev'] = parser.allow_abbrev
-
-        # Add remaining arguments specific to add_parser()
+        # Keyword arguments for ArgumentParser.add_subparser()
+        add_parser_kwargs = dict()
         if help is not None:
-            parser_args['help'] = help
+            add_parser_kwargs['help'] = help
         if aliases is not None:
-            parser_args['aliases'] = aliases[:]
+            add_parser_kwargs['aliases'] = aliases[:]
 
-        setattr(func, constants.SUBCMD_ATTR_PARSER_ARGS, parser_args)
+        setattr(func, constants.SUBCMD_ATTR_ADD_PARSER_KWARGS, add_parser_kwargs)
 
         return func
 

--- a/examples/modular_subcommands.py
+++ b/examples/modular_subcommands.py
@@ -23,10 +23,11 @@ class LoadableFruits(CommandSet):
     def do_apple(self, cmd: cmd2.Cmd, _: cmd2.Statement):
         cmd.poutput('Apple')
 
-    banana_parser = cmd2.Cmd2ArgumentParser(add_help=False)
+    banana_description = "Cut a banana"
+    banana_parser = cmd2.Cmd2ArgumentParser(add_help=False, description=banana_description)
     banana_parser.add_argument('direction', choices=['discs', 'lengthwise'])
 
-    @cmd2.as_subcommand_to('cut', 'banana', banana_parser)
+    @cmd2.as_subcommand_to('cut', 'banana', banana_parser, help=banana_description.lower())
     def cut_banana(self, cmd: cmd2.Cmd, ns: argparse.Namespace):
         """Cut banana"""
         cmd.poutput('cutting banana: ' + ns.direction)
@@ -40,10 +41,11 @@ class LoadableVegetables(CommandSet):
     def do_arugula(self, cmd: cmd2.Cmd, _: cmd2.Statement):
         cmd.poutput('Arugula')
 
-    bokchoy_parser = cmd2.Cmd2ArgumentParser(add_help=False)
+    bokchoy_description = "Cut some bokchoy"
+    bokchoy_parser = cmd2.Cmd2ArgumentParser(add_help=False, description=bokchoy_description)
     bokchoy_parser.add_argument('style', choices=['quartered', 'diced'])
 
-    @cmd2.as_subcommand_to('cut', 'bokchoy', bokchoy_parser)
+    @cmd2.as_subcommand_to('cut', 'bokchoy', bokchoy_parser, help=bokchoy_description.lower())
     def cut_bokchoy(self, cmd: cmd2.Cmd, _: cmd2.Statement):
         cmd.poutput('Bok Choy')
 
@@ -95,9 +97,9 @@ class ExampleApp(cmd2.Cmd):
 
     @with_argparser(cut_parser)
     def do_cut(self, ns: argparse.Namespace):
+        # Call handler for whatever subcommand was selected
         handler = ns.get_handler()
         if handler is not None:
-            # Call whatever subcommand function was selected
             handler(ns)
         else:
             # No subcommand was provided, so call help

--- a/examples/modular_subcommands.py
+++ b/examples/modular_subcommands.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
-"""A simple example demonstracting modular subcommand loading through CommandSets
+"""A simple example demonstrating modular subcommand loading through CommandSets
 
 In this example, there are loadable CommandSets defined. Each CommandSet has 1 subcommand defined that will be
 attached to the 'cut' command.

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -330,7 +330,7 @@ class LoadableFruits(cmd2.CommandSet):
     banana_parser = cmd2.Cmd2ArgumentParser(add_help=False)
     banana_parser.add_argument('direction', choices=['discs', 'lengthwise'])
 
-    @cmd2.as_subcommand_to('cut', 'banana', banana_parser, help_text='Cut banana', aliases=['bananer'])
+    @cmd2.as_subcommand_to('cut', 'banana', banana_parser, help='Cut banana', aliases=['bananer'])
     def cut_banana(self, cmd: cmd2.Cmd, ns: argparse.Namespace):
         """Cut banana"""
         cmd.poutput('cutting banana: ' + ns.direction)
@@ -545,7 +545,7 @@ class AppWithSubCommands(cmd2.Cmd):
     banana_parser = cmd2.Cmd2ArgumentParser(add_help=False)
     banana_parser.add_argument('direction', choices=['discs', 'lengthwise'])
 
-    @cmd2.as_subcommand_to('cut', 'banana', banana_parser, help_text='Cut banana', aliases=['bananer'])
+    @cmd2.as_subcommand_to('cut', 'banana', banana_parser, help='Cut banana', aliases=['bananer'])
     def cut_banana(self, ns: argparse.Namespace):
         """Cut banana"""
         self.poutput('cutting banana: ' + ns.direction)


### PR DESCRIPTION
* Fixed `prog` value of subcommands added with `as_subcommand_to()` decorator.
* Fixed missing settings in subcommand parsers created with `as_subcommand_to()` decorator. These settings include things like description and epilog text.