### PR TITLE
docs/features/modular_commands: fix broken link

### DIFF
--- a/docs/features/modular_commands.rst
+++ b/docs/features/modular_commands.rst
@@ -29,7 +29,7 @@ Features
 
 See API documentation for :attr:`cmd2.command_definition.CommandSet`
 
-See the examples for more details: https://github.com/python-cmd2/cmd2/tree/master/plugins/command_sets/examples
+See [the examples](https://github.com/python-cmd2/cmd2/tree/master/examples/modular_commands) for more details.
 
 
 Defining Commands


### PR DESCRIPTION
I guess the examples structure has changed since the docs.

I suggest changing the broken link: https://github.com/python-cmd2/cmd2/tree/master/plugins/command_sets/examples
to 
https://github.com/python-cmd2/cmd2/tree/master/examples/modular_commands

Maybe also hiding the full link is nice.