### PR TITLE
Updated Ctrl-C behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
     * Added `include_py` keyword parameter to `cmd2.Cmd.__init__()`. If `False`, then the `py` command will
       not be available. Defaults to `False`. `run_pyscript` is not affected by this parameter.
     * Made the amount of space between columns in a SimpleTable configurable
+    * On POSIX systems, shell commands and processes being piped to are now run in the user's preferred shell
+      instead of /bin/sh. The preferred shell is obtained by reading the SHELL environment variable. If that
+      doesn't exist or is empty, then /bin/sh is used.
 
 ## 1.5.0 (January 31, 2021)
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
       and just opens an interactive Python shell.
     * Changed default behavior of `runcmds_plus_hooks()` to not stop when Ctrl-C is pressed and instead
       run the next command in its list.
+    * Removed `cmd2.Cmd.quit_on_sigint` flag, which when `True`, quit the application when Ctrl-C was pressed at the prompt.
 * Enhancements
     * Added support for custom tab completion and up-arrow input history to `cmd2.Cmd2.read_input`.
       See [read_input.py](https://github.com/python-cmd2/cmd2/blob/master/examples/read_input.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
       of this parameter.
     * Removed ability to run Python commands from the command line with `py`. Now `py` takes no arguments
       and just opens an interactive Python shell.
+    * Changed default behavior of `runcmds_plus_hooks()` to not stop when Ctrl-C is pressed and instead
+      run the next command in its list.
 * Enhancements
     * Added support for custom tab completion and up-arrow input history to `cmd2.Cmd2.read_input`.
       See [read_input.py](https://github.com/python-cmd2/cmd2/blob/master/examples/read_input.py)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2405,7 +2405,7 @@ class Cmd(cmd.Cmd):
         cmds: Union[List[HistoryItem], List[str]],
         *,
         add_to_history: bool = True,
-        stop_on_keyboard_interrupt: bool = True,
+        stop_on_keyboard_interrupt: bool = False,
     ) -> bool:
         """
         Used when commands are being run in an automated fashion like text scripts or history replays.
@@ -2413,8 +2413,9 @@ class Cmd(cmd.Cmd):
 
         :param cmds: commands to run
         :param add_to_history: If True, then add these commands to history. Defaults to True.
-        :param stop_on_keyboard_interrupt: stop command loop if Ctrl-C is pressed instead of just
-                                           moving to the next command. Defaults to True.
+        :param stop_on_keyboard_interrupt: if True, then stop running contents of cmds if Ctrl-C is pressed instead of moving
+                                           to the next command in the list. This is used when the commands are part of a
+                                           group, like a text script, which should stop upon Ctrl-C. Defaults to False.
         :return: True if running of commands should stop
         """
         for line in cmds:
@@ -4684,7 +4685,7 @@ class Cmd(cmd.Cmd):
             if args.transcript:
                 self._generate_transcript(script_commands, os.path.expanduser(args.transcript))
             else:
-                return self.runcmds_plus_hooks(script_commands)
+                return self.runcmds_plus_hooks(script_commands, stop_on_keyboard_interrupt=True)
 
         finally:
             with self.sigint_protection:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -293,7 +293,6 @@ class Cmd(cmd.Cmd):
 
         # Attributes which should NOT be dynamically settable via the set command at runtime
         self.default_to_shell = False  # Attempt to run unrecognized commands as shell commands
-        self.quit_on_sigint = False  # Ctrl-C at the prompt will quit the program instead of just resetting prompt
         self.allow_redirection = allow_redirection  # Security setting to prevent redirection of stdout
 
         # Attributes which ARE dynamically settable via the set command at runtime
@@ -2490,13 +2489,10 @@ class Cmd(cmd.Cmd):
                     nextline = '\n'
                     self.poutput(nextline)
                 line = f'{self._multiline_in_progress}{nextline}'
-            except KeyboardInterrupt as ex:
-                if self.quit_on_sigint:
-                    raise ex
-                else:
-                    self.poutput('^C')
-                    statement = self.statement_parser.parse('')
-                    break
+            except KeyboardInterrupt:
+                self.poutput('^C')
+                statement = self.statement_parser.parse('')
+                break
             finally:
                 self._at_continuation_prompt = False
 
@@ -3067,12 +3063,9 @@ class Cmd(cmd.Cmd):
                 # Get commands from user
                 try:
                     line = self._read_command_line(self.prompt)
-                except KeyboardInterrupt as ex:
-                    if self.quit_on_sigint:
-                        raise ex
-                    else:
-                        self.poutput('^C')
-                        line = ''
+                except KeyboardInterrupt:
+                    self.poutput('^C')
+                    line = ''
 
                 # Run the command along with all associated pre and post hooks
                 stop = self.onecmd_plus_hooks(line)

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -601,8 +601,8 @@ class ProcReader:
         import signal
 
         if sys.platform.startswith('win'):
-            # cmd2 started the Windows process in a new process group. Therefore
-            # a CTRL_C_EVENT can't be sent to it. Send a CTRL_BREAK_EVENT instead.
+            # cmd2 started the Windows process in a new process group. Therefore we must send
+            # a CTRL_BREAK_EVENT since CTRL_C_EVENT signals cannot be generated for process groups.
             self._proc.send_signal(signal.CTRL_BREAK_EVENT)
         else:
             # Since cmd2 uses shell=True in its Popen calls, we need to send the SIGINT to

--- a/docs/features/initialization.rst
+++ b/docs/features/initialization.rst
@@ -146,8 +146,6 @@ override:
   everything available with **self_in_py**)
 - **quiet**: if ``True`` then completely suppress nonessential output (Default:
   ``False``)
