### PR TITLE
Run Shell without arguments

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3375,7 +3375,7 @@ class Cmd(cmd.Cmd):
                 self.poutput(result_str)
 
     shell_parser = DEFAULT_ARGUMENT_PARSER(description="Execute a command as if at the OS prompt")
-    shell_parser.add_argument('command', help='the command to run', completer_method=shell_cmd_complete)
+    shell_parser.add_argument('command', nargs='?', default='bash', help='the command to run', completer_method=shell_cmd_complete)
     shell_parser.add_argument('command_args', nargs=argparse.REMAINDER, help='arguments to pass to command',
                               completer_method=path_complete)
 


### PR DESCRIPTION
In some scenarios, you would like to allow the user to have a native (bash/zsh/sh) shell, rather than simply run a command.
I think it would be simpler for the final user to just run `shell` or `!` to directly enter into a native shell rather than `!bash` or `shell sh`

Please, if you find some easier way to do this (and, maybe, make it more flexible such as allow to modify the shell, etc) I would love to hear.
Also, I'm constrained to use the keyword "shell" to support this functionality, so create an alias such as "bash" would be nice but does not fits my current requirements :disappointed: .

Thank you !!