### PR TITLE
CommandSet Settables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
     * Removed `with_argparser_and_unknown_args` since it was deprecated in 1.3.0.
     * Replaced `cmd2.Cmd.completion_header` with `cmd2.Cmd.formatted_completions`. See Enhancements
       for description of this new class member.
+    * Settables now have new initialization parameters. It is now a required parameter to supply the reference to the
+      object that holds the settable attribute. `cmd2.Cmd.settables` is no longer a public dict attribute - it is now a
+      property that aggregates all Settables across all registered CommandSets.
 * Enhancements
     * Added support for custom tab completion and up-arrow input history to `cmd2.Cmd2.read_input`.
       See [read_input.py](https://github.com/python-cmd2/cmd2/blob/master/examples/read_input.py)
@@ -25,7 +28,12 @@
     * Added `cmd2.exceptions.PassThroughException` to raise unhandled command exceptions instead of printing them.
     * Added support for ANSI styles and newlines in tab completion results using `cmd2.Cmd.formatted_completions`.
       `cmd2` provides this capability automatically if you return argparse completion matches as `CompletionItems`.
-
+    * Settables enhancements:
+        * Settables may be optionally scoped to a CommandSet. Settables added to CommandSets will appear when a
+          CommandSet is registered and disappear when a CommandSet is unregistered. Optionally, scoped Settables
+          may have a prepended prefix.
+        * Settables now allow changes to be applied to any arbitrary object attribute. It no longer needs to match an
+          attribute added to the cmd2 instance itself.
 ## 1.5.0 (January 31, 2021)
 * Bug Fixes
     * Fixed bug where setting `always_show_hint=True` did not show a hint when completing `Settables`

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -230,7 +230,7 @@ def style_aware_write(fileobj: IO[str], msg: str) -> None:
     fileobj.write(msg)
 
 
-def fg_lookup(fg_name: Union[str, fg]) -> Fore:
+def fg_lookup(fg_name: Union[str, fg]) -> str:
     """
     Look up ANSI escape codes based on foreground color name.
 
@@ -239,16 +239,16 @@ def fg_lookup(fg_name: Union[str, fg]) -> Fore:
     :raises: ValueError: if the color cannot be found
     """
     if isinstance(fg_name, fg):
-        return fg_name.value
+        return str(fg_name.value)
 
     try:
         ansi_escape = fg[fg_name.lower()].value
     except KeyError:
         raise ValueError('Foreground color {!r} does not exist; must be one of: {}'.format(fg_name, fg.colors()))
-    return ansi_escape
+    return str(ansi_escape)
 
 
-def bg_lookup(bg_name: Union[str, bg]) -> Back:
+def bg_lookup(bg_name: Union[str, bg]) -> str:
     """
     Look up ANSI escape codes based on background color name.
 
@@ -257,13 +257,13 @@ def bg_lookup(bg_name: Union[str, bg]) -> Back:
     :raises: ValueError: if the color cannot be found
     """
     if isinstance(bg_name, bg):
-        return bg_name.value
+        return str(bg_name.value)
 
     try:
         ansi_escape = bg[bg_name.lower()].value
     except KeyError:
         raise ValueError('Background color {!r} does not exist; must be one of: {}'.format(bg_name, bg.colors()))
-    return ansi_escape
+    return str(ansi_escape)
 
 
 # noinspection PyShadowingNames
@@ -292,13 +292,13 @@ def style(
     :return: the stylized string
     """
     # List of strings that add style
-    additions = []
+    additions: List[str] = []
 
     # List of strings that remove style
-    removals = []
+    removals: List[str] = []
 
     # Convert the text object into a string if it isn't already one
-    text = "{}".format(text)
+    text_formatted = "{}".format(text)
 
     # Process the style settings
     if fg:
@@ -322,7 +322,7 @@ def style(
         removals.append(UNDERLINE_DISABLE)
 
     # Combine the ANSI style sequences with the text
-    return cast(str, "".join(additions) + text + "".join(removals))
+    return "".join(additions) + text_formatted + "".join(removals)
 
 
 # Default styles for printing strings of various types.

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -13,15 +13,16 @@ from typing import (
     Any,
     List,
     Union,
+    cast,
 )
 
-import colorama
+import colorama  # type: ignore [import]
 from colorama import (
     Back,
     Fore,
     Style,
 )
-from wcwidth import (
+from wcwidth import (  # type: ignore [import]
     wcswidth,
 )
 
@@ -86,14 +87,14 @@ class ColorBase(Enum):
         Support building a color string when self is the left operand
         e.g. fg.blue + "hello"
         """
-        return str(self) + other
+        return cast(str, str(self) + other)
 
     def __radd__(self, other: Any) -> str:
         """
         Support building a color string when self is the right operand
         e.g. "hello" + fg.reset
         """
-        return other + str(self)
+        return cast(str, other + str(self))
 
     @classmethod
     def colors(cls) -> List[str]:
@@ -194,7 +195,7 @@ def style_aware_wcswidth(text: str) -> int:
              then this function returns -1. Replace tabs with spaces before calling this.
     """
     # Strip ANSI style sequences since they cause wcswidth to return -1
-    return wcswidth(strip_style(text))
+    return cast(int, wcswidth(strip_style(text)))
 
 
 def widest_line(text: str) -> int:
@@ -217,7 +218,7 @@ def widest_line(text: str) -> int:
     return max(lines_widths)
 
 
-def style_aware_write(fileobj: IO, msg: str) -> None:
+def style_aware_write(fileobj: IO[str], msg: str) -> None:
     """
     Write a string to a fileobject and strip its ANSI style sequences if required by allow_style setting
 
@@ -229,7 +230,7 @@ def style_aware_write(fileobj: IO, msg: str) -> None:
     fileobj.write(msg)
 
 
-def fg_lookup(fg_name: Union[str, fg]) -> str:
+def fg_lookup(fg_name: Union[str, fg]) -> Fore:
     """
     Look up ANSI escape codes based on foreground color name.
 
@@ -247,7 +248,7 @@ def fg_lookup(fg_name: Union[str, fg]) -> str:
     return ansi_escape
 
 
-def bg_lookup(bg_name: Union[str, bg]) -> str:
+def bg_lookup(bg_name: Union[str, bg]) -> Back:
     """
     Look up ANSI escape codes based on background color name.
 
@@ -321,7 +322,7 @@ def style(
         removals.append(UNDERLINE_DISABLE)
 
     # Combine the ANSI style sequences with the text
-    return "".join(additions) + text + "".join(removals)
+    return cast(str, "".join(additions) + text + "".join(removals))
 
 
 # Default styles for printing strings of various types.
@@ -400,4 +401,4 @@ def set_title_str(title: str) -> str:
     :param title: new title for the window
     :return: string to write to sys.stderr in order to set the window title to the desired test
     """
-    return colorama.ansi.set_title(title)
+    return cast(str, colorama.ansi.set_title(title))

--- a/cmd2/clipboard.py
+++ b/cmd2/clipboard.py
@@ -2,7 +2,11 @@
 """
 This module provides basic ability to copy from and paste to the clipboard/pastebuffer.
 """
-import pyperclip
+from typing import (
+    cast,
+)
+
+import pyperclip  # type: ignore [import]
 
 # noinspection PyProtectedMember
 from pyperclip import (
@@ -26,7 +30,7 @@ def get_paste_buffer() -> str:
 
     :return: contents of the clipboard
     """
-    pb_str = pyperclip.paste()
+    pb_str = cast(str, pyperclip.paste())
     return pb_str
 
 

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -148,11 +148,14 @@ class CommandSet(object):
 
         :param settable: Settable object being added
         """
-        if self._cmd and not self._cmd.always_prefix_settables:
-            if settable.name in self._cmd.settables.keys() and settable.name not in self._settables.keys():
-                raise KeyError(f'Duplicate settable: {settable.name}')
-        if settable.settable_obj is None:
-            settable.settable_obj = self
+        if self._cmd:
+            if not self._cmd.always_prefix_settables:
+                if settable.name in self._cmd.settables.keys() and settable.name not in self._settables.keys():
+                    raise KeyError(f'Duplicate settable: {settable.name}')
+            else:
+                prefixed_name = f'{self._settable_prefix}.{settable.name}'
+                if prefixed_name in self._cmd.settables.keys() and settable.name not in self._settables.keys():
+                    raise KeyError(f'Duplicate settable: {settable.name}')
         self._settables[settable.name] = settable
 
     def remove_settable(self, name: str) -> None:

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 """Custom exceptions for cmd2"""
 
+from typing import (
+    Any,
+)
 
 ############################################################################################################
 # The following exceptions are part of the public API
@@ -49,7 +52,7 @@ class CompletionError(Exception):
     - Tab completion hints
     """
 
-    def __init__(self, *args, apply_style: bool = True):
+    def __init__(self, *args: Any, apply_style: bool = True) -> None:
         """
         Initializer for CompletionError
         :param apply_style: If True, then ansi.style_error will be applied to the message text when printed.
@@ -68,7 +71,7 @@ class PassThroughException(Exception):
     This class is used to wrap an exception that should be raised instead of printed.
     """
 
-    def __init__(self, *args, wrapped_ex: BaseException):
+    def __init__(self, *args: Any, wrapped_ex: BaseException) -> None:
         """
         Initializer for PassThroughException
         :param wrapped_ex: the exception that will be raised

--- a/cmd2/plugin.py
+++ b/cmd2/plugin.py
@@ -3,33 +3,37 @@
 """Classes for the cmd2 plugin system"""
 import attr
 
+from .parsing import (
+    Statement,
+)
 
-@attr.s
+
+@attr.s(auto_attribs=True)
 class PostparsingData:
     """Data class containing information passed to postparsing hook methods"""
 
-    stop = attr.ib()
-    statement = attr.ib()
+    stop: bool
+    statement: Statement
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class PrecommandData:
     """Data class containing information passed to precommand hook methods"""
 
-    statement = attr.ib()
+    statement: Statement
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class PostcommandData:
     """Data class containing information passed to postcommand hook methods"""
 
-    stop = attr.ib()
-    statement = attr.ib()
+    stop: bool
+    statement: Statement
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class CommandFinalizationData:
     """Data class containing information passed to command finalization hook methods"""
 
-    stop = attr.ib()
-    statement = attr.ib()
+    stop: bool
+    statement: Statement

--- a/cmd2/py_bridge.py
+++ b/cmd2/py_bridge.py
@@ -10,16 +10,17 @@ from contextlib import (
     redirect_stdout,
 )
 from typing import (
+    Any,
+    NamedTuple,
     Optional,
 )
 
-from .utils import (
+from .utils import (  # namedtuple_with_defaults,
     StdSim,
-    namedtuple_with_defaults,
 )
 
 
-class CommandResult(namedtuple_with_defaults('CommandResult', ['stdout', 'stderr', 'stop', 'data'])):
+class CommandResult(NamedTuple):
     """Encapsulates the results from a cmd2 app command
 
     :stdout: str - output captured from stdout while this command is executing
@@ -55,6 +56,11 @@ class CommandResult(namedtuple_with_defaults('CommandResult', ['stdout', 'stderr
        Named tuples are immutable. The contents are there for access,
        not for modification.
     """
+
+    stdout: str = ''
+    stderr: str = ''
+    stop: bool = False
+    data: Any = None
 
     def __bool__(self) -> bool:
         """Returns True if the command succeeded, otherwise False"""

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -90,8 +90,6 @@ Miscellaneous
 
 .. autofunction:: cmd2.utils.str_to_bool
 
-.. autofunction:: cmd2.utils.namedtuple_with_defaults
-
 .. autofunction:: cmd2.utils.categorize
 
 .. autofunction:: cmd2.utils.remove_duplicates

--- a/examples/cmd_as_argument.py
+++ b/examples/cmd_as_argument.py
@@ -36,7 +36,7 @@ class CmdLineApp(cmd2.Cmd):
         self.self_in_py = True
         self.maxrepeats = 3
         # Make maxrepeats settable at runtime
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
     speak_parser = argparse.ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -49,7 +49,7 @@ class CmdLineApp(cmd2.Cmd):
 
         self.maxrepeats = 3
         # Make maxrepeats settable at runtime
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
         # Should ANSI color output be allowed
         self.allow_style = ansi.STYLE_TERMINAL

--- a/examples/decorator_example.py
+++ b/examples/decorator_example.py
@@ -31,7 +31,7 @@ class CmdLineApp(cmd2.Cmd):
 
         self.maxrepeats = 3
         # Make maxrepeats settable at runtime
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
         # Example of args set from the command-line (but they aren't being used here)
         self._ip = ip_addr

--- a/examples/environment.py
+++ b/examples/environment.py
@@ -13,8 +13,10 @@ class EnvironmentApp(cmd2.Cmd):
         super().__init__()
         self.degrees_c = 22
         self.sunny = False
-        self.add_settable(cmd2.Settable('degrees_c', int, 'Temperature in Celsius', onchange_cb=self._onchange_degrees_c))
-        self.add_settable(cmd2.Settable('sunny', bool, 'Is it sunny outside?'))
+        self.add_settable(
+            cmd2.Settable('degrees_c', int, 'Temperature in Celsius', self, onchange_cb=self._onchange_degrees_c)
+        )
+        self.add_settable(cmd2.Settable('sunny', bool, 'Is it sunny outside?', self))
 
     def do_sunbathe(self, arg):
         """Attempt to sunbathe."""

--- a/examples/example.py
+++ b/examples/example.py
@@ -32,7 +32,7 @@ class CmdLineApp(cmd2.Cmd):
 
         # Make maxrepeats settable at runtime
         self.maxrepeats = 3
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
     speak_parser = argparse.ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')

--- a/examples/first_app.py
+++ b/examples/first_app.py
@@ -27,7 +27,7 @@ class FirstApp(cmd2.Cmd):
 
         # Make maxrepeats settable at runtime
         self.maxrepeats = 3
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
     speak_parser = argparse.ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')

--- a/examples/initialization.py
+++ b/examples/initialization.py
@@ -51,7 +51,7 @@ class BasicApp(cmd2.Cmd):
 
         # Make echo_fg settable at runtime
         self.add_settable(
-            cmd2.Settable('foreground_color', str, 'Foreground color to use with echo command', choices=fg.colors())
+            cmd2.Settable('foreground_color', str, 'Foreground color to use with echo command', self, choices=fg.colors())
         )
 
     @cmd2.with_category(CUSTOM_CATEGORY)

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -28,7 +28,7 @@ class Pirate(cmd2.Cmd):
         self.songcolor = 'blue'
 
         # Make songcolor settable at runtime
-        self.add_settable(cmd2.Settable('songcolor', str, 'Color to ``sing``', choices=cmd2.ansi.fg.colors()))
+        self.add_settable(cmd2.Settable('songcolor', str, 'Color to ``sing``', self, choices=cmd2.ansi.fg.colors()))
 
         # prompts and defaults
         self.gold = 0

--- a/examples/plumbum_colors.py
+++ b/examples/plumbum_colors.py
@@ -62,11 +62,11 @@ class BgColors(ansi.ColorBase):
     purple = bg.Purple
 
 
-def get_fg(name: str):
+def get_fg(name: str) -> str:
     return str(FgColors[name])
 
 
-def get_bg(name: str):
+def get_bg(name: str) -> str:
     return str(BgColors[name])
 
 
@@ -83,7 +83,7 @@ class CmdLineApp(cmd2.Cmd):
 
         self.maxrepeats = 3
         # Make maxrepeats settable at runtime
-        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
+        self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
         # Should ANSI color output be allowed
         self.allow_style = ansi.STYLE_TERMINAL

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [tool:pytest]
 testpaths =
     tests
+addopts =
+    --cov=cmd2
+    --cov-append
+    --cov-report=term
+    --cov-report=html
 
 [flake8]
 count = True
@@ -37,3 +42,16 @@ use_parentheses = true
 ignore-path=docs/_build,.git,.idea,.pytest_cache,.tox,.nox,.venv,.vscode,build,cmd2,examples,tests,cmd2.egg-info,dist,htmlcov,__pycache__,*.egg,plugins
 max-line-length=120
 verbose=0
+
+[mypy]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+warn_redundant_casts = True
+warn_unused_ignores = False
+warn_return_any = True
+warn_unreachable = True
+strict = True
+show_error_context = True
+show_column_numbers = True
+show_error_codes = True

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ INSTALL_REQUIRES = [
     'colorama >= 0.3.7',
     'importlib_metadata>=1.6.0;python_version<"3.8"',
     'pyperclip >= 1.6',
+    'typing_extensions; python_version<"3.8"',
     'wcwidth >= 0.1.7',
 ]
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -214,7 +214,7 @@ def test_set_allow_style(base_app, new_val, is_valid, expected):
 class OnChangeHookApp(cmd2.Cmd):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.add_settable(utils.Settable('quiet', bool, "my description", onchange_cb=self._onchange_quiet))
+        self.add_settable(utils.Settable('quiet', bool, "my description", self, onchange_cb=self._onchange_quiet))
 
     def _onchange_quiet(self, name, old, new) -> None:
         """Runs when quiet is changed via set command"""

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -176,7 +176,7 @@ Parameter 'qqq' not supported (type 'set' for list of parameters).
 
 
 def test_set_no_settables(base_app):
-    base_app.settables = {}
+    base_app._settables.clear()
     out, err = run_cmd(base_app, 'set quiet True')
     expected = normalize("There are no settable parameters")
     assert err == expected
@@ -229,11 +229,10 @@ def onchange_app():
 
 def test_set_onchange_hook(onchange_app):
     out, err = run_cmd(onchange_app, 'set quiet True')
-    expected = normalize(
-        """
+    expected = normalize("""
+You changed quiet
 quiet - was: False
 now: True
-You changed quiet
 """
     )
     assert out == expected

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -229,7 +229,8 @@ def onchange_app():
 
 def test_set_onchange_hook(onchange_app):
     out, err = run_cmd(onchange_app, 'set quiet True')
-    expected = normalize("""
+    expected = normalize(
+        """
 You changed quiet
 quiet - was: False
 now: True

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -67,7 +67,13 @@ class CompletionsExample(cmd2.Cmd):
         cmd2.Cmd.__init__(self, multiline_commands=['test_multiline'])
         self.foo = 'bar'
         self.add_settable(
-            utils.Settable('foo', str, description="a settable param", completer=CompletionsExample.complete_foo_val)
+            utils.Settable(
+                'foo',
+                str,
+                description="a settable param",
+                settable_object=self,
+                completer=CompletionsExample.complete_foo_val,
+            )
         )
 
     def do_test_basic(self, args):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -42,7 +42,7 @@ class CmdLineApp(cmd2.Cmd):
         super().__init__(*args, multiline_commands=['orate'], **kwargs)
 
         # Make maxrepeats settable at runtime
-        self.add_settable(Settable('maxrepeats', int, 'Max number of `--repeat`s allowed'))
+        self.add_settable(Settable('maxrepeats', int, 'Max number of `--repeat`s allowed', self))
 
         self.intro = 'This is an intro banner ...'
 

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -20,10 +20,10 @@ from cmd2.exceptions import (
 )
 
 from .conftest import (
+    WithCommandSets,
     complete_tester,
     normalize,
     run_cmd,
-    WithCommandSets,
 )
 
 


### PR DESCRIPTION
- Each CommandSet has its own settables.
- Renamed attribute settables to _settables and added a new settables property that combines cmd2's _settables with the ones from all CommandSets
- New cmd2.Cmd attribute always_prefix_settables will prepend all settables from CommandSets with a settable_prefix provided by each CommandSet
- Settable now allows you to route to any attribute on any object - it doesn't have to be an attribute of Cmd or CommandSet. It also allows the name presented to the user to be different from the name of the underlying attribute.

Also make some progress addressing mypy validation issues in a few files. 

Closes #965 