### PR TITLE
Completion refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0 (TBD)
+* Breaking changes
+    * Argparse Completion / Settables
+        * Replaced `choices_function` / `choices_method` with `choices_provider`.
+        * Replaced `completer_function` / `completer_method` with `completer`.
+        * ArgparseCompleter now always passes `cmd2.Cmd` or `CommandSet` instance as the
+        `self argument` to choices_provider and completer functions.
+    * Moved `basic_complete` from utils into `cmd2.Cmd` class.
+    * Moved `CompletionError` to exceptions.py
+
 ## 1.3.3 (August 13, 2020)
 * Breaking changes
     * CommandSet command functions (do_, complete_, help_) will no longer have the cmd2 app

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -32,8 +32,8 @@ from .command_definition import CommandSet, with_default_category
 from .constants import COMMAND_NAME, DEFAULT_SHORTCUTS
 from .decorators import with_argument_list, with_argparser, with_argparser_and_unknown_args, with_category, \
     as_subcommand_to
-from .exceptions import Cmd2ArgparseError, SkipPostcommandHooks, CommandSetRegistrationError
+from .exceptions import Cmd2ArgparseError, CommandSetRegistrationError, CompletionError, SkipPostcommandHooks
 from . import plugin
 from .parsing import Statement
 from .py_bridge import CommandResult
-from .utils import categorize, CompletionError, Settable
+from .utils import categorize, Settable

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -580,12 +580,12 @@ class ArgparseCompleter:
             # The completer may or may not be defined in the same class as the command. Since completer
             # functions are registered with the command argparser before anything is instantiated, we
             # need to find an instance at runtime that matches the types during declaration
-            cmd_set = self._cmd2_app._resolve_func_self(arg_choices.to_call, cmd_set)
-            if cmd_set is None:
+            self_arg = self._cmd2_app._resolve_func_self(arg_choices.to_call, cmd_set)
+            if self_arg is None:
                 # No cases matched, raise an error
                 raise CompletionError('Could not find CommandSet instance matching defining type for completer')
 
-            args.append(cmd_set)
+            args.append(self_arg)
 
             # Check if arg_choices.to_call expects arg_tokens
             to_call_params = inspect.signature(arg_choices.to_call).parameters

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -24,8 +24,9 @@ from .argparse_custom import (
     generate_range_error,
 )
 from .command_definition import CommandSet
+from .exceptions import CompletionError
 from .table_creator import Column, SimpleTable
-from .utils import CompletionError, basic_complete, get_defining_class
+from .utils import get_defining_class
 
 # If no descriptive header is supplied, then this will be used instead
 DEFAULT_DESCRIPTIVE_HEADER = 'Description'
@@ -459,7 +460,7 @@ class ArgparseCompleter:
                 if action.help != argparse.SUPPRESS:
                     match_against.append(flag)
 
-        return basic_complete(text, line, begidx, endidx, match_against)
+        return self._cmd2_app.basic_complete(text, line, begidx, endidx, match_against)
 
     def _format_completions(self, action, completions: List[Union[str, CompletionItem]]) -> List[str]:
         # Check if the results are CompletionItems and that there aren't too many to display
@@ -524,7 +525,7 @@ class ArgparseCompleter:
                     return completer.complete_subcommand_help(tokens[token_index:], text, line, begidx, endidx)
                 elif token_index == len(tokens) - 1:
                     # Since this is the last token, we will attempt to complete it
-                    return basic_complete(text, line, begidx, endidx, self._subcommand_action.choices)
+                    return self._cmd2_app.basic_complete(text, line, begidx, endidx, self._subcommand_action.choices)
                 else:
                     break
         return []
@@ -568,45 +569,44 @@ class ArgparseCompleter:
         args = []
         kwargs = {}
         if isinstance(arg_choices, ChoicesCallable):
-            if arg_choices.is_method:
-                # figure out what class the completer was defined in
-                completer_class = get_defining_class(arg_choices.to_call)
+            # figure out what class the completer was defined in
+            completer_class = get_defining_class(arg_choices.to_call)
 
-                # Was there a defining class identified? If so, is it a sub-class of CommandSet?
-                if completer_class is not None and issubclass(completer_class, CommandSet):
-                    # Since the completer function is provided as an unbound function, we need to locate the instance
-                    # of the CommandSet to pass in as `self` to emulate a bound method call.
-                    # We're searching for candidates that match the completer function's parent type in this order:
-                    #   1. Does the CommandSet registered with the command's argparser match as a subclass?
-                    #   2. Do any of the registered CommandSets in the Cmd2 application exactly match the type?
-                    #   3. Is there a registered CommandSet that is is the only matching subclass?
+            # Was there a defining class identified? If so, is it a sub-class of CommandSet?
+            if completer_class is not None and issubclass(completer_class, CommandSet):
+                # Since the completer function is provided as an unbound function, we need to locate the instance
+                # of the CommandSet to pass in as `self` to emulate a bound method call.
+                # We're searching for candidates that match the completer function's parent type in this order:
+                #   1. Does the CommandSet registered with the command's argparser match as a subclass?
+                #   2. Do any of the registered CommandSets in the Cmd2 application exactly match the type?
+                #   3. Is there a registered CommandSet that is is the only matching subclass?
 
-                    # Now get the CommandSet associated with the current command/subcommand argparser
-                    parser_cmd_set = getattr(self._parser, constants.PARSER_ATTR_COMMANDSET, cmd_set)
-                    if isinstance(parser_cmd_set, completer_class):
-                        # Case 1: Parser's CommandSet is a sub-class of the completer function's CommandSet
-                        cmd_set = parser_cmd_set
-                    else:
-                        # Search all registered CommandSets
-                        cmd_set = None
-                        candidate_sets = []  # type: List[CommandSet]
-                        for installed_cmd_set in self._cmd2_app._installed_command_sets:
-                            if type(installed_cmd_set) == completer_class:
-                                # Case 2: CommandSet is an exact type match for the completer's CommandSet
-                                cmd_set = installed_cmd_set
-                                break
+                # Now get the CommandSet associated with the current command/subcommand argparser
+                parser_cmd_set = getattr(self._parser, constants.PARSER_ATTR_COMMANDSET, cmd_set)
+                if isinstance(parser_cmd_set, completer_class):
+                    # Case 1: Parser's CommandSet is a sub-class of the completer function's CommandSet
+                    cmd_set = parser_cmd_set
+                else:
+                    # Search all registered CommandSets
+                    cmd_set = None
+                    candidate_sets = []  # type: List[CommandSet]
+                    for installed_cmd_set in self._cmd2_app._installed_command_sets:
+                        if type(installed_cmd_set) == completer_class:
+                            # Case 2: CommandSet is an exact type match for the completer's CommandSet
+                            cmd_set = installed_cmd_set
+                            break
 
-                            # Add candidate for Case 3:
-                            if isinstance(installed_cmd_set, completer_class):
-                                candidate_sets.append(installed_cmd_set)
-                        if cmd_set is None and len(candidate_sets) == 1:
-                            # Case 3: There exists exactly 1 CommandSet that is a subclass of the completer's CommandSet
-                            cmd_set = candidate_sets[0]
-                    if cmd_set is None:
-                        # No cases matched, raise an error
-                        raise CompletionError('Could not find CommandSet instance matching defining type for completer')
-                    args.append(cmd_set)
-                args.append(self._cmd2_app)
+                        # Add candidate for Case 3:
+                        if isinstance(installed_cmd_set, completer_class):
+                            candidate_sets.append(installed_cmd_set)
+                    if cmd_set is None and len(candidate_sets) == 1:
+                        # Case 3: There exists exactly 1 CommandSet that is a subclass of the completer's CommandSet
+                        cmd_set = candidate_sets[0]
+                if cmd_set is None:
+                    # No cases matched, raise an error
+                    raise CompletionError('Could not find CommandSet instance matching defining type for completer')
+                args.append(cmd_set)
+            args.append(self._cmd2_app)
 
             # Check if arg_choices.to_call expects arg_tokens
             to_call_params = inspect.signature(arg_choices.to_call).parameters
@@ -650,6 +650,6 @@ class ArgparseCompleter:
             arg_choices = [choice for choice in arg_choices if choice not in used_values]
 
             # Do tab completion on the choices
-            results = basic_complete(text, line, begidx, endidx, arg_choices)
+            results = self._cmd2_app.basic_complete(text, line, begidx, endidx, arg_choices)
 
         return self._format_completions(arg_action, results)

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -39,82 +39,56 @@ hints about the current argument that print when tab is pressed. In addition,
 you can add tab completion for each argument's values using parameters passed
 to add_argument().
 
