### PR TITLE
Fixed error in set --long, which should be set -v

### DIFF
--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -134,9 +134,9 @@ changes a setting, and will receive both the old value and the new value.
 
 .. code-block:: text
 
-   (Cmd) set --long | grep sunny
+   (Cmd) set -v | grep sunny
    sunny: False                # Is it sunny outside?
-   (Cmd) set --long | grep degrees
+   (Cmd) set -v | grep degrees
    degrees_c: 22               # Temperature in Celsius
    (Cmd) sunbathe
    Too dim.

--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -134,9 +134,9 @@ changes a setting, and will receive both the old value and the new value.
 
 .. code-block:: text
 
-   (Cmd) set -v | grep sunny
+   (Cmd) set --verbose | grep sunny
    sunny: False                # Is it sunny outside?
-   (Cmd) set -v | grep degrees
+   (Cmd) set --verbose | grep degrees
    degrees_c: 22               # Temperature in Celsius
    (Cmd) sunbathe
    Too dim.


### PR DESCRIPTION
I think I found a minor bug in the documentation:

```
(Cmd) set --long
Usage: set [-h] [-v] [param] [value]
Error: unrecognized arguments: --long
```

Should be:

```
(Cmd) set -v | grep sunny
sunny: False              # Is it sunny outside?
```