-- **quit_on_sigint**: if ``True`` Ctrl-C at the prompt will quit the program
-  instead of just resetting prompt
 - **settable**: dictionary that controls which of these instance attributes
   are settable at runtime using the *set* command
 - **timing**: if ``True`` display execution time for each command (Default:

--- a/docs/features/misc.rst
+++ b/docs/features/misc.rst
@@ -99,21 +99,3 @@ method be called.
   (Cmd) my dog has fleas
   sh: my: not found
   *** Unknown syntax: my dog has fleas
-
-
-Quit on SIGINT
---------------
-
-On many shells, SIGINT (most often triggered by the user pressing Ctrl+C)
-while at the prompt only cancels the current line, not the entire command
-loop. By default, a ``cmd2`` application matches this behavior. However, if
-``quit_on_sigint`` is set to ``True``, the command loop will quit instead.
-
-::
-
-  (Cmd) typing a comma^C
-  (Cmd)
-
-.. warning::
-    The default SIGINT behavior will only function properly if **cmdloop** is running
-    in the main thread.

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -422,19 +422,19 @@ def test_runcmds_plus_hooks_ctrl_c(base_app, capsys):
 
     setattr(base_app, 'do_keyboard_interrupt', types.MethodType(do_keyboard_interrupt, base_app))
 
-    # Default behavior is to stop command loop on Ctrl-C
+    # Default behavior is to not stop runcmds_plus_hooks() on Ctrl-C
     base_app.history.clear()
     base_app.runcmds_plus_hooks(['help', 'keyboard_interrupt', 'shortcuts'])
     out, err = capsys.readouterr()
-    assert err.startswith("Interrupting this command")
-    assert len(base_app.history) == 2
-
-    # Ctrl-C should not stop command loop in this case
-    base_app.history.clear()
-    base_app.runcmds_plus_hooks(['help', 'keyboard_interrupt', 'shortcuts'], stop_on_keyboard_interrupt=False)
-    out, err = capsys.readouterr()
     assert not err
     assert len(base_app.history) == 3
+
+    # Ctrl-C should stop runcmds_plus_hooks() in this case
+    base_app.history.clear()
+    base_app.runcmds_plus_hooks(['help', 'keyboard_interrupt', 'shortcuts'], stop_on_keyboard_interrupt=True)
+    out, err = capsys.readouterr()
+    assert err.startswith("Interrupting this command")
+    assert len(base_app.history) == 2
 
 
 def test_relative_run_script(base_app, request):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -7,6 +7,7 @@ import argparse
 import builtins
 import io
 import os
+import signal
 import sys
 import tempfile
 from code import (
@@ -900,6 +901,22 @@ def test_stty_sane(base_app, monkeypatch):
 
         base_app.onecmd_plus_hooks('help')
         m.assert_called_once_with(['stty', 'sane'])
+
+
+def test_sigint_handler(base_app):
+    # No KeyboardInterrupt should be raised when using sigint_protection
+    with base_app.sigint_protection:
+        base_app.sigint_handler(signal.SIGINT, 1)
+
+    # Without sigint_protection, a KeyboardInterrupt is raised
+    with pytest.raises(KeyboardInterrupt):
+        base_app.sigint_handler(signal.SIGINT, 1)
+
+
+def test_raise_keyboard_interrupt(base_app):
+    with pytest.raises(KeyboardInterrupt) as excinfo:
+        base_app._raise_keyboard_interrupt()
+    assert 'Got a keyboard interrupt' in str(excinfo.value)
 
 
 class HookFailureApp(cmd2.Cmd):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -962,36 +962,13 @@ def say_app():
     return app
 
 
-def test_interrupt_quit(say_app):
-    say_app.quit_on_sigint = True
-
+def test_ctrl_c_at_prompt(say_app):
     # Mock out the input call so we don't actually wait for a user's response on stdin
     m = mock.MagicMock(name='input')
     m.side_effect = ['say hello', KeyboardInterrupt(), 'say goodbye', 'eof']
     builtins.input = m
 
-    try:
-        say_app.cmdloop()
-    except KeyboardInterrupt:
-        pass
-
-    # And verify the expected output to stdout
-    out = say_app.stdout.getvalue()
-    assert out == 'hello\n'
-
-
-def test_interrupt_noquit(say_app):
-    say_app.quit_on_sigint = False
-
-    # Mock out the input call so we don't actually wait for a user's response on stdin
-    m = mock.MagicMock(name='input')
-    m.side_effect = ['say hello', KeyboardInterrupt(), 'say goodbye', 'eof']
-    builtins.input = m
-
-    try:
-        say_app.cmdloop()
-    except KeyboardInterrupt:
-        pass
+    say_app.cmdloop()
 
     # And verify the expected output to stdout
     out = say_app.stdout.getvalue()


### PR DESCRIPTION
Changed default behavior of runcmds_plus_hooks() to not stop when Ctrl-C is pressed and instead run the next command in its list.

This means `run_script` will still stop upon Ctrl-C, but running commands from history and startup commands will act like the main command loop in that Ctrl-C will just move to the next command in the list.

Stopping a shell command with Ctrl-C now raises a KeyboardInterrupt to support stopping a text script which ran the shell command.

Removed `cmd2.Cmd.quit_on_sigint`.