-Below are the 5 add_argument() parameters for enabling tab completion of an
+Below are the 3 add_argument() parameters for enabling tab completion of an
 argument's value. Only one can be used at a time.
 
 ``choices`` - pass a list of values to the choices parameter.
 
     Example::
 
-        parser.add_argument('-o', '--options', choices=['An Option', 'SomeOtherOption'])
+        my_list = ['An Option', 'SomeOtherOption']
         parser.add_argument('-o', '--options', choices=my_list)
 
-``choices_function`` - pass a function that returns choices. This is good in
+``choices_provider`` - pass a function that returns choices. This is good in
 cases where the choice list is dynamically generated when the user hits tab.
 
-    Example::
-
-        def my_choices_function():
-            ...
-            return my_generated_list
-
-        parser.add_argument('-o', '--options', choices_function=my_choices_function)
-
-``choices_method`` - this is equivalent to choices_function, but the function
-needs to be an instance method of a cmd2.Cmd or cmd2.CommandSet subclass. When
-ArgparseCompleter calls the method, it well detect whether is is bound to a
-CommandSet or Cmd subclass.
-If bound to a cmd2.Cmd subclass, it will pass the app instance as the `self`
-argument. This is good in cases where the list of choices being generated
-relies on state data of the cmd2-based app.
-If bound to a cmd2.CommandSet subclass, it will pass the CommandSet instance
-as the `self` argument, and the app instance as the positional argument.
+When ArgparseCompleter calls the provider, it well detect whether is is bound
+to a Cmd subclass or CommandSet. If bound to a cmd2.Cmd subclass, it will pass
+the app instance as the `self` argument. If bound to a cmd2.CommandSet
+subclass, it will pass the CommandSet instance as the `self` argument, and the
+app instance as the positional argument.
 
     Example bound to cmd2.Cmd::
 
-        def my_choices_method(self):
+        def my_choices_provider(self):
             ...
             return my_generated_list
 
-        parser.add_argument("arg", choices_method=my_choices_method)
+        parser.add_argument("arg", choices_provider=my_choices_provider)
 
-    Example bound to cmd2.CommandSEt::
+    Example bound to cmd2.CommandSet::
 
-        def my_choices_method(self, app: cmd2.Cmd):
+        def my_choices_provider(self, app: cmd2.Cmd):
             ...
             return my_generated_list
 
-        parser.add_argument("arg", choices_method=my_choices_method)
+        parser.add_argument("arg", choices_provider=my_choices_provider)
 
-``completer_function`` - pass a tab completion function that does custom
-completion. Since custom tab completion operations commonly need to modify
-cmd2's instance variables related to tab completion, it will be rare to need a
-completer function. completer_method should be used in those cases.
+``completer`` - pass a tab completion function that does custom completion.
 
-    Example::
+When ArgparseCompleter calls the completer, it well detect whether is is bound
+to a Cmd subclass or CommandSet. If bound to a cmd2.Cmd subclass, it will pass
+the app instance as the `self` argument. If bound to a cmd2.CommandSet
+subclass, it will pass the CommandSet instance as the `self` argument, and the
+app instance as the positional argument.
 
-        def my_completer_function(text, line, begidx, endidx):
-            ...
-            return completions
-        parser.add_argument('-o', '--options', completer_function=my_completer_function)
-
-``completer_method`` - this is equivalent to completer_function, but the function
-needs to be an instance method of a cmd2.Cmd or cmd2.CommandSet subclass. When
-ArgparseCompleter calls the method, it well detect whether is is bound to a
-CommandSet or Cmd subclass.
-If bound to a cmd2.Cmd subclass, it will pass the app instance as the `self`
-argument. This is good in cases where the list of choices being generated
-relies on state data of the cmd2-based app.
-If bound to a cmd2.CommandSet subclass, it will pass the CommandSet instance
-as the `self` argument, and the app instance as the positional argument.
-cmd2 provides a few completer methods for convenience (e.g.,
-path_complete, delimiter_complete)
+cmd2 provides a few completer methods for convenience (e.g., path_complete,
+delimiter_complete)
 
     Example::
 
         # This adds file-path completion to an argument
-        parser.add_argument('-o', '--options', completer_method=cmd2.Cmd.path_complete)
-
+        parser.add_argument('-o', '--options', completer=cmd2.Cmd.path_complete)
 
     You can use functools.partial() to prepopulate values of the underlying
     choices and completer functions/methods.
@@ -122,13 +96,13 @@ path_complete, delimiter_complete)
     Example::
 
         # This says to call path_complete with a preset value for its path_filter argument
-        completer_method = functools.partial(path_complete,
-                                             path_filter=lambda path: os.path.isdir(path))
-        parser.add_argument('-o', '--options', choices_method=completer_method)
+        dir_completer = functools.partial(path_complete,
+                                          path_filter=lambda path: os.path.isdir(path))
+        parser.add_argument('-o', '--options', completer=dir_completer)
 
-Of the 5 tab completion parameters, choices is the only one where argparse
+Of the 3 tab completion parameters, choices is the only one where argparse
 validates user input against items in the choices list. This is because the
-other 4 parameters are meant to tab complete data sets that are viewed as
+other 2 parameters are meant to tab complete data sets that are viewed as
 dynamic. Therefore it is up to the developer to validate if the user has typed
 an acceptable value for these arguments.
 
@@ -136,10 +110,8 @@ The following functions exist in cases where you may want to manually add a
 choice-providing function/method to an existing argparse action. For instance,
 in __init__() of a custom action class.
 
-    - set_choices_function(action, func)
-    - set_choices_method(action, method)
-    - set_completer_function(action, func)
-    - set_completer_method(action, method)
+    - set_choices_provider(action, func)
+    - set_completer(action, func)
 
 There are times when what's being tab completed is determined by a previous
 argument on the command line. In theses cases, Autocompleter can pass a
@@ -149,8 +121,8 @@ choices/completer function should have an argument called arg_tokens.
 
     Example::
 
-        def my_choices_method(self, arg_tokens)
-        def my_completer_method(self, text, line, begidx, endidx, arg_tokens)
+        def my_choices_provider(self, arg_tokens)
+        def my_completer(self, text, line, begidx, endidx, arg_tokens)
 
 All values of the arg_tokens dictionary are lists, even if a particular
 argument expects only 1 token. Since ArgparseCompleter is for tab completion,
@@ -302,15 +274,13 @@ class ChoicesCallable:
     Enables using a callable as the choices provider for an argparse argument.
     While argparse has the built-in choices attribute, it is limited to an iterable.
     """
-    def __init__(self, is_method: bool, is_completer: bool, to_call: Callable):
+    def __init__(self, is_completer: bool, to_call: Callable):
         """
         Initializer
