### PR TITLE
Mypy explicit export

### DIFF
--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -15,6 +15,8 @@ except importlib_metadata.PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass
 
+from typing import List
+
 from .ansi import style, fg, bg
 from .argparse_custom import Cmd2ArgumentParser, Cmd2AttributeWrapper, CompletionItem, set_default_argument_parser
 
@@ -38,3 +40,42 @@ from . import plugin
 from .parsing import Statement
 from .py_bridge import CommandResult
 from .utils import categorize, CompletionMode, CustomCompletionSettings, Settable
+
+
+__all__: List[str] = [
+    'COMMAND_NAME',
+    'DEFAULT_ARGUMENT_PARSER',
+    'DEFAULT_SHORTCUTS',
+    # ANSI Style exports
+    'bg',
+    'fg',
+    'style',
+    # Argparse Exports
+    'Cmd2ArgumentParser',
+    'Cmd2AttributeWrapper',
+    'CompletionItem',
+    'set_default_argument_parser',
+    # Cmd2
+    'Cmd',
+    'CommandResult',
+    'CommandSet',
+    'Statement',
+    # Decorators
+    'with_argument_list',
+    'with_argparser',
+    'with_category',
+    'with_default_category',
+    'as_subcommand_to',
+    # Exceptions
+    'Cmd2ArgparseError',
+    'CommandSetRegistrationError',
+    'CompletionError',
+    'SkipPostcommandHooks',
+    # modules
+    'plugin',
+    # Utilities
+    'categorize',
+    'CompletionMode',
+    'CustomCompletionSettings',
+    'Settable',
+]

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -3,10 +3,12 @@
 # flake8: noqa F401
 """This simply imports certain things for backwards compatibility."""
 
-try:
-    # For python 3.8 and later
+import sys
+
+# For python 3.8 and late
+if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata
-except ImportError:
+else:
     # For everyone else
     import importlib_metadata
 try:

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -872,7 +872,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         usage: Optional[str] = None,
         description: Optional[str] = None,
         epilog: Optional[str] = None,
-        parents: Sequence[argparse.ArgumentParser] = [],
+        parents: Sequence[argparse.ArgumentParser] = (),
         formatter_class: Type[argparse.HelpFormatter] = Cmd2HelpFormatter,
         prefix_chars: str = '-',
         fromfile_prefix_chars: Optional[str] = None,
@@ -989,7 +989,7 @@ class Cmd2AttributeWrapper:
     arguments from a parser and which were added by cmd2.
     """
 
-    def __init__(self, attribute: Any):
+    def __init__(self, attribute: Any) -> None:
         self.__attribute = attribute
 
     def get(self) -> Any:

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -215,7 +215,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 from . import (
@@ -279,7 +278,7 @@ class CompletionItem(str):
     """
 
     def __new__(cls, value: object, *args: Any, **kwargs: Any) -> 'CompletionItem':
-        return cast(CompletionItem, super(CompletionItem, cls).__new__(cls, value))  # type: ignore [call-arg]
+        return super(CompletionItem, cls).__new__(cls, value)
 
     # noinspection PyUnusedLocal
     def __init__(self, value: object, desc: str = '', *args: Any) -> None:
@@ -887,7 +886,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
             description=description,
             epilog=epilog,
             parents=parents if parents else [],
-            formatter_class=formatter_class,
+            formatter_class=formatter_class,  # type: ignore[arg-type]
             prefix_chars=prefix_chars,
             fromfile_prefix_chars=fromfile_prefix_chars,
             argument_default=argument_default,
@@ -930,7 +929,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         formatter = self._get_formatter()
 
         # usage
-        formatter.add_usage(self.usage, self._actions, self._mutually_exclusive_groups)
+        formatter.add_usage(self.usage, self._actions, self._mutually_exclusive_groups)  # type: ignore[arg-type]
 
         # description
         formatter.add_text(self.description)

