### PR TITLE
do_eof() now just calls the quit function

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3684,15 +3684,20 @@ class Cmd(cmd.Cmd):
     eof_parser = DEFAULT_ARGUMENT_PARSER(description="Called when Ctrl-D is pressed", epilog=INTERNAL_COMMAND_EPILOG)
 
     @with_argparser(eof_parser)
-    def do_eof(self, _: argparse.Namespace) -> bool:
-        """Called when Ctrl-D is pressed"""
-        # Return True to stop the command loop
-        return True
+    def do_eof(self, _: argparse.Namespace) -> Optional[bool]:
+        """
+        Called when Ctrl-D is pressed and calls quit with no arguments.
+        This can be overridden if quit should be called differently.
+        """
+        self.poutput()
+
+        # noinspection PyTypeChecker
+        return self.do_quit('')
 
     quit_parser = DEFAULT_ARGUMENT_PARSER(description="Exit this application")
 
     @with_argparser(quit_parser)
-    def do_quit(self, _: argparse.Namespace) -> bool:
+    def do_quit(self, _: argparse.Namespace) -> Optional[bool]:
         """Exit this application"""
         # Return True to stop the command loop
         return True

--- a/docs/features/redirection.rst
+++ b/docs/features/redirection.rst
@@ -64,6 +64,7 @@ Disabling Redirection
        from cmd2 import Cmd
        class App(Cmd):
            def __init__(self):
+               super().__init__()
                self.allow_redirection = False
 
    cmd2's parser will still treat the ``>``, ``>>``, and `|` symbols as output

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -972,7 +972,7 @@ def test_ctrl_c_at_prompt(say_app):
 
     # And verify the expected output to stdout
     out = say_app.stdout.getvalue()
-    assert out == 'hello\n^C\ngoodbye\n'
+    assert out == 'hello\n^C\ngoodbye\n\n'
 
 
 class ShellApp(cmd2.Cmd):


### PR DESCRIPTION
This is for convenience in case programs override quit.