-        :param is_method: True if to_call is an instance method of a cmd2 app. False if it is a function.
         :param is_completer: True if to_call is a tab completion routine which expects
                              the args: text, line, begidx, endidx
         :param to_call: the callable object that will be called to provide choices for the argument
         """
-        self.is_method = is_method
         self.is_completer = is_completer
         self.to_call = to_call
 
@@ -325,34 +295,24 @@ def _set_choices_callable(action: argparse.Action, choices_callable: ChoicesCall
     # Verify consistent use of parameters
     if action.choices is not None:
         err_msg = ("None of the following parameters can be used alongside a choices parameter:\n"
-                   "choices_function, choices_method, completer_function, completer_method")
+                   "choices_provider, completer")
         raise (TypeError(err_msg))
     elif action.nargs == 0:
         err_msg = ("None of the following parameters can be used on an action that takes no arguments:\n"
-                   "choices_function, choices_method, completer_function, completer_method")
+                   "choices_provider, completer")
         raise (TypeError(err_msg))
 
     setattr(action, ATTR_CHOICES_CALLABLE, choices_callable)
 
 
-def set_choices_function(action: argparse.Action, choices_function: Callable) -> None:
-    """Set choices_function on an argparse action"""
-    _set_choices_callable(action, ChoicesCallable(is_method=False, is_completer=False, to_call=choices_function))
+def set_choices_provider(action: argparse.Action, choices_provider: Callable) -> None:
+    """Set choices_provider on an argparse action"""
+    _set_choices_callable(action, ChoicesCallable(is_completer=False, to_call=choices_provider))
 
 
-def set_choices_method(action: argparse.Action, choices_method: Callable) -> None:
-    """Set choices_method on an argparse action"""
-    _set_choices_callable(action, ChoicesCallable(is_method=True, is_completer=False, to_call=choices_method))
-
-
-def set_completer_function(action: argparse.Action, completer_function: Callable) -> None:
-    """Set completer_function on an argparse action"""
-    _set_choices_callable(action, ChoicesCallable(is_method=False, is_completer=True, to_call=completer_function))
-
-
-def set_completer_method(action: argparse.Action, completer_method: Callable) -> None:
-    """Set completer_method on an argparse action"""
-    _set_choices_callable(action, ChoicesCallable(is_method=True, is_completer=True, to_call=completer_method))
+def set_completer(action: argparse.Action, completer: Callable) -> None:
+    """Set completer on an argparse action"""
+    _set_choices_callable(action, ChoicesCallable(is_completer=True, to_call=completer))
 
 
 ############################################################################################################
@@ -366,10 +326,8 @@ orig_actions_container_add_argument = argparse._ActionsContainer.add_argument
 
 def _add_argument_wrapper(self, *args,
                           nargs: Union[int, str, Tuple[int], Tuple[int, int], None] = None,
-                          choices_function: Optional[Callable] = None,
-                          choices_method: Optional[Callable] = None,
-                          completer_function: Optional[Callable] = None,
-                          completer_method: Optional[Callable] = None,
+                          choices_provider: Optional[Callable] = None,
+                          completer: Optional[Callable] = None,
                           suppress_tab_hint: bool = False,
                           descriptive_header: Optional[str] = None,
                           **kwargs) -> argparse.Action:
@@ -385,10 +343,8 @@ def _add_argument_wrapper(self, *args,
                   to specify a max value with no upper bound, use a 1-item tuple (min,)
 
     # Added args used by ArgparseCompleter
-    :param choices_function: function that provides choices for this argument
-    :param choices_method: cmd2-app method that provides choices for this argument
-    :param completer_function: tab completion function that provides choices for this argument
-    :param completer_method: cmd2-app tab completion method that provides choices for this argument
+    :param choices_provider: function that provides choices for this argument
+    :param completer: tab completion function that provides choices for this argument
     :param suppress_tab_hint: when ArgparseCompleter has no results to show during tab completion, it displays the
                               current argument's help text as a hint. Set this to True to suppress the hint. If this
                               argument's help text is set to argparse.SUPPRESS, then tab hints will not display
@@ -400,7 +356,7 @@ def _add_argument_wrapper(self, *args,
     :param kwargs: keyword-arguments recognized by argparse._ActionsContainer.add_argument
 
     Note: You can only use 1 of the following in your argument:
-          choices, choices_function, choices_method, completer_function, completer_method
+          choices, choices_provider, completer
 
           See the header of this file for more information
 
@@ -408,12 +364,12 @@ def _add_argument_wrapper(self, *args,
     :raises: ValueError on incorrect parameter usage
     """
     # Verify consistent use of arguments
-    choices_callables = [choices_function, choices_method, completer_function, completer_method]
+    choices_callables = [choices_provider, completer]
     num_params_set = len(choices_callables) - choices_callables.count(None)
 
     if num_params_set > 1:
         err_msg = ("Only one of the following parameters may be used at a time:\n"
-                   "choices_function, choices_method, completer_function, completer_method")
+                   "choices_provider, completer")
         raise (ValueError(err_msg))
 
     # Pre-process special ranged nargs
@@ -472,14 +428,10 @@ def _add_argument_wrapper(self, *args,
     # Set the custom attributes
     setattr(new_arg, ATTR_NARGS_RANGE, nargs_range)
 
-    if choices_function:
-        set_choices_function(new_arg, choices_function)
-    elif choices_method:
-        set_choices_method(new_arg, choices_method)
-    elif completer_function:
-        set_completer_function(new_arg, completer_function)
-    elif completer_method:
-        set_completer_method(new_arg, completer_method)
+    if choices_provider:
+        set_choices_provider(new_arg, choices_provider)
+    elif completer:
+        set_completer(new_arg, completer)
 
     setattr(new_arg, ATTR_SUPPRESS_TAB_HINT, suppress_tab_hint)
     setattr(new_arg, ATTR_DESCRIPTIVE_COMPLETION_HEADER, descriptive_header)

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -52,18 +52,15 @@ argument's value. Only one can be used at a time.
 ``choices_provider`` - pass a function that returns choices. This is good in
 cases where the choice list is dynamically generated when the user hits tab.
 
-When ArgparseCompleter calls the provider, it will detect whether is is bound
-to a Cmd subclass or CommandSet. If bound to a cmd2.Cmd subclass, it will pass
-the app instance as the `self` argument. If bound to a cmd2.CommandSet
-subclass, it will pass the CommandSet instance as the `self` argument.
+    Example::
 
+        def my_choices_provider(self):
+            ...
+            return my_generated_list
+
+        parser.add_argument("arg", choices_provider=my_choices_provider)
 
 ``completer`` - pass a tab completion function that does custom completion.
-
-When ArgparseCompleter calls the completer, it will detect whether is is bound
-to a Cmd subclass or CommandSet. If bound to a cmd2.Cmd subclass, it will pass
-the app instance as the `self` argument. If bound to a cmd2.CommandSet
-subclass, it will pass the CommandSet instance as the `self` argument.
 
 cmd2 provides a few completer methods for convenience (e.g., path_complete,
 delimiter_complete)
@@ -82,6 +79,15 @@ delimiter_complete)
         dir_completer = functools.partial(path_complete,
                                           path_filter=lambda path: os.path.isdir(path))
         parser.add_argument('-o', '--options', completer=dir_completer)
+
+For `choices_provider` and `completer`, do not set them to a bound method. This
+is because ArgparseCompleter passes the `self` argument explicitly to these
+functions. When ArgparseCompleter calls one, it will detect whether it is bound
+to a `Cmd` subclass or `CommandSet`. If bound to a `cmd2.Cmd subclass`, it will
+pass the app instance as the `self` argument. If bound to a `cmd2.CommandSet`
+subclass, it will pass the `CommandSet` instance as the `self` argument.
+Therefore instead of passing something like `self.path_complete`, pass
+`cmd2.Cmd.path_complete`.
 
 Of the 3 tab completion parameters, choices is the only one where argparse
 validates user input against items in the choices list. This is because the

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -51,6 +51,7 @@ from .decorators import with_argparser
 from .exceptions import (
     CommandSetRegistrationError,
     Cmd2ShlexError,
+    CompletionError,
     EmbeddedConsoleExit,
     EmptyStatement,
     RedirectionError,
@@ -59,7 +60,7 @@ from .exceptions import (
 from .history import History, HistoryItem
 from .parsing import Macro, MacroArg, Statement, StatementParser, shlex_split
 from .rl_utils import RlType, rl_get_point, rl_make_safe_prompt, rl_set_prompt, rl_type, rl_warning, vt100_support
-from .utils import CompletionError, Settable
+from .utils import Settable
 
 # Set up readline
 if rl_type == RlType.NONE:  # pragma: no cover
@@ -987,6 +988,21 @@ class Cmd(cmd.Cmd):
 
         return tokens, raw_tokens
 
+    # noinspection PyMethodMayBeStatic, PyUnusedLocal
+    def basic_complete(self, text: str, line: str, begidx: int, endidx: int, match_against: Iterable) -> List[str]:
+        """
+        Basic tab completion function that matches against a list of strings without considering line contents
+        or cursor position. The args required by this function are defined in the header of Python's cmd.py.
+
+        :param text: the string prefix we are attempting to match (all matches must begin with it)
+        :param line: the current input line with leading whitespace removed
+        :param begidx: the beginning index of the prefix text
+        :param endidx: the ending index of the prefix text
+        :param match_against: the strings being matched against
+        :return: a list of possible tab completions
+        """
+        return [cur_match for cur_match in match_against if cur_match.startswith(text)]
+
     def delimiter_complete(self, text: str, line: str, begidx: int, endidx: int,
                            match_against: Iterable, delimiter: str) -> List[str]:
         """
@@ -1021,7 +1037,7 @@ class Cmd(cmd.Cmd):
         :param delimiter: what delimits each portion of the matches (ex: paths are delimited by a slash)
         :return: a list of possible tab completions
         """
-        matches = utils.basic_complete(text, line, begidx, endidx, match_against)
+        matches = self.basic_complete(text, line, begidx, endidx, match_against)
 
         # Display only the portion of the match that's being completed based on delimiter
         if matches:
@@ -1082,7 +1098,7 @@ class Cmd(cmd.Cmd):
 
         # Perform tab completion using an Iterable
         if isinstance(match_against, Iterable):
-            completions_matches = utils.basic_complete(text, line, begidx, endidx, match_against)
+            completions_matches = self.basic_complete(text, line, begidx, endidx, match_against)
 
         # Perform tab completion using a function
         elif callable(match_against):
@@ -1126,7 +1142,7 @@ class Cmd(cmd.Cmd):
 
         # Perform tab completion using a Iterable
         if isinstance(match_against, Iterable):
-            matches = utils.basic_complete(text, line, begidx, endidx, match_against)
+            matches = self.basic_complete(text, line, begidx, endidx, match_against)
 
         # Perform tab completion using a function
         elif callable(match_against):
@@ -1710,7 +1726,7 @@ class Cmd(cmd.Cmd):
                 # Otherwise complete token against anything a user can run
                 else:
                     match_against = self._get_commands_aliases_and_macros_for_completion()
-                    self.completion_matches = utils.basic_complete(text, line, begidx, endidx, match_against)
+                    self.completion_matches = self.basic_complete(text, line, begidx, endidx, match_against)
 
                 # If we have one result and we are at the end of the line, then add a space if allowed
                 if len(self.completion_matches) == 1 and endidx == len(line) and self.allow_appended_space:
@@ -2692,9 +2708,9 @@ class Cmd(cmd.Cmd):
                                                       epilog=alias_create_epilog)
     alias_create_parser.add_argument('name', help='name of this alias')
     alias_create_parser.add_argument('command', help='what the alias resolves to',
-                                     choices_method=_get_commands_aliases_and_macros_for_completion)
+                                     choices_provider=_get_commands_aliases_and_macros_for_completion)
     alias_create_parser.add_argument('command_args', nargs=argparse.REMAINDER, help='arguments to pass to command',
-                                     completer_method=path_complete)
+                                     completer=path_complete)
     alias_create_parser.set_defaults(func=_alias_create)
 
     # alias -> delete