--- a/cmd2/command_definition.py
+++ b/cmd2/command_definition.py
@@ -3,6 +3,7 @@
 Supports the definition of commands in separate classes to be composed into cmd2.Cmd
 """
 from typing import (
+    Callable,
     Dict,
     Mapping,
     Optional,
@@ -33,7 +34,12 @@ except ImportError:  # pragma: no cover
     pass
 
 
-def with_default_category(category: str, *, heritable: bool = True):
+#: Callable signature for a basic command  function
+#: Further refinements are needed to define the input parameters
+CommandFunc = Callable[..., Optional[bool]]
+
+
+def with_default_category(category: str, *, heritable: bool = True) -> Callable[[Type['CommandSet']], Type['CommandSet']]:
     """
     Decorator that applies a category to all ``do_*`` command methods in a class that do not already
     have a category specified.
@@ -52,7 +58,7 @@ def with_default_category(category: str, *, heritable: bool = True):
     :return: decorator function
     """
 
-    def decorate_class(cls: Type[CommandSet]):
+    def decorate_class(cls: Type[CommandSet]) -> Type[CommandSet]:
         if heritable:
             setattr(cls, CLASS_ATTR_DEFAULT_HELP_CATEGORY, category)
 
@@ -93,19 +99,18 @@ class CommandSet(object):
     ``do_``, ``help_``, and ``complete_`` functions differ only in that self is the CommandSet instead of the cmd2 app
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cmd: Optional[cmd2.Cmd] = None
         self._settables: Dict[str, Settable] = {}
         self._settable_prefix = self.__class__.__name__
 
-    def on_register(self, cmd) -> None:
+    def on_register(self, cmd: 'cmd2.Cmd') -> None:
         """
         Called by cmd2.Cmd as the first step to registering a CommandSet. The commands defined in this class have
         not be added to the CLI object at this point. Subclasses can override this to perform any initialization
         requiring access to the Cmd object (e.g. configure commands and their parsers based on CLI state data).
 
         :param cmd: The cmd2 main application
-        :type cmd: cmd2.Cmd
         """
         if self._cmd is None:
             self._cmd = cmd

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -108,7 +108,7 @@ def _arg_swap(args: Union[Tuple[Any], List[Any]], search_arg: Any, *replace_arg:
 
 def with_argument_list(
     func_arg: Optional[Callable[[List[str]], Optional[bool]]] = None, *, preserve_quotes: bool = False
-) -> Union[Callable[[List[str]], Optional[bool]],]:
+) -> Union[Callable[[List[str]], Optional[bool]]]:
     """
     A decorator to alter the arguments passed to a ``do_*`` method. Default
     passes a string of whatever the user typed. With this decorator, the

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -35,7 +35,7 @@ def shlex_split(str_to_split: str) -> List[str]:
     return shlex.split(str_to_split, comments=False, posix=False)
 
 
-@attr.s(frozen=True)
+@attr.s(auto_attribs=True, frozen=True)
 class MacroArg:
     """
     Information used to replace or unescape arguments in a macro value when the macro is resolved
@@ -44,15 +44,15 @@ class MacroArg:
     """
 
     # The starting index of this argument in the macro value
-    start_index = attr.ib(validator=attr.validators.instance_of(int))
+    start_index: int = attr.ib(validator=attr.validators.instance_of(int))
 
     # The number string that appears between the braces
     # This is a string instead of an int because we support unicode digits and must be able
     # to reproduce this string later
-    number_str = attr.ib(validator=attr.validators.instance_of(str))
+    number_str: str = attr.ib(validator=attr.validators.instance_of(str))
 
     # Tells if this argument is escaped and therefore needs to be unescaped
-    is_escaped = attr.ib(validator=attr.validators.instance_of(bool))
+    is_escaped: bool = attr.ib(validator=attr.validators.instance_of(bool))
 
     # Pattern used to find normal argument
     # Digits surrounded by exactly 1 brace on a side and 1 or more braces on the opposite side
@@ -68,24 +68,24 @@ class MacroArg:
     digit_pattern = re.compile(r'\d+')
 
 
