### PR TITLE
Error cleanup

### DIFF
--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -296,7 +296,7 @@ class StatementParser:
     def is_valid_command(self, word: str, *, is_subcommand: bool = False) -> Tuple[bool, str]:
         """Determine whether a word is a valid name for a command.
 
-        Commands can not include redirection characters, whitespace,
+        Commands cannot include redirection characters, whitespace,
         or termination characters. They also cannot start with a
         shortcut.
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -5,7 +5,7 @@ These pages document the public API for ``cmd2``. If a method, class, function,
 attribute, or constant is not documented here, consider it private and subject
 to change. There are many classes, methods, functions, and constants in the
 source code which do not begin with an underscore but are not documented here.
-When looking at the source code for this library, you can not safely assume
+When looking at the source code for this library, you cannot safely assume
 that because something doesn't start with an underscore, it is a public API.
 
 If a release of this library changes any of the items documented here, the

--- a/docs/features/argument_processing.rst
+++ b/docs/features/argument_processing.rst
@@ -170,7 +170,7 @@ To add additional text to the end of the generated help message, use the ``epilo
    from cmd2 import with_argparser
 
    argparser = argparse.ArgumentParser(description='create an html tag',
-                                       epilog='This command can not generate tags with no content, like <br/>.')
+                                       epilog='This command cannot generate tags with no content, like <br/>.')
    argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argparser(argparser)
@@ -193,7 +193,7 @@ Which yields:
    optional arguments:
      -h, --help  show this help message and exit
 
-   This command can not generate tags with no content, like <br/>
+   This command cannot generate tags with no content, like <br/>
 
 .. warning::
 

--- a/docs/features/hooks.rst
+++ b/docs/features/hooks.rst
@@ -207,7 +207,7 @@ with the :data:`~cmd2.plugin.PostparsingData.stop` attribute set to ``True``:
 Precommand Hooks
 ----------------
 
-Precommand hooks can modify the user input, but can not request the application
+Precommand hooks can modify the user input, but cannot request the application
 terminate. If your hook needs to be able to exit the application, you should
 implement it as a postparsing hook.
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -616,7 +616,7 @@ def test_history_verbose_with_other_options(base_app):
     for opt in options_to_test:
         out, err = run_cmd(base_app, 'history -v ' + opt)
         assert len(out) == 4
-        assert out[0] == '-v can not be used with any other options'
+        assert out[0] == '-v cannot be used with any other options'
         assert out[1].startswith('Usage:')
 
 
@@ -635,7 +635,7 @@ def test_history_script_with_invalid_options(base_app):
     for opt in options_to_test:
         out, err = run_cmd(base_app, 'history -s ' + opt)
         assert len(out) == 4
-        assert out[0] == '-s and -x can not be used with -c, -r, -e, -o, or -t'
+        assert out[0] == '-s and -x cannot be used with -c, -r, -e, -o, or -t'
         assert out[1].startswith('Usage:')
 
 
@@ -653,7 +653,7 @@ def test_history_expanded_with_invalid_options(base_app):
     for opt in options_to_test:
         out, err = run_cmd(base_app, 'history -x ' + opt)
         assert len(out) == 4
-        assert out[0] == '-s and -x can not be used with -c, -r, -e, -o, or -t'
+        assert out[0] == '-s and -x cannot be used with -c, -r, -e, -o, or -t'
         assert out[1].startswith('Usage:')
 
 
@@ -761,7 +761,7 @@ def test_history_file_permission_error(mocker, capsys):
     cmd2.Cmd(persistent_history_file='/tmp/doesntmatter')
     out, err = capsys.readouterr()
     assert not out
-    assert 'Can not read' in err
+    assert 'Cannot read' in err
 
 
 def test_history_file_conversion_no_truncate_on_init(hist_file, capsys):
@@ -843,4 +843,4 @@ def test_persist_history_permission_error(hist_file, mocker, capsys):
     app._persist_history()
     out, err = capsys.readouterr()
     assert not out
-    assert 'Can not write' in err
+    assert 'Cannot write' in err

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -157,7 +157,7 @@ def test_custom_construct_commandsets():
     cmds_cats, cmds_doc, cmds_undoc, help_topics = app._build_command_info()
     assert 'Command Set B' in cmds_cats
 
-    # Verifies that the same CommandSet can not be loaded twice
+    # Verifies that the same CommandSet cannot be loaded twice
     command_set_2 = CommandSetB('bar')
     with pytest.raises(CommandSetRegistrationError):
         assert app.register_command_set(command_set_2)


### PR DESCRIPTION
- Replaced some pexcept() calls with perror().
- Converted some strings to f-strings.
- Fixed some grammar in error messages and docs.
- Increase code coverage.