@@ -2703,7 +2719,7 @@ class Cmd(cmd.Cmd):
     alias_delete_parser = alias_subparsers.add_parser('delete', help=alias_delete_help,
                                                       description=alias_delete_description)
     alias_delete_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='alias(es) to delete',
-                                     choices_method=_get_alias_completion_items, descriptive_header='Value')
+                                     choices_provider=_get_alias_completion_items, descriptive_header='Value')
     alias_delete_parser.add_argument('-a', '--all', action='store_true', help="delete all aliases")
     alias_delete_parser.set_defaults(func=_alias_delete)
 
@@ -2717,7 +2733,7 @@ class Cmd(cmd.Cmd):
     alias_list_parser = alias_subparsers.add_parser('list', help=alias_list_help,
                                                     description=alias_list_description)
     alias_list_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='alias(es) to list',
-                                   choices_method=_get_alias_completion_items, descriptive_header='Value')
+                                   choices_provider=_get_alias_completion_items, descriptive_header='Value')
     alias_list_parser.set_defaults(func=_alias_list)
 
     # Preserve quotes since we are passing strings to other commands
@@ -2892,9 +2908,9 @@ class Cmd(cmd.Cmd):
                                                       epilog=macro_create_epilog)
     macro_create_parser.add_argument('name', help='name of this macro')
     macro_create_parser.add_argument('command', help='what the macro resolves to',
-                                     choices_method=_get_commands_aliases_and_macros_for_completion)
+                                     choices_provider=_get_commands_aliases_and_macros_for_completion)
     macro_create_parser.add_argument('command_args', nargs=argparse.REMAINDER,
-                                     help='arguments to pass to command', completer_method=path_complete)
+                                     help='arguments to pass to command', completer=path_complete)
     macro_create_parser.set_defaults(func=_macro_create)
 
     # macro -> delete
@@ -2903,7 +2919,7 @@ class Cmd(cmd.Cmd):
     macro_delete_parser = macro_subparsers.add_parser('delete', help=macro_delete_help,
                                                       description=macro_delete_description)
     macro_delete_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='macro(s) to delete',
-                                     choices_method=_get_macro_completion_items, descriptive_header='Value')
+                                     choices_provider=_get_macro_completion_items, descriptive_header='Value')
     macro_delete_parser.add_argument('-a', '--all', action='store_true', help="delete all macros")
     macro_delete_parser.set_defaults(func=_macro_delete)
 
@@ -2916,7 +2932,7 @@ class Cmd(cmd.Cmd):
 
     macro_list_parser = macro_subparsers.add_parser('list', help=macro_list_help, description=macro_list_description)
     macro_list_parser.add_argument('names', nargs=argparse.ZERO_OR_MORE, help='macro(s) to list',
-                                   choices_method=_get_macro_completion_items, descriptive_header='Value')
+                                   choices_provider=_get_macro_completion_items, descriptive_header='Value')
     macro_list_parser.set_defaults(func=_macro_list)
 
     # Preserve quotes since we are passing strings to other commands
@@ -2934,7 +2950,7 @@ class Cmd(cmd.Cmd):
         topics = set(self.get_help_topics())
         visible_commands = set(self.get_visible_commands())
         strs_to_match = list(topics | visible_commands)
-        return utils.basic_complete(text, line, begidx, endidx, strs_to_match)
+        return self.basic_complete(text, line, begidx, endidx, strs_to_match)
 
     def complete_help_subcommands(self, text: str, line: str, begidx: int, endidx: int,
                                   arg_tokens: Dict[str, List[str]]) -> List[str]:
@@ -2961,9 +2977,9 @@ class Cmd(cmd.Cmd):
     help_parser = DEFAULT_ARGUMENT_PARSER(description="List available commands or provide "
                                                       "detailed help for a specific command")
     help_parser.add_argument('command', nargs=argparse.OPTIONAL, help="command to retrieve help for",
-                             completer_method=complete_help_command)
+                             completer=complete_help_command)
     help_parser.add_argument('subcommands', nargs=argparse.REMAINDER, help="subcommand(s) to retrieve help for",
-                             completer_method=complete_help_subcommands)
+                             completer=complete_help_subcommands)
     help_parser.add_argument('-v', '--verbose', action='store_true',
                              help="print a list of all commands with descriptions of each")
 
@@ -3225,10 +3241,8 @@ class Cmd(cmd.Cmd):
         arg_name = 'value'
         settable_parser.add_argument(arg_name, metavar=arg_name, help=settable.description,
                                      choices=settable.choices,
-                                     choices_function=settable.choices_function,
-                                     choices_method=settable.choices_method,
-                                     completer_function=settable.completer_function,
-                                     completer_method=settable.completer_method)
+                                     choices_provider=settable.choices_provider,
+                                     completer=settable.completer)
 
         from .argparse_completer import ArgparseCompleter
         completer = ArgparseCompleter(settable_parser, self)
@@ -3246,12 +3260,12 @@ class Cmd(cmd.Cmd):
     set_parser_parent.add_argument('-v', '--verbose', action='store_true',
                                    help='include description of parameters when viewing')
     set_parser_parent.add_argument('param', nargs=argparse.OPTIONAL, help='parameter to set or view',
-                                   choices_method=_get_settable_completion_items, descriptive_header='Description')
+                                   choices_provider=_get_settable_completion_items, descriptive_header='Description')
 
     # Create the parser for the set command
     set_parser = DEFAULT_ARGUMENT_PARSER(parents=[set_parser_parent])
     set_parser.add_argument('value', nargs=argparse.OPTIONAL, help='new value for settable',
-                            completer_method=complete_set_value)
+                            completer=complete_set_value)
 
     # Preserve quotes so users can pass in quoted empty strings and flags (e.g. -h) as the value
     @with_argparser(set_parser, preserve_quotes=True)
@@ -3312,9 +3326,9 @@ class Cmd(cmd.Cmd):
                 self.poutput(result_str)
 
     shell_parser = DEFAULT_ARGUMENT_PARSER(description="Execute a command as if at the OS prompt")
-    shell_parser.add_argument('command', help='the command to run', completer_method=shell_cmd_complete)
+    shell_parser.add_argument('command', help='the command to run', completer=shell_cmd_complete)
     shell_parser.add_argument('command_args', nargs=argparse.REMAINDER, help='arguments to pass to command',
-                              completer_method=path_complete)
+                              completer=path_complete)
 
     # Preserve quotes since we are passing these strings to the shell
     @with_argparser(shell_parser, preserve_quotes=True)
@@ -3605,9 +3619,9 @@ class Cmd(cmd.Cmd):
         return py_bridge.stop
 
     run_pyscript_parser = DEFAULT_ARGUMENT_PARSER(description="Run a Python script file inside the console")
