### PR TITLE
Remove unnecessary runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,13 @@ Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines())))  # noqa: E128
 
-SETUP_REQUIRES = ['setuptools_scm >= 3.0']
+SETUP_REQUIRES = ['setuptools >= 34.4', 'setuptools_scm >= 3.0']
 
 INSTALL_REQUIRES = [
     'attrs >= 16.3.0',
     'colorama >= 0.3.7',
     'importlib_metadata>=1.6.0;python_version<"3.8"',
     'pyperclip >= 1.6',
-    'setuptools >= 34.4',
     'wcwidth >= 0.1.7',
 ]
 


### PR DESCRIPTION
The package does not seem to use setuptools or pkg_resources anywhere,
and the dependency is probably leftover after migration to
importlib.metadata.