### PR TITLE
Make _run_editor() public

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -4384,7 +4384,7 @@ class Cmd(cmd.Cmd):
                     else:
                         fobj.write(f'{command.raw}\n')
             try:
-                self._run_editor(fname)
+                self.run_editor(fname)
                 # noinspection PyTypeChecker
                 self.do_run_script(utils.quote_string(fname))
             finally:
@@ -4627,9 +4627,9 @@ class Cmd(cmd.Cmd):
     @with_argparser(edit_parser)
     def do_edit(self, args: argparse.Namespace) -> None:
         """Run a text editor and optionally open a file with it"""
-        self._run_editor(args.file_path)
+        self.run_editor(args.file_path)
 
-    def _run_editor(self, file_path: Optional[str]) -> None:
+    def run_editor(self, file_path: Optional[str]) -> None:
         """
         Run a text editor and optionally open a file with it
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -544,9 +544,9 @@ def test_history_edit(monkeypatch):
     # going to call it due to the mock
     app.editor = 'fooedit'
 
-    # Mock out the _run_editor call so we don't actually open an editor
-    edit_mock = mock.MagicMock(name='_run_editor')
-    monkeypatch.setattr("cmd2.Cmd._run_editor", edit_mock)
+    # Mock out the run_editor call so we don't actually open an editor
+    edit_mock = mock.MagicMock(name='run_editor')
+    monkeypatch.setattr("cmd2.Cmd.run_editor", edit_mock)
 
     # Mock out the run_script call since the mocked edit won't produce a file
     run_script_mock = mock.MagicMock(name='do_run_script')


### PR DESCRIPTION
It is useful for commands to be able to do the following

    with NamedTemporaryFile() as fileh:
        # convert data to text
        self._run_editor(fileh.name)
        # convert text back to data