### PR TITLE
Fixed width calculation when table column headers had tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     * Fixed bug where setting `always_show_hint=True` did not show a hint when completing `Settables`
     * Fixed bug in editor detection logic on Linux systems that do not have `which`
     * Fixed bug in table creator where column headers with tabs would result in an incorrect width calculation
+    * Fixed `FileNotFoundError` which occurred when running `history --clear` and no history file existed.
 * Enhancements
     * Added `silent_startup_script` option to `cmd2.Cmd.__init__()`. If `True`, then the startup script's
       output will be suppressed. Anything written to stderr will still display.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Bug Fixes
     * Fixed bug where setting `always_show_hint=True` did not show a hint when completing `Settables`
     * Fixed bug in editor detection logic on Linux systems that do not have `which`
+    * Fixed bug in table creator where column headers with tabs would result in an incorrect width calculation
 * Enhancements
     * Added `silent_startup_script` option to `cmd2.Cmd.__init__()`. If `True`, then the startup script's
       output will be suppressed. Anything written to stderr will still display.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3989,7 +3989,10 @@ class Cmd(cmd.Cmd):
             self.history.clear()
 
             if self.persistent_history_file:
-                os.remove(self.persistent_history_file)
+                try:
+                    os.remove(self.persistent_history_file)
+                except FileNotFoundError:
+                    pass
 
             if rl_type != RlType.NONE:
                 readline.clear_history()

--- a/tests/test_table_creator.py
+++ b/tests/test_table_creator.py
@@ -20,18 +20,6 @@ from cmd2.table_creator import (
 
 
 def test_column_creation():
-    # No width specified, blank label
-    c = Column("")
-    assert c.width == 1
-
-    # No width specified, label isn't blank but has no width
-    c = Column(ansi.style('', fg=ansi.fg.green))
-    assert c.width == 1
-
-    # No width specified, label has width
-    c = Column("short\nreally long")
-    assert c.width == ansi.style_aware_wcswidth("really long")
-
     # Width less than 1
     with pytest.raises(ValueError) as excinfo:
         Column("Column 1", width=0)
@@ -45,6 +33,36 @@ def test_column_creation():
     with pytest.raises(ValueError) as excinfo:
         Column("Column 1", max_data_lines=0)
     assert "Max data lines cannot be less than 1" in str(excinfo.value)
+
+    # No width specified, blank label
+    c = Column("")
+    assert c.width is None
+    tc = TableCreator([c])
+    assert tc.cols[0].width == 1
+
+    # No width specified, label isn't blank but has no width
+    c = Column(ansi.style('', fg=ansi.fg.green))
+    assert c.width is None
+    tc = TableCreator([c])
+    assert tc.cols[0].width == 1
+
+    # No width specified, label has width
+    c = Column("a line")
+    assert c.width is None
+    tc = TableCreator([c])
+    assert tc.cols[0].width == ansi.style_aware_wcswidth("a line")
+
+    # No width specified, label has width and multiple lines
+    c = Column("short\nreally long")
+    assert c.width is None
+    tc = TableCreator([c])
+    assert tc.cols[0].width == ansi.style_aware_wcswidth("really long")
+
+    # No width specified, label has tabs
+    c = Column("line\twith\ttabs")
+    assert c.width is None
+    tc = TableCreator([c])
+    assert tc.cols[0].width == ansi.style_aware_wcswidth("line    with    tabs")
 
 
 def test_column_alignment():


### PR DESCRIPTION
Also fixed `FileNotFoundError` if you ran back-to-back `history --clear` commands when using a history file.