### PR TITLE
Python352

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 matrix:
     include:
         - os: linux
+          python: 3.5.2
+          env: NOXSESSION=tests-3.5.2
+        - os: linux
           python: 3.5.3
           env: NOXSESSION=tests-3.5.3
         - os: linux
@@ -38,7 +41,7 @@ matrix:
 #            - BREW_INSTALL=python3
 
 install:
-  - pip install flake8 nox
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5.2 ]]; then pip install flake8 nox==2019.11.9; else pip install flake8 nox; fi
 #  - |
 #    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 #      if [[ -n "$BREW_INSTALL" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.3.3 (TBD)
 * Bug Fixes
-    * Added explicit testing against python 3.5.3 for Debian 9 support.
+    * Added explicit testing against python 3.5.2 for Ubuntu 16.04, and 3.5.3 for Debian 9
     * Added fallback definition of typing.Deque (taken from 3.5.4)
+    * Removed explicit type hints that fail due to a bug in 3.5.2 favoring comment-based hints instead
 * Other 
     * Added missing doc-string for new cmd2.Cmd __init__ parameters 
       introduced by CommandSet enhancement

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import unicodedata
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Union
 
 from . import constants
 
@@ -1041,15 +1041,20 @@ def categorize(func: Union[Callable, Iterable[Callable]], category: str) -> None
         setattr(func, constants.CMD_ATTR_HELP_CATEGORY, category)
 
 
-def get_defining_class(meth: Callable) -> Optional[Type]:
+def get_defining_class(meth):
     """
     Attempts to resolve the class that defined a method.
 
     Inspired by implementation published here:
         https://stackoverflow.com/a/25959545/1956611
 
+    TODO: Python 3.5.2 is unable to handle the type hints Callable and Optional[Type].
+          Restore proper type hints after we drop 3.5.2 support
+
     :param meth: method to inspect
+    :type meth: Callable
     :return: class type in which the supplied method was defined. None if it couldn't be resolved.
+    :rtype: Optional[Type]
     """
     if isinstance(meth, functools.partial):
         return get_defining_class(meth.func)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ def docs(session):
                 '-d', '{}/doctrees'.format(tmpdir), '.', '{}/html'.format(tmpdir))
 
 
-@nox.session(python=['3.5.3', '3.5', '3.6', '3.7', '3.8', '3.9'])
+@nox.session(python=['3.5.2', '3.5.3', '3.5', '3.6', '3.7', '3.8', '3.9'])
 @nox.parametrize('plugin', [None,
                             'ext_test',
                             'template',
@@ -29,10 +29,9 @@ def tests(session, plugin):
         session.install('invoke', 'codecov', 'coverage')
         session.run('codecov')
     else:
-        session.install('invoke', '.')
+        session.install('invoke', './', 'plugins/{}[test]'.format(plugin))
 
         # cd into test directory to run other unit test
-        session.install('plugins/{}[test]'.format(plugin))
         session.run('invoke',
                     'plugin.{}.pytest'.format(plugin.replace('_', '-')),
                     '--junit',

--- a/setup.py
+++ b/setup.py
@@ -51,13 +51,19 @@ EXTRAS_REQUIRE = {
         "mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
         'codecov',
         'coverage',
-        'pytest',
+        'pytest>=4.6',
         'pytest-cov',
         'pytest-mock',
     ],
     # development only dependencies:  install with 'pip install -e .[dev]'
     'dev': ["mock ; python_version<'3.6'",  # for python 3.5 we need the third party mock module
-            'pytest', 'codecov', 'pytest-cov', 'pytest-mock', 'nox', 'flake8',
+            "pytest>=4.6",
+            'codecov',
+            'pytest-cov',
+            'pytest-mock',
+            "nox==2019.11.9 ; python_version=='3.5.2'",
+            "nox ; python_version>'3.5.2'",
+            'flake8',
             'sphinx', 'sphinx-rtd-theme', 'sphinx-autobuild', 'doc8',
             'invoke', 'twine>=1.11',
             ]


### PR DESCRIPTION
For Python 3.5.2 pinned nox to an older version that doesn't exercise bug typing bug introduced in 3.5.2.
Changed a couple type hints in utils.py to also not exercise the 3.5.2 typing bugs.