### PR TITLE
Added black to Pipfile and black configuration to pyrpoject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Install python prerequisites
         run: pip install -U --user pip setuptools setuptools-scm flake8
       - name: Lint
-        run: python -m flake8 . --count --ignore=E252,W503 --max-complexity=26 --max-line-length=127 --show-source --statistics ;
+        run: python -m flake8 .

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ setuptools = ">=34.4"
 wcwidth = ">=0.1.7"
 
 [dev-packages]
+black = "*"
 cmd2 = {editable = true,path = "."}
 cmd2_ext_test = {editable = true,path = "plugins/ext_test"}
 codecov = "*"
@@ -32,3 +33,6 @@ sphinx-autobuild = "*"
 sphinx-rtd-theme = "*"
 tableformatter="*"
 twine = ">=1.11"
+
+[pipenv]
+allow_prereleases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,26 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.black]
+skip-string-normalization = true
+line-length = 127
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.github
+  | \.idea
+  | \.mypy_cache
+  | \.pytest_cache
+  | \.tox
+  | \.venv
+  | \.vscode
+  | _build
+  | build
+  | cmd2.egg-info
+  | cmd2_history.dat
+  | dist
+  | htmlcov
+)/
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,31 @@ testpaths =
     tests
 
 [flake8]
-exclude = .git,.idea,.pytest_cache,.tox,.nox,.venv,.vscode,build,cmd2.egg-info,dist,htmlcov,__pycache__,*.egg
-max-line-length = 127
+count = True
+ignore = E203,E231,W503  # E231 can be removed once black is fixed.
 max-complexity = 26
+max-line-length = 127
+show-source = True
+statistics = True
+exclude =
+    .git
+    __pycache__
+    .tox
+    .nox
+    .eggs
+    *.eggs,
+    .venv,
+    .idea,
+    .pytest_cache,
+    .vscode,
+    build,
+    dist,
+    htmlcov
 
 [isort]
-line_length=1
-skip=cmd2/__init__.py
+line_length = 1
+skip = cmd2/__init__.py,.git,__pycache,.tox,.nox,.venv,.eggs,.idea,.vscode,build,dist.htmlcov
+profile = black
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/tasks.py
+++ b/tasks.py
@@ -349,8 +349,7 @@ namespace.add_task(pypi_test)
 def flake8(context):
     """Run flake8 linter and tool for style guide enforcement"""
     with context.cd(TASK_ROOT_STR):
-        context.run("flake8 --ignore=E252,W503 --max-complexity=26 --max-line-length=127 --show-source --statistics "
-                    "--exclude=.git,__pycache__,.tox,.nox,.eggs,*.egg,.venv,.idea,.pytest_cache,.vscode,build,dist,htmlcov")
+        context.run("flake8")
 
 
 namespace.add_task(flake8)


### PR DESCRIPTION
Added `black` to Pipfile and black configuration to pyrpoject.toml

Also:
- Updated flake8 and isort config in setup.cfg to be consistent with black
- Simplified how flake8 is executed by invoke task
- Simplified how flake8 is executed by GitHub Actions workflow

This PR encompasses just the configuration changes present in the much larger PR #1052 - the point is to separate the configuration changes from the auto-generated changes made by `black` and `isort`

This partially addresses #930