### PR TITLE
Try to fix tests failures on master

### DIFF
--- a/plugins/template/setup.py
+++ b/plugins/template/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     license='MIT',
     packages=['cmd2_myplugin'],
     python_requires='>=3.6',
-    install_requires=['cmd2 >= 0.9.4, <=2'],
+    install_requires=['cmd2 >= 0.9.4, <3'],
     setup_requires=['setuptools_scm'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
There are test failures on master related to plugin requirements for `cmd2` version conflicting with `cmd2` version.