### PR TITLE
Exclude plugins directory from tarball when cmd2 release is published

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include examples *
 recursive-include tests *
 recursive-include docs *
 recursive-exclude docs/_build *
+recursive-exclude plugins *
 exclude .github .gitignore azure-pipelines.yml tasks.py


### PR DESCRIPTION
Exclude plugins directory from tarball when cmd2 release is published to PyPI