-    run_pyscript_parser.add_argument('script_path', help='path to the script file', completer_method=path_complete)
+    run_pyscript_parser.add_argument('script_path', help='path to the script file', completer=path_complete)
     run_pyscript_parser.add_argument('script_arguments', nargs=argparse.REMAINDER,
-                                     help='arguments to pass to script', completer_method=path_complete)
+                                     help='arguments to pass to script', completer=path_complete)
 
     @with_argparser(run_pyscript_parser)
     def do_run_pyscript(self, args: argparse.Namespace) -> Optional[bool]:
@@ -3701,10 +3715,10 @@ class Cmd(cmd.Cmd):
                                       help='edit and then run selected history items')
     history_action_group.add_argument('-o', '--output_file', metavar='FILE',
                                       help='output commands to a script file, implies -s',
-                                      completer_method=path_complete)
+                                      completer=path_complete)
     history_action_group.add_argument('-t', '--transcript', metavar='TRANSCRIPT_FILE',
                                       help='output commands and results to a transcript file,\nimplies -s',
-                                      completer_method=path_complete)
+                                      completer=path_complete)
     history_action_group.add_argument('-c', '--clear', action='store_true', help='clear all history')
 
     history_format_group = history_parser.add_argument_group(title='formatting')
@@ -4011,7 +4025,7 @@ class Cmd(cmd.Cmd):
 
     edit_parser = DEFAULT_ARGUMENT_PARSER(description=edit_description)
     edit_parser.add_argument('file_path', nargs=argparse.OPTIONAL,
-                             help="optional path to a file to open in editor", completer_method=path_complete)
+                             help="optional path to a file to open in editor", completer=path_complete)
 
     @with_argparser(edit_parser)
     def do_edit(self, args: argparse.Namespace) -> None:
@@ -4054,8 +4068,8 @@ class Cmd(cmd.Cmd):
     run_script_parser = DEFAULT_ARGUMENT_PARSER(description=run_script_description)
     run_script_parser.add_argument('-t', '--transcript', metavar='TRANSCRIPT_FILE',
                                    help='record the output of the script as a transcript file',
-                                   completer_method=path_complete)
-    run_script_parser.add_argument('script_path', help="path to the script file", completer_method=path_complete)
+                                   completer=path_complete)
+    run_script_parser.add_argument('script_path', help="path to the script file", completer=path_complete)
 
     @with_argparser(run_script_parser)
     def do_run_script(self, args: argparse.Namespace) -> Optional[bool]:

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -31,6 +31,31 @@ class CommandSetRegistrationError(Exception):
     """
     pass
 
+
+class CompletionError(Exception):
+    """
+    Raised during tab completion operations to report any sort of error you want printed. This can also be used
+    just to display a message, even if it's not an error. For instance, ArgparseCompleter raises CompletionErrors
+    to display tab completion hints and sets apply_style to False so hints aren't colored like error text.
+
+    Example use cases
+
+    - Reading a database to retrieve a tab completion data set failed
+    - A previous command line argument that determines the data set being completed is invalid
+    - Tab completion hints
+    """
+    def __init__(self, *args, apply_style: bool = True, **kwargs):
+        """
+        Initializer for CompletionError
+        :param apply_style: If True, then ansi.style_error will be applied to the message text when printed.
+                            Set to False in cases where the message text already has the desired style.
+                            Defaults to True.
+        """
+        self.apply_style = apply_style
+
+        # noinspection PyArgumentList
+        super().__init__(*args, **kwargs)
+
 ############################################################################################################
 # The following exceptions are NOT part of the public API and are intended for internal use only.
 ############################################################################################################

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -74,40 +74,13 @@ def str_to_bool(val: str) -> bool:
     raise ValueError("must be True or False (case-insensitive)")
 
 
-class CompletionError(Exception):
-    """
-    Raised during tab completion operations to report any sort of error you want printed. This can also be used
-    just to display a message, even if it's not an error. For instance, ArgparseCompleter raises CompletionErrors
-    to display tab completion hints and sets apply_style to False so hints aren't colored like error text.
-
-    Example use cases
-
-    - Reading a database to retrieve a tab completion data set failed
-    - A previous command line argument that determines the data set being completed is invalid
-    - Tab completion hints
-    """
-    def __init__(self, *args, apply_style: bool = True, **kwargs):
-        """
-        Initializer for CompletionError
-        :param apply_style: If True, then ansi.style_error will be applied to the message text when printed.
-                            Set to False in cases where the message text already has the desired style.
-                            Defaults to True.
-        """
-        self.apply_style = apply_style
-
-        # noinspection PyArgumentList
-        super().__init__(*args, **kwargs)
-
-
 class Settable:
     """Used to configure a cmd2 instance member to be settable via the set command in the CLI"""
     def __init__(self, name: str, val_type: Callable, description: str, *,
                  onchange_cb: Callable[[str, Any, Any], Any] = None,
                  choices: Iterable = None,
-                 choices_function: Optional[Callable] = None,
-                 choices_method: Optional[Callable] = None,
-                 completer_function: Optional[Callable] = None,
-                 completer_method: Optional[Callable] = None):
+                 choices_provider: Optional[Callable] = None,
+                 completer: Optional[Callable] = None):
         """
         Settable Initializer
 
@@ -129,14 +102,11 @@ class Settable:
         same settings in argparse-based tab completion. A maximum of one of these should be provided.
 
         :param choices: iterable of accepted values
-        :param choices_function: function that provides choices for this argument
-        :param choices_method: cmd2-app method that provides choices for this argument (See note below)
-        :param completer_function: tab completion function that provides choices for this argument
-        :param completer_method: cmd2-app tab completion method that provides choices
-                                 for this argument (See note below)
+        :param choices_provider: function that provides choices for this argument
+        :param completer: tab completion function that provides choices for this argument
 
         Note:
-        For choices_method and completer_method, do not set them to a bound method. This is because
+        For choices_provider and completer, do not set them to a bound method. This is because
         ArgparseCompleter passes the self argument explicitly to these functions.
 
         Therefore instead of passing something like self.path_complete, pass cmd2.Cmd.path_complete.
@@ -150,10 +120,8 @@ class Settable:
         self.description = description
         self.onchange_cb = onchange_cb
         self.choices = choices
