### PR TITLE
Fixed alias/macro list commands to include quoted redirectors and terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.11 (TBD, 2020)
+* Bug Fixes
+    * Fixed issue where quoted redirectors and terminators in aliases and macros were not being
+    restored when read from a startup script.
+
 ## 1.3.10 (September 17, 2020)
 * Enhancements
     * Added user-settable option called `always_show_hint`. If True, then tab completion hints will always

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -318,17 +318,29 @@ def natural_sort(list_to_sort: Iterable[str]) -> List[str]:
     return sorted(list_to_sort, key=natural_keys)
 
 
-def unquote_specific_tokens(args: List[str], tokens_to_unquote: List[str]) -> None:
+def quote_specific_tokens(tokens: List[str], tokens_to_quote: List[str]) -> None:
     """
-    Unquote a specific tokens in a list of command-line arguments
-    This is used when certain tokens have to be passed to another command
-    :param args: the command line args
-    :param tokens_to_unquote: the tokens, which if present in args, to unquote
+    Quote specific tokens in a list
+
+    :param tokens: token list being edited
+    :param tokens_to_quote: the tokens, which if present in tokens, to quote
     """
-    for i, arg in enumerate(args):
-        unquoted_arg = strip_quotes(arg)
-        if unquoted_arg in tokens_to_unquote:
-            args[i] = unquoted_arg
+    for i, token in enumerate(tokens):
+        if token in tokens_to_quote:
+            tokens[i] = quote_string(token)
+
+
+def unquote_specific_tokens(tokens: List[str], tokens_to_unquote: List[str]) -> None:
+    """
+    Unquote specific tokens in a list
+
+    :param tokens: token list being edited
+    :param tokens_to_unquote: the tokens, which if present in tokens, to unquote
+    """
+    for i, token in enumerate(tokens):
+        unquoted_token = strip_quotes(token)
+        if unquoted_token in tokens_to_unquote:
+            tokens[i] = unquoted_token
 
 
 def expand_user(token: str) -> str:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -22,6 +22,10 @@ Quote Handling
 
 .. autofunction:: cmd2.utils.strip_quotes
 
+.. autofunction:: cmd2.utils.quote_specific_tokens
+
+.. autofunction:: cmd2.utils.unquote_specific_tokens
+
 
 IO Handling
 -----------

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1639,16 +1639,17 @@ def test_alias_create(base_app):
     out, err = run_cmd(base_app, 'alias list --with_silent fake')
     assert out == normalize('alias create --silent fake set')
 
-def test_alias_create_with_quoted_value(base_app):
-    """Demonstrate that quotes in alias value will be preserved (except for redirectors and terminators)"""
+def test_alias_create_with_quoted_tokens(base_app):
+    """Demonstrate that quotes in alias value will be preserved"""
+    create_command = 'alias create fake help ">" "out file.txt" ";"'
 
     # Create the alias
-    out, err = run_cmd(base_app, 'alias create fake help ">" "out file.txt" ";"')
+    out, err = run_cmd(base_app, create_command)
     assert out == normalize("Alias 'fake' created")
 
-    # Look up the new alias (Only the redirector should be unquoted)
+    # Look up the new alias and verify all quotes are preserved
     out, err = run_cmd(base_app, 'alias list fake')
-    assert out == normalize('alias create fake help > "out file.txt" ;')
+    assert out == normalize(create_command)
 
 @pytest.mark.parametrize('alias_name', invalid_command_name)
 def test_alias_create_invalid_name(base_app, alias_name, capsys):
@@ -1748,15 +1749,17 @@ def test_macro_create(base_app):
     out, err = run_cmd(base_app, 'macro list --with_silent fake')
     assert out == normalize('macro create --silent fake set')
 
-def test_macro_create_with_quoted_value(base_app):
-    """Demonstrate that quotes in macro value will be preserved (except for redirectors and terminators)"""
+def test_macro_create_with_quoted_tokens(base_app):
+    """Demonstrate that quotes in macro value will be preserved"""
+    create_command = 'macro create fake help ">" "out file.txt" ";"'
+
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake help ">" "out file.txt" ";"')
+    out, err = run_cmd(base_app, create_command)
     assert out == normalize("Macro 'fake' created")
 
-    # Look up the new macro (Only the redirector should be unquoted)
+    # Look up the new macro and verify all quotes are preserved
     out, err = run_cmd(base_app, 'macro list fake')
-    assert out == normalize('macro create fake help > "out file.txt" ;')
+    assert out == normalize(create_command)
 
 @pytest.mark.parametrize('macro_name', invalid_command_name)
 def test_macro_create_invalid_name(base_app, macro_name):


### PR DESCRIPTION
Since alias/macro list didn't include the quoted redirectors and terminators, startup scripts did not correctly recreate all aliases and macros.