-@attr.s(frozen=True)
+@attr.s(auto_attribs=True, frozen=True)
 class Macro:
     """Defines a cmd2 macro"""
 
     # Name of the macro
-    name = attr.ib(validator=attr.validators.instance_of(str))
+    name: str = attr.ib(validator=attr.validators.instance_of(str))
 
     # The string the macro resolves to
-    value = attr.ib(validator=attr.validators.instance_of(str))
+    value: str = attr.ib(validator=attr.validators.instance_of(str))
 
     # The minimum number of args the user has to pass to this macro
-    minimum_arg_count = attr.ib(validator=attr.validators.instance_of(int))
+    minimum_arg_count: int = attr.ib(validator=attr.validators.instance_of(int))
 
     # Used to fill in argument placeholders in the macro
-    arg_list = attr.ib(default=attr.Factory(list), validator=attr.validators.instance_of(list))
+    arg_list: List[MacroArg] = attr.ib(default=attr.Factory(list), validator=attr.validators.instance_of(list))
 
 
-@attr.s(frozen=True)
+@attr.s(auto_attribs=True, frozen=True)
 class Statement(str):
     """String subclass with additional attributes to store the results of parsing.
 
@@ -117,34 +117,34 @@ class Statement(str):
     """
 
     # the arguments, but not the command, nor the output redirection clauses.
-    args = attr.ib(default='', validator=attr.validators.instance_of(str))
+    args: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # string containing exactly what we input by the user
-    raw = attr.ib(default='', validator=attr.validators.instance_of(str))
+    raw: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # the command, i.e. the first whitespace delimited word
-    command = attr.ib(default='', validator=attr.validators.instance_of(str))
+    command: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # list of arguments to the command, not including any output redirection or terminators; quoted args remain quoted
-    arg_list = attr.ib(default=attr.Factory(list), validator=attr.validators.instance_of(list))
+    arg_list: List[str] = attr.ib(default=attr.Factory(list), validator=attr.validators.instance_of(list))
 
     # if the command is a multiline command, the name of the command, otherwise empty
-    multiline_command = attr.ib(default='', validator=attr.validators.instance_of(str))
+    multiline_command: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # the character which terminated the multiline command, if there was one
-    terminator = attr.ib(default='', validator=attr.validators.instance_of(str))
+    terminator: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # characters appearing after the terminator but before output redirection, if any
-    suffix = attr.ib(default='', validator=attr.validators.instance_of(str))
+    suffix: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # if output was piped to a shell command, the shell command as a string
-    pipe_to = attr.ib(default='', validator=attr.validators.instance_of(str))
+    pipe_to: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # if output was redirected, the redirection token, i.e. '>>'
-    output = attr.ib(default='', validator=attr.validators.instance_of(str))
+    output: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     # if output was redirected, the destination file token (quotes preserved)
-    output_to = attr.ib(default='', validator=attr.validators.instance_of(str))
+    output_to: str = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     def __new__(cls, value: object, *pos_args, **kw_args):
         """Create a new instance of Statement.

--- a/cmd2/plugin.py
+++ b/cmd2/plugin.py
@@ -1,6 +1,10 @@
 #
 # coding=utf-8
 """Classes for the cmd2 plugin system"""
+from typing import (
+    Optional,
+)
+
 import attr
 
 from .parsing import (
@@ -36,4 +40,4 @@ class CommandFinalizationData:
     """Data class containing information passed to command finalization hook methods"""
 
     stop: bool
-    statement: Statement
+    statement: Optional[Statement]

--- a/cmd2/py_bridge.py
+++ b/cmd2/py_bridge.py
@@ -33,7 +33,6 @@ class CommandResult(NamedTuple):
 
     :stdout: str - output captured from stdout while this command is executing
     :stderr: str - output captured from stderr while this command is executing
-             None if no error captured.
     :stop: bool - return value of onecmd_plus_hooks after it runs the given
            command line.
     :data: possible data populated by the command.
@@ -66,7 +65,7 @@ class CommandResult(NamedTuple):
     """
 
     stdout: str = ''