-        self.choices_function = choices_function
-        self.choices_method = choices_method
-        self.completer_function = completer_function
-        self.completer_method = completer_method
+        self.choices_provider = choices_provider
+        self.completer = completer
 
 
 def namedtuple_with_defaults(typename: str, field_names: Union[str, List[str]],
@@ -687,22 +655,6 @@ class RedirectionSavedState:
         # Used to restore values after command ends regardless of whether the command redirected
         self.saved_pipe_proc_reader = pipe_proc_reader
         self.saved_redirecting = saved_redirecting
-
-
-# noinspection PyUnusedLocal
-def basic_complete(text: str, line: str, begidx: int, endidx: int, match_against: Iterable) -> List[str]:
-    """
-    Basic tab completion function that matches against a list of strings without considering line contents
-    or cursor position. The args required by this function are defined in the header of Python's cmd.py.
-
-    :param text: the string prefix we are attempting to match (all matches must begin with it)
-    :param line: the current input line with leading whitespace removed
-    :param begidx: the beginning index of the prefix text
-    :param endidx: the ending index of the prefix text
-    :param match_against: the strings being matched against
-    :return: a list of possible tab completions
-    """
-    return [cur_match for cur_match in match_against if cur_match.startswith(text)]
 
 
 class TextAlignment(Enum):

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -12,3 +12,6 @@ Custom cmd2 exceptions
 
 .. autoclass:: cmd2.exceptions.CommandSetRegistrationError
     :members:
+
+.. autoclass:: cmd2.exceptions.CompletionError
+    :members:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -36,15 +36,6 @@ IO Handling
     :members:
 
 
-Tab Completion
---------------
-
-.. autoclass:: cmd2.utils.CompletionError
-    :members:
-
-.. autofunction:: cmd2.utils.basic_complete
-
-
 Text Alignment
 --------------
 

--- a/docs/features/completion.rst
+++ b/docs/features/completion.rst
@@ -38,7 +38,7 @@ Included Tab Completion Functions
 ---------------------------------
 ``cmd2`` provides the following tab completion functions
 
-- :attr:`cmd2.utils.basic_complete` - helper method for tab completion against
+- :attr:`cmd2.Cmd.basic_complete` - helper method for tab completion against
   a list
 - :attr:`cmd2.Cmd.path_complete` - helper method provides flexible tab
   completion of file system paths
@@ -79,7 +79,7 @@ to be reported to the user. These include the following example cases:
   is invalid
 - Tab completion hints
 
-``cmd2`` provides the :class:`cmd2.utils.CompletionError` exception class for
+``cmd2`` provides the :class:`cmd2.exceptions.CompletionError` exception class for
 this capability. If an error occurs in which it is more desirable to display
 a message than a stack trace, then raise a ``CompletionError``. By default, the
 message displays in red like an error. However, ``CompletionError`` has a
@@ -95,18 +95,18 @@ Tab Completion Using argparse Decorators
 When using one the argparse-based :ref:`api/decorators:cmd2.decorators`,
 ``cmd2`` provides automatic tab completion of flag names.
 
-Tab completion of argument values can be configured by using one of five
+Tab completion of argument values can be configured by using one of three
 parameters to :meth:`argparse.ArgumentParser.add_argument`
 
 - ``choices``
-- ``choices_function`` or ``choices_method``
-- ``completer_function`` or ``completer_method``
+- ``choices_provider``
+- ``completer``
 
 See the arg_decorators_ or colors_ example for a demonstration of how to
 use the ``choices`` parameter. See the argparse_completion_ example for a
-demonstration of how to use the ``choices_function`` and ``choices_method``
-parameters. See the arg_decorators_ or argparse_completion_ example for a
-demonstration of how to use the ``completer_method`` parameter.
+demonstration of how to use the ``choices_provider`` parameter. See the
+arg_decorators_ or argparse_completion_ example for a demonstration
+of how to use the ``completer`` parameter.
 
 When tab completing flags or argument values for a ``cmd2`` command using
 one of these decorators, ``cmd2`` keeps track of state so that once a flag has
@@ -126,8 +126,8 @@ When tab completing things like a unique ID from a database, it can often be
 beneficial to provide the user with some extra context about the item being
 completed, such as a description.  To facilitate this, ``cmd2`` defines the
 :class:`cmd2.argparse_custom.CompletionItem` class which can be returned from
-any of the 4 completion functions: ``choices_function``, ``choices_method``,
-``completion_function``, or ``completion_method``.
+any of the 3 completion parameters: ``choices``, ``choices_provider``, and
+``completer``.
 
 See the argparse_completion_ example or the implementation of the built-in
 :meth:`~cmd2.Cmd.do_set` command for demonstration of how this is used.

--- a/examples/arg_decorators.py
+++ b/examples/arg_decorators.py
@@ -18,7 +18,7 @@ class ArgparsingApp(cmd2.Cmd):
                               help='add comma for thousands separator')
     fsize_parser.add_argument('-u', '--unit', choices=['MB', 'KB'], help='unit to display size in')
     fsize_parser.add_argument('file_path', help='path of file',
-                              completer_method=cmd2.Cmd.path_complete)
+                              completer=cmd2.Cmd.path_complete)
 
     @cmd2.with_argparser(fsize_parser)
     def do_fsize(self, args: argparse.Namespace) -> None:

--- a/examples/argparse_completion.py
+++ b/examples/argparse_completion.py
@@ -6,53 +6,10 @@ A simple example demonstrating how to integrate tab completion with argparse-bas
 import argparse
 from typing import Dict, List
 
-from cmd2 import Cmd, Cmd2ArgumentParser, CompletionItem, with_argparser
-from cmd2.utils import CompletionError, basic_complete
+from cmd2 import Cmd, Cmd2ArgumentParser, CompletionError, CompletionItem, with_argparser
 
 # Data source for argparse.choices
 food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
-
-
-def choices_function() -> List[str]:
-    """Choices functions are useful when the choice list is dynamically generated (e.g. from data in a database)"""
-    return ['a', 'dynamic', 'list', 'goes', 'here']
-
-
-def completer_function(text: str, line: str, begidx: int, endidx: int) -> List[str]:
-    """
-    A tab completion function not dependent on instance data. Since custom tab completion operations commonly
-    need to modify cmd2's instance variables related to tab completion, it will be rare to need a completer
-    function. completer_method should be used in those cases.
-    """
-    match_against = ['a', 'dynamic', 'list', 'goes', 'here']
-    return basic_complete(text, line, begidx, endidx, match_against)
-
-
-def choices_completion_item() -> List[CompletionItem]:
-    """Return CompletionItem instead of strings. These give more context to what's being tab completed."""
-    items = \
-        {
-            1: "My item",
-            2: "Another item",
-            3: "Yet another item"
-        }
-    return [CompletionItem(item_id, description) for item_id, description in items.items()]
-
-
-def choices_arg_tokens(arg_tokens: Dict[str, List[str]]) -> List[str]:
-    """
-    If a choices or completer function/method takes a value called arg_tokens, then it will be
-    passed a dictionary that maps the command line tokens up through the one being completed
-    to their argparse argument name.  All values of the arg_tokens dictionary are lists, even if
-    a particular argument expects only 1 token.
-    """
-    # Check if choices_function flag has appeared
-    values = ['choices_function', 'flag']
-    if 'choices_function' in arg_tokens:
-        values.append('is {}'.format(arg_tokens['choices_function'][0]))
-    else:
-        values.append('not supplied')
-    return values
 
 
 class ArgparseCompletion(Cmd):
@@ -60,8 +17,8 @@ class ArgparseCompletion(Cmd):
         super().__init__(*args, **kwargs)
         self.sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
-    def choices_method(self) -> List[str]:
-        """Choices methods are useful when the choice list is based on instance data of your application"""
+    def choices_provider(self) -> List[str]:
+        """A choices provider is useful when the choice list is based on instance data of your application"""
         return self.sport_item_strs
 
     def choices_completion_error(self) -> List[str]:
@@ -76,6 +33,33 @@ class ArgparseCompletion(Cmd):
             return self.sport_item_strs
         raise CompletionError("debug must be true")
 
+    # noinspection PyMethodMayBeStatic
+    def choices_completion_item(self) -> List[CompletionItem]:
+        """Return CompletionItem instead of strings. These give more context to what's being tab completed."""
+        items = \
+            {
+                1: "My item",
+                2: "Another item",
+                3: "Yet another item"
+            }
+        return [CompletionItem(item_id, description) for item_id, description in items.items()]
+
+    # noinspection PyMethodMayBeStatic
+    def choices_arg_tokens(self, arg_tokens: Dict[str, List[str]]) -> List[str]:
+        """
+        If a choices or completer function/method takes a value called arg_tokens, then it will be
+        passed a dictionary that maps the command line tokens up through the one being completed
+        to their argparse argument name.  All values of the arg_tokens dictionary are lists, even if
+        a particular argument expects only 1 token.
+        """
+        # Check if choices_provider flag has appeared
+        values = ['choices_provider', 'flag']
+        if 'choices_provider' in arg_tokens:
+            values.append('is {}'.format(arg_tokens['choices_provider'][0]))
+        else:
+            values.append('not supplied')
+        return values
+
     # Parser for example command
     example_parser = Cmd2ArgumentParser(description="Command demonstrating tab completion with argparse\n"
                                                     "Notice even the flags of this command tab complete")
@@ -85,29 +69,25 @@ class ArgparseCompletion(Cmd):
     example_parser.add_argument('--choices', choices=food_item_strs, metavar="CHOICE",
                                 help="tab complete using choices")
 
-    # Tab complete from choices provided by a choices function and choices method
-    example_parser.add_argument('--choices_function', choices_function=choices_function,
-                                help="tab complete using a choices_function")
-    example_parser.add_argument('--choices_method', choices_method=choices_method,
-                                help="tab complete using a choices_method")
+    # Tab complete from choices provided by a choices_provider
+    example_parser.add_argument('--choices_provider', choices_provider=choices_provider,
+                                help="tab complete using a choices_provider")
 
-    # Tab complete using a completer function and completer method
-    example_parser.add_argument('--completer_function', completer_function=completer_function,
-                                help="tab complete using a completer_function")
-    example_parser.add_argument('--completer_method', completer_method=Cmd.path_complete,
-                                help="tab complete using a completer_method")
+    # Tab complete using a completer
+    example_parser.add_argument('--completer', completer=Cmd.path_complete,
+                                help="tab complete using a completer")
 
     # Demonstrate raising a CompletionError while tab completing
