### PR TITLE
Add the tests_isolated directory back to the PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,4 @@ recursive-include tests *
 recursive-include docs *
 recursive-exclude docs/_build *
 recursive-exclude plugins *
-recursive-exclude tests_isolated *
 exclude .github .gitignore azure-pipelines.yml tasks.py


### PR DESCRIPTION
Add the tests_isolated directory back to the PyPI package for testing the CommandSet stuff.

Adding back because anselor@ things its a good idea and I don't have a strong opinion.