### PR TITLE
Will now traverse down CommandSet inheritance tree to find all leaf d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 1.3.2 (August 7, 2020)
+## 1.3.2 (August 10, 2020)
 * Bug Fixes
     * Fixed `prog` value of subcommands added with `as_subcommand_to()` decorator.
     * Fixed missing settings in subcommand parsers created with `as_subcommand_to()` decorator. These settings
       include things like description and epilog text.
+    * Fixed issue with CommandSet auto-discovery only searching direct sub-classes
+* Enhancements
+    * Added functions to fetch registered CommandSets by type and command name
 
 ## 1.3.1 (August 6, 2020)
 * Bug Fixes

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -6,6 +6,7 @@ import functools
 from typing import Callable, Iterable, Optional, Type
 
 from .constants import COMMAND_FUNC_PREFIX
+from .exceptions import CommandSetRegistrationError
 
 # Allows IDEs to resolve types without impacting imports at runtime, breaking circular dependency issues
 try:  # pragma: no cover
@@ -92,7 +93,10 @@ class CommandSet(object):
         :param cmd: The cmd2 main application
         :type cmd: cmd2.Cmd
         """
-        self._cmd = cmd
+        if self._cmd is None:
+            self._cmd = cmd
+        else:
+            raise CommandSetRegistrationError('This CommandSet has already been registered')
 
     def on_unregister(self, cmd):
         """

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -15,8 +15,12 @@ from .conftest import complete_tester, WithCommandSets
 from cmd2.exceptions import CommandSetRegistrationError
 
 
+class CommandSetBase(cmd2.CommandSet):
+    pass
+
+
 @cmd2.with_default_category('Fruits')
-class CommandSetA(cmd2.CommandSet):
+class CommandSetA(CommandSetBase):
     def do_apple(self, cmd: cmd2.Cmd, statement: cmd2.Statement):
         cmd.poutput('Apple!')
 
@@ -60,7 +64,7 @@ class CommandSetA(cmd2.CommandSet):
 
 
 @cmd2.with_default_category('Command Set B')
-class CommandSetB(cmd2.CommandSet):
+class CommandSetB(CommandSetBase):
     def __init__(self, arg1):
         super().__init__()
         self._arg1 = arg1
@@ -95,8 +99,8 @@ def test_autoload_commands(command_sets_app):
 
 def test_custom_construct_commandsets():
     # Verifies that a custom initialized CommandSet loads correctly when passed into the constructor
-    command_set = CommandSetB('foo')
-    app = WithCommandSets(command_sets=[command_set])
+    command_set_b = CommandSetB('foo')
+    app = WithCommandSets(command_sets=[command_set_b])
 
     cmds_cats, cmds_doc, cmds_undoc, help_topics = app._build_command_info()
     assert 'Command Set B' in cmds_cats
@@ -107,15 +111,40 @@ def test_custom_construct_commandsets():
         assert app.install_command_set(command_set_2)
 
     # Verify that autoload doesn't conflict with a manually loaded CommandSet that could be autoloaded.
-    app2 = WithCommandSets(command_sets=[CommandSetA()])
+    command_set_a = CommandSetA()
+    app2 = WithCommandSets(command_sets=[command_set_a])
+
+    with pytest.raises(CommandSetRegistrationError):
+        app2.install_command_set(command_set_b)
+
+    app.uninstall_command_set(command_set_b)
+
+    app2.install_command_set(command_set_b)
+
     assert hasattr(app2, 'do_apple')
+    assert hasattr(app2, 'do_aardvark')
+
+    assert app2.find_commandset_for_command('aardvark') is command_set_b
+    assert app2.find_commandset_for_command('apple') is command_set_a
+
+    matches = app2.find_commandsets(CommandSetBase, subclass_match=True)
+    assert command_set_a in matches
+    assert command_set_b in matches
+    assert command_set_2 not in matches
 
 
 def test_load_commands(command_sets_manual):
 
     # now install a command set and verify the commands are now present
     cmd_set = CommandSetA()
+
+    assert command_sets_manual.find_commandset_for_command('elderberry') is None
+    assert not command_sets_manual.find_commandsets(CommandSetA)
+
     command_sets_manual.install_command_set(cmd_set)
+
+    assert command_sets_manual.find_commandsets(CommandSetA)[0] is cmd_set
+    assert command_sets_manual.find_commandset_for_command('elderberry') is cmd_set
 
     cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
 


### PR DESCRIPTION
…escendants.

CommandSet now has a check to ensure it is only registered with one
cmd2.Cmd instance at a time.
Adds function to find command set by type and by command name