### PR TITLE
Added handling for OSError when loading GNU readline shared library

### DIFF
--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -129,10 +129,10 @@ elif 'gnureadline' in sys.modules or 'readline' in sys.modules:
             import ctypes
 
             readline_lib = ctypes.CDLL(readline.__file__)
-        except AttributeError:  # pragma: no cover
+        except (AttributeError, OSError):  # pragma: no cover
             _rl_warn_reason = (
                 "this application is running in a non-standard Python environment in\n"
-                "which readline is not loaded dynamically from a shared library file."
+                "which GNU readline is not loaded dynamically from a shared library file."
             )
         else:
             rl_type = RlType.GNU


### PR DESCRIPTION
Fixes #1096 

PyPy has a pure Python implementation of readline and therefore does not have a shared library to load.