### PR TITLE
Pass SystemExit code to self.exit_code

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2362,7 +2362,8 @@ class Cmd(cmd.Cmd):
         except KeyboardInterrupt as ex:
             if raise_keyboard_interrupt and not stop:
                 raise ex
-        except SystemExit:
+        except SystemExit as exit_code:
+            self.exit_code = exit_code
             stop = True
         except PassThroughException as ex:
             raise ex.wrapped_ex
@@ -2374,7 +2375,8 @@ class Cmd(cmd.Cmd):
             except KeyboardInterrupt as ex:
                 if raise_keyboard_interrupt and not stop:
                     raise ex
-            except SystemExit:
+            except SystemExit as exit_code:
+                self.exit_code = exit_code
                 stop = True
             except PassThroughException as ex:
                 raise ex.wrapped_ex


### PR DESCRIPTION
The exit code will be missed, if it's not passed to `self.exit_code`