-    stderr: Optional[str] = None
+    stderr: str = ''
     stop: bool = False
     data: Any = None
 
@@ -132,10 +131,10 @@ class PyBridge:
                 self._cmd2_app.stdout = cast(IO[str], copy_cmd_stdout.inner_stream)
                 self.stop = stop or self.stop
 
-        # Save the output. If stderr is empty, set it to None.
+        # Save the result
         result = CommandResult(
             stdout=copy_cmd_stdout.getvalue(),
-            stderr=copy_stderr.getvalue() if copy_stderr.getvalue() else None,
+            stderr=copy_stderr.getvalue(),
             stop=stop,
             data=self._cmd2_app.last_result,
         )

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -10,13 +10,13 @@ from enum import (
 # Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
 try:
     # noinspection PyPackageRequirements
-    import gnureadline as readline
+    import gnureadline as readline  # type: ignore[import]
 except ImportError:
     # Try to import readline, but allow failure for convenience in Windows unit testing
     # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
     try:
         # noinspection PyUnresolvedReferences
-        import readline
+        import readline  # type: ignore[no-redef]
     except ImportError:  # pragma: no cover
         pass
 
@@ -182,7 +182,7 @@ def rl_get_point() -> int:  # pragma: no cover
         return ctypes.c_int.in_dll(readline_lib, "rl_point").value
 
     elif rl_type == RlType.PYREADLINE:
-        return readline.rl.mode.l_buffer.point
+        return int(readline.rl.mode.l_buffer.point)
 
     else:
         return 0

--- a/cmd2/transcript.py
+++ b/cmd2/transcript.py
@@ -12,13 +12,22 @@ class is used in cmd2.py::run_transcript_tests()
 import re
 import unittest
 from typing import (
+    TYPE_CHECKING,
+    List,
+    Optional,
     Tuple,
+    cast,
 )
 
 from . import (
     ansi,
     utils,
 )
+
+if TYPE_CHECKING:  # pragma: no cover
+    from cmd2 import (
+        Cmd,
+    )
 
 
 class Cmd2TestCase(unittest.TestCase):
@@ -31,7 +40,7 @@ class Cmd2TestCase(unittest.TestCase):
     See example.py
     """
 
-    cmdapp = None
+    cmdapp: Optional['Cmd'] = None
 
     def setUp(self):
         if self.cmdapp:
@@ -54,7 +63,8 @@ class Cmd2TestCase(unittest.TestCase):
 
     def _fetchTranscripts(self):
         self.transcripts = {}
-        for fname in self.cmdapp.testfiles:
+        testfiles = cast(List[str], getattr(self.cmdapp, 'testfiles', []))
+        for fname in testfiles:
             tfile = open(fname)
             self.transcripts[fname] = iter(tfile.readlines())
             tfile.close()

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -120,7 +120,7 @@ class Settable:
         choices: Optional[Iterable[Any]] = None,
         choices_provider: Optional[Union[ChoicesProviderFunc, ChoicesProviderFuncWithTokens]] = None,
         completer: Optional[Union[CompleterFunc, CompleterFuncWithTokens]] = None,
-    ):
+    ) -> None:
         """
         Settable Initializer
 
@@ -445,7 +445,7 @@ class StdSim:
 
     def __init__(
         self,
-        inner_stream: Union[TextIO, 'StdSim'],
+        inner_stream: Union[TextIO, 'StdSim', IO[str]],
         *,
         echo: bool = False,
         encoding: str = 'utf-8',
@@ -574,7 +574,7 @@ class ProcReader:
     If neither are pipes, then the process will run normally and no output will be captured.
     """
 
-    def __init__(self, proc: subprocess.Popen, stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
+    def __init__(self, proc: subprocess.Popen, stdout: Union[StdSim, IO[str]], stderr: Union[StdSim, IO[str]]) -> None:
         """
         ProcReader initializer
         :param proc: the Popen process being read from
@@ -1127,7 +1127,7 @@ class CompletionMode(Enum):
 class CustomCompletionSettings:
     """Used by cmd2.Cmd.complete() to tab complete strings other than command arguments"""
 
-    def __init__(self, parser: argparse.ArgumentParser, *, preserve_quotes: bool = False):
+    def __init__(self, parser: argparse.ArgumentParser, *, preserve_quotes: bool = False) -> None:
         """
         Initializer
 

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 """Shared utility functions"""
-
 import argparse
 import collections
 import functools
@@ -17,7 +16,6 @@ from enum import (
     Enum,
 )
 from typing import (
-    IO,
     TYPE_CHECKING,
     Any,
     Callable,
@@ -44,6 +42,11 @@ from .argparse_custom import (
 
 if TYPE_CHECKING:  # pragma: no cover
     import cmd2  # noqa: F401
+
+    PopenTextIO = subprocess.Popen[bytes]
+
+else:
+    PopenTextIO = subprocess.Popen
 
 
 _T = TypeVar('_T')
@@ -445,7 +448,7 @@ class StdSim:
 
     def __init__(
         self,
-        inner_stream: Union[TextIO, 'StdSim', IO[str]],
+        inner_stream: Union[TextIO, 'StdSim'],
         *,
         echo: bool = False,
         encoding: str = 'utf-8',
@@ -574,7 +577,7 @@ class ProcReader:
     If neither are pipes, then the process will run normally and no output will be captured.
     """
 
-    def __init__(self, proc: subprocess.Popen, stdout: Union[StdSim, IO[str]], stderr: Union[StdSim, IO[str]]) -> None:
+    def __init__(self, proc: PopenTextIO, stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
         """
         ProcReader initializer
         :param proc: the Popen process being read from
@@ -650,7 +653,7 @@ class ProcReader:
         # Run until process completes
         while self._proc.poll() is None:
             # noinspection PyUnresolvedReferences
-            available = read_stream.peek()
+            available = read_stream.peek()  # type: ignore[attr-defined]
             if available:
                 read_stream.read(len(available))
                 self._write_bytes(write_stream, available)
@@ -699,8 +702,8 @@ class RedirectionSavedState:
 
     def __init__(
         self,
-        self_stdout: Union[StdSim, IO[str]],
-        sys_stdout: Union[StdSim, IO[str]],
+        self_stdout: Union[StdSim, TextIO],
+        sys_stdout: Union[StdSim, TextIO],
         pipe_proc_reader: Optional[ProcReader],
         saved_redirecting: bool,
     ) -> None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,4 +183,5 @@ nitpick_ignore = [
     ('py:class', 'argparse._SubParsersAction'),
     ('py:class', '_T'),
     ('py:class', 'StdSim'),
+    ('py:class', 'frame'),
 ]

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -257,28 +257,24 @@ def test_commandset_decorators(command_sets_app):
     assert 'extra1' in result.data['unknown']
     assert 'extra2' in result.data['unknown']
     assert result.data['arg1'] == 'juice'
-    assert result.stderr is None
+    assert not result.stderr
 
     result = command_sets_app.app_cmd('durian juice extra1 extra2')
     assert len(result.data['args']) == 3
     assert 'juice' in result.data['args']
     assert 'extra1' in result.data['args']
     assert 'extra2' in result.data['args']
-    assert result.stderr is None
+    assert not result.stderr
 
     result = command_sets_app.app_cmd('durian')
     assert len(result.data['args']) == 0
-    assert result.stderr is None
+    assert not result.stderr
 
     result = command_sets_app.app_cmd('elderberry')
-    assert result.stderr is not None
-    assert len(result.stderr) > 0
     assert 'arguments are required' in result.stderr
     assert result.data is None
 
     result = command_sets_app.app_cmd('elderberry a b')
-    assert result.stderr is not None
-    assert len(result.stderr) > 0
     assert 'unrecognized arguments' in result.stderr
     assert result.data is None
 


### PR DESCRIPTION
Running mypy with strict checking gets a lot of errors when using cmd2 related to implicit exports.
General mypy related validation fixes added.

Took a stab at creating a type declaration for matching argparse command functions. Will likely need further refinement.