### PR TITLE
Setting always_show_hint to True is not working when completing Settables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1 (TBD, 2020)
+* Bug Fixes
+    * Fixed bug where setting `always_show_hint=True` did not show a hint when completing `Settables`
+
 ## 1.4.0 (November 11, 2020)
 * Bug Fixes
     * Fixed tab completion crash on Windows

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -415,7 +415,9 @@ class ArgparseCompleter:
 
             # If we have results, then return them
             if completion_results:
-                self._cmd2_app.completion_hint = _build_hint(self._parser, flag_arg_state.action)
+                # Don't overwrite an existing hint
+                if not self._cmd2_app.completion_hint:
+                    self._cmd2_app.completion_hint = _build_hint(self._parser, flag_arg_state.action)
                 return completion_results
 
             # Otherwise, print a hint if the flag isn't finished or text isn't possibly the start of a flag
@@ -437,7 +439,9 @@ class ArgparseCompleter:
 
             # If we have results, then return them
             if completion_results:
-                self._cmd2_app.completion_hint = _build_hint(self._parser, pos_arg_state.action)
+                # Don't overwrite an existing hint
+                if not self._cmd2_app.completion_hint:
+                    self._cmd2_app.completion_hint = _build_hint(self._parser, pos_arg_state.action)
                 return completion_results
 
             # Otherwise, print a hint if text isn't possibly the start of a flag

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -972,6 +972,7 @@ def test_complete_set_value(cmd2_app):
 
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
     assert first_match == "SUCCESS "
+    assert cmd2_app.completion_hint == "Hint:\n  value  a settable param\n"
 
 def test_complete_set_value_invalid_settable(cmd2_app, capsys):
     text = ''


### PR DESCRIPTION
Fixed bug where setting `always_show_hint=True` did not show a hint when completing `Settables`