-    example_parser.add_argument('--completion_error', choices_method=choices_completion_error,
+    example_parser.add_argument('--completion_error', choices_provider=choices_completion_error,
                                 help="raise a CompletionError while tab completing if debug is False")
 
     # Demonstrate returning CompletionItems instead of strings
-    example_parser.add_argument('--completion_item', choices_function=choices_completion_item, metavar="ITEM_ID",
+    example_parser.add_argument('--completion_item', choices_provider=choices_completion_item, metavar="ITEM_ID",
                                 descriptive_header="Description",
                                 help="demonstrate use of CompletionItems")
 
     # Demonstrate use of arg_tokens dictionary
-    example_parser.add_argument('--arg_tokens', choices_function=choices_arg_tokens,
+    example_parser.add_argument('--arg_tokens', choices_provider=choices_arg_tokens,
                                 help="demonstrate use of arg_tokens dictionary")
 
     @with_argparser(example_parser)

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -4,8 +4,7 @@ A simple example demonstrating a loadable command set
 """
 from typing import List
 
-from cmd2 import Cmd, CommandSet, Statement, with_category, with_default_category
-from cmd2.utils import CompletionError
+from cmd2 import Cmd, CommandSet, CompletionError, Statement, with_category, with_default_category
 
 
 @with_default_category('Basic Completion')

--- a/examples/modular_commands/commandset_complex.py
+++ b/examples/modular_commands/commandset_complex.py
@@ -8,7 +8,6 @@ import argparse
 from typing import List
 
 import cmd2
-from cmd2 import utils
 
 
 @cmd2.with_default_category('Fruits')
@@ -42,7 +41,7 @@ class CommandSetA(cmd2.CommandSet):
         cmd.poutput(', '.join(['{}']*len(args)).format(*args))
 
     def complete_durian(self, cmd: cmd2.Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
-        return utils.basic_complete(text, line, begidx, endidx, ['stinks', 'smells', 'disgusting'])
+        return cmd.basic_complete(text, line, begidx, endidx, ['stinks', 'smells', 'disgusting'])
 
     elderberry_parser = cmd2.Cmd2ArgumentParser('elderberry')
     elderberry_parser.add_argument('arg1')

--- a/examples/modular_commands_main.py
+++ b/examples/modular_commands_main.py
@@ -5,58 +5,13 @@ A complex example demonstrating a variety of methods to load CommandSets using a
 with examples of how to integrate tab completion with argparse-based commands.
 """
 import argparse
-from typing import Dict, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
-from cmd2 import Cmd, Cmd2ArgumentParser, CommandSet, CompletionItem, with_argparser
-from cmd2.utils import CompletionError, basic_complete
 from modular_commands.commandset_basic import BasicCompletionCommandSet  # noqa: F401
 from modular_commands.commandset_complex import CommandSetA  # noqa: F401
 from modular_commands.commandset_custominit import CustomInitCommandSet  # noqa: F401
 
-# Data source for argparse.choices
-food_item_strs = ['Pizza', 'Ham', 'Ham Sandwich', 'Potato']
-
-
-def choices_function() -> List[str]:
-    """Choices functions are useful when the choice list is dynamically generated (e.g. from data in a database)"""
-    return ['a', 'dynamic', 'list', 'goes', 'here']
-
-
-def completer_function(text: str, line: str, begidx: int, endidx: int) -> List[str]:
-    """
-    A tab completion function not dependent on instance data. Since custom tab completion operations commonly
-    need to modify cmd2's instance variables related to tab completion, it will be rare to need a completer
-    function. completer_method should be used in those cases.
-    """
-    match_against = ['a', 'dynamic', 'list', 'goes', 'here']
-    return basic_complete(text, line, begidx, endidx, match_against)
-
-
-def choices_completion_item() -> List[CompletionItem]:
-    """Return CompletionItem instead of strings. These give more context to what's being tab completed."""
-    items = \
-        {
-            1: "My item",
-            2: "Another item",
-            3: "Yet another item"
-        }
-    return [CompletionItem(item_id, description) for item_id, description in items.items()]
-
-
-def choices_arg_tokens(arg_tokens: Dict[str, List[str]]) -> List[str]:
-    """
-    If a choices or completer function/method takes a value called arg_tokens, then it will be
-    passed a dictionary that maps the command line tokens up through the one being completed
-    to their argparse argument name.  All values of the arg_tokens dictionary are lists, even if
-    a particular argument expects only 1 token.
-    """
-    # Check if choices_function flag has appeared
-    values = ['choices_function', 'flag']
-    if 'choices_function' in arg_tokens:
-        values.append('is {}'.format(arg_tokens['choices_function'][0]))
-    else:
-        values.append('not supplied')
-    return values
+from cmd2 import Cmd, Cmd2ArgumentParser, CommandSet, with_argparser
 
 
 class WithCommandSets(Cmd):
@@ -64,21 +19,9 @@ class WithCommandSets(Cmd):
         super().__init__(command_sets=command_sets)
         self.sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
-    def choices_method(self) -> List[str]:
-        """Choices methods are useful when the choice list is based on instance data of your application"""
+    def choices_provider(self) -> List[str]:
+        """A choices provider is useful when the choice list is based on instance data of your application"""
         return self.sport_item_strs
-
-    def choices_completion_error(self) -> List[str]:
-        """
-        CompletionErrors can be raised if an error occurs while tab completing.
-
-        Example use cases
-            - Reading a database to retrieve a tab completion data set failed
-            - A previous command line argument that determines the data set being completed is invalid
-        """
-        if self.debug:
-            return self.sport_item_strs
-        raise CompletionError("debug must be true")
 
     # Parser for example command
     example_parser = Cmd2ArgumentParser(description="Command demonstrating tab completion with argparse\n"
@@ -86,33 +29,16 @@ class WithCommandSets(Cmd):
 
     # Tab complete from a list using argparse choices. Set metavar if you don't
     # want the entire choices list showing in the usage text for this command.
-    example_parser.add_argument('--choices', choices=food_item_strs, metavar="CHOICE",
+    example_parser.add_argument('--choices', choices=['some', 'choices', 'here'], metavar="CHOICE",
                                 help="tab complete using choices")
 
-    # Tab complete from choices provided by a choices function and choices method
-    example_parser.add_argument('--choices_function', choices_function=choices_function,
-                                help="tab complete using a choices_function")
-    example_parser.add_argument('--choices_method', choices_method=choices_method,
-                                help="tab complete using a choices_method")
+    # Tab complete from choices provided by a choices provider
+    example_parser.add_argument('--choices_provider', choices_provider=choices_provider,
+                                help="tab complete using a choices_provider")
 
-    # Tab complete using a completer function and completer method
-    example_parser.add_argument('--completer_function', completer_function=completer_function,
-                                help="tab complete using a completer_function")
-    example_parser.add_argument('--completer_method', completer_method=Cmd.path_complete,
-                                help="tab complete using a completer_method")
-
-    # Demonstrate raising a CompletionError while tab completing
-    example_parser.add_argument('--completion_error', choices_method=choices_completion_error,
-                                help="raise a CompletionError while tab completing if debug is False")
-
-    # Demonstrate returning CompletionItems instead of strings
-    example_parser.add_argument('--completion_item', choices_function=choices_completion_item, metavar="ITEM_ID",
-                                descriptive_header="Description",
-                                help="demonstrate use of CompletionItems")
-
-    # Demonstrate use of arg_tokens dictionary
-    example_parser.add_argument('--arg_tokens', choices_function=choices_arg_tokens,
-                                help="demonstrate use of arg_tokens dictionary")
+    # Tab complete using a completer
+    example_parser.add_argument('--completer', completer=Cmd.path_complete,
+                                help="tab complete using a completer")
 
     @with_argparser(example_parser)
     def do_example(self, _: argparse.Namespace) -> None:

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -41,13 +41,9 @@ def fake_func():
 
 
 @pytest.mark.parametrize('kwargs, is_valid', [
-    ({'choices_function': fake_func}, True),
-    ({'choices_method': fake_func}, True),
-    ({'completer_function': fake_func}, True),
-    ({'completer_method': fake_func}, True),
-    ({'choices_function': fake_func, 'choices_method': fake_func}, False),
-    ({'choices_method': fake_func, 'completer_function': fake_func}, False),
-    ({'completer_function': fake_func, 'completer_method': fake_func}, False),
+    ({'choices_provider': fake_func}, True),
+    ({'completer': fake_func}, True),
+    ({'choices_provider': fake_func, 'completer': fake_func}, False),
 ])
 def test_apcustom_choices_callable_count(kwargs, is_valid):
     parser = Cmd2ArgumentParser()
@@ -60,10 +56,8 @@ def test_apcustom_choices_callable_count(kwargs, is_valid):
 
 
 @pytest.mark.parametrize('kwargs', [
-    ({'choices_function': fake_func}),
-    ({'choices_method': fake_func}),
-    ({'completer_function': fake_func}),
-    ({'completer_method': fake_func})
+    ({'choices_provider': fake_func}),
+    ({'completer': fake_func})
 ])
 def test_apcustom_no_choices_callables_alongside_choices(kwargs):
     with pytest.raises(TypeError) as excinfo:
@@ -73,10 +67,8 @@ def test_apcustom_no_choices_callables_alongside_choices(kwargs):
 
 
 @pytest.mark.parametrize('kwargs', [
-    ({'choices_function': fake_func}),
-    ({'choices_method': fake_func}),
-    ({'completer_function': fake_func}),
-    ({'completer_method': fake_func})
+    ({'choices_provider': fake_func}),
+    ({'completer': fake_func})
 ])
 def test_apcustom_no_choices_callables_when_nargs_is_0(kwargs):
     with pytest.raises(TypeError) as excinfo:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -65,13 +65,13 @@ class CompletionsExample(cmd2.Cmd):
         cmd2.Cmd.__init__(self, multiline_commands=['test_multiline'])
         self.foo = 'bar'
         self.add_settable(utils.Settable('foo', str, description="a settable param",
-                                         completer_method=CompletionsExample.complete_foo_val))
+                                         completer=CompletionsExample.complete_foo_val))
 
     def do_test_basic(self, args):
         pass
 
     def complete_test_basic(self, text, line, begidx, endidx):
-        return utils.basic_complete(text, line, begidx, endidx, food_item_strs)
+        return self.basic_complete(text, line, begidx, endidx, food_item_strs)
 
     def do_test_delimited(self, args):
         pass
@@ -84,7 +84,7 @@ class CompletionsExample(cmd2.Cmd):
 
     def complete_test_sort_key(self, text, line, begidx, endidx):
         num_strs = ['2', '11', '1']
-        return utils.basic_complete(text, line, begidx, endidx, num_strs)
+        return self.basic_complete(text, line, begidx, endidx, num_strs)
 
     def do_test_raise_exception(self, args):
         pass
@@ -96,7 +96,7 @@ class CompletionsExample(cmd2.Cmd):
         pass
 
     def complete_test_multiline(self, text, line, begidx, endidx):
-        return utils.basic_complete(text, line, begidx, endidx, sport_item_strs)
+        return self.basic_complete(text, line, begidx, endidx, sport_item_strs)
 
     def do_test_no_completer(self, args):
         """Completing this should result in completedefault() being called"""
@@ -541,7 +541,7 @@ def test_basic_completion_single(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert utils.basic_complete(text, line, begidx, endidx, food_item_strs) == ['Pizza']
+    assert cmd2_app.basic_complete(text, line, begidx, endidx, food_item_strs) == ['Pizza']
 
 def test_basic_completion_multiple(cmd2_app):
     text = ''
@@ -549,7 +549,7 @@ def test_basic_completion_multiple(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    matches = sorted(utils.basic_complete(text, line, begidx, endidx, food_item_strs))
+    matches = sorted(cmd2_app.basic_complete(text, line, begidx, endidx, food_item_strs))
     assert matches == sorted(food_item_strs)
 
 def test_basic_completion_nomatch(cmd2_app):
@@ -558,7 +558,7 @@ def test_basic_completion_nomatch(cmd2_app):
     endidx = len(line)
     begidx = endidx - len(text)
 
-    assert utils.basic_complete(text, line, begidx, endidx, food_item_strs) == []
+    assert cmd2_app.basic_complete(text, line, begidx, endidx, food_item_strs) == []
 
 def test_delimiter_completion(cmd2_app):
     text = '/home/'

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -47,7 +47,7 @@ class CommandSetA(cmd2.CommandSet):
         cmd.last_result = {'args': args}
 
     def complete_durian(self, cmd: cmd2.Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
-        return utils.basic_complete(text, line, begidx, endidx, ['stinks', 'smells', 'disgusting'])
+        return cmd.basic_complete(text, line, begidx, endidx, ['stinks', 'smells', 'disgusting'])
 
     elderberry_parser = cmd2.Cmd2ArgumentParser('elderberry')
     elderberry_parser.add_argument('arg1')
@@ -271,7 +271,6 @@ class LoadableBase(cmd2.CommandSet):
             cmd.pwarning('This command does nothing without sub-parsers registered')
             cmd.do_help('cut')
 
-
     stir_parser = cmd2.Cmd2ArgumentParser('stir')
     stir_subparsers = stir_parser.add_subparsers(title='item', help='what to stir')
 
@@ -362,7 +361,7 @@ class LoadableVegetables(cmd2.CommandSet):
         return ['quartered', 'diced']
 
     bokchoy_parser = cmd2.Cmd2ArgumentParser(add_help=False)
-    bokchoy_parser.add_argument('style', completer_method=complete_style_arg)
+    bokchoy_parser.add_argument('style', completer=complete_style_arg)
 
     @cmd2.as_subcommand_to('cut', 'bokchoy', bokchoy_parser)
     def cut_bokchoy(self, cmd: cmd2.Cmd, _: cmd2.Statement):
@@ -554,7 +553,7 @@ class AppWithSubCommands(cmd2.Cmd):
         return ['quartered', 'diced']
 
     bokchoy_parser = cmd2.Cmd2ArgumentParser(add_help=False)
-    bokchoy_parser.add_argument('style', completer_method=complete_style_arg)
+    bokchoy_parser.add_argument('style', completer=complete_style_arg)
 
     @cmd2.as_subcommand_to('cut', 'bokchoy', bokchoy_parser)
     def cut_bokchoy(self, _: cmd2.Statement):
@@ -604,12 +603,12 @@ class WithCompleterCommandSet(cmd2.CommandSet):
 
     def complete_states(self, cmd: cmd2.Cmd, text: str, line: str, begidx: int, endidx: int) -> List[str]:
         assert self is complete_states_expected_self
-        return utils.basic_complete(text, line, begidx, endidx, self.states)
+        return cmd.basic_complete(text, line, begidx, endidx, self.states)
 
 
 class SubclassCommandSetCase1(WithCompleterCommandSet):
     parser = cmd2.Cmd2ArgumentParser()
-    parser.add_argument('state', type=str, completer_method=WithCompleterCommandSet.complete_states)
+    parser.add_argument('state', type=str, completer=WithCompleterCommandSet.complete_states)
 
     @cmd2.with_argparser(parser)
     def do_case1(self, cmd: cmd2.Cmd, ns: argparse.Namespace):
@@ -618,7 +617,7 @@ class SubclassCommandSetCase1(WithCompleterCommandSet):
 
 class SubclassCommandSetErrorCase2(WithCompleterCommandSet):
     parser = cmd2.Cmd2ArgumentParser()
-    parser.add_argument('state', type=str, completer_method=WithCompleterCommandSet.complete_states)
+    parser.add_argument('state', type=str, completer=WithCompleterCommandSet.complete_states)
 
     @cmd2.with_argparser(parser)
     def do_error2(self, cmd: cmd2.Cmd, ns: argparse.Namespace):
@@ -631,7 +630,7 @@ class SubclassCommandSetCase2(cmd2.CommandSet):
         super(SubclassCommandSetCase2, self).__init__()
 
     parser = cmd2.Cmd2ArgumentParser()
-    parser.add_argument('state', type=str, completer_method=WithCompleterCommandSet.complete_states)
+    parser.add_argument('state', type=str, completer=WithCompleterCommandSet.complete_states)
 
     @cmd2.with_argparser(parser)
     def do_case2(self, cmd: cmd2.Cmd, ns: argparse.Namespace):
@@ -760,7 +759,7 @@ class CommandSetWithPathComplete(cmd2.CommandSet):
         super(CommandSetWithPathComplete, self).__init__()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('path', nargs='+', help='paths', completer_method=cmd2.Cmd.path_complete)
+    parser.add_argument('path', nargs='+', help='paths', completer=cmd2.Cmd.path_complete)
 
     @cmd2.with_argparser(parser)
     def do_path(self, app: cmd2.Cmd, args):


### PR DESCRIPTION
Initial changes for 2.0.0 release
* Breaking changes
    * Argparse Completion / Settables
        * Replaced `choices_function` / `choices_method` with `choices_provider`.
        * Replaced `completer_function` / `completer_method` with `completer`.
        * ArgparseCompleter now always passes `cmd2.Cmd` or `CommandSet` instance as the
        `self argument` to choices_provider and completer functions.
    * Moved `basic_complete` from utils into `cmd2.Cmd` class.
    * Moved `CompletionError` to exceptions.py