### PR TITLE
Fixed handling of argparse's default options group name which was changed in Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.2]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-beta.2"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,4 +27,4 @@ jobs:
       - name: Run tests and post coverage results
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python -m nox --non-interactive --session tests-${{ matrix.python-version }}  # Run nox for a single version of Python
+        run: python -m nox --non-interactive --session tests  # Run nox for a single version of Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-beta.2"]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,4 +27,27 @@ jobs:
       - name: Run tests and post coverage results
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python -m nox --non-interactive --session tests  # Run nox for a single version of Python
+        run: python -m nox --non-interactive --session tests-${{ matrix.python-version }}  # Run nox for a single version of Python
+  ci-beta:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10.0-beta.2"]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2  # https://github.com/actions/checkout
+        with:
+          # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
+          # Set fetch-depth: 0 to fetch all history for all branches and tags.
+          fetch-depth: 0 # Needed for setuptools_scm to work correctly
+      - name: Set up Python
+        uses: actions/setup-python@v2  # https://github.com/actions/setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install python prerequisites
+        run: pip install -U --user pip setuptools setuptools-scm nox
+      - name: Run tests and post coverage results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m nox --non-interactive --session tests-3.10  # Run nox for a single version of Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1 (TBD, 2021)
+* Bug Fixes
+   * Fixed handling of argparse's default options group name which was changed in Python 3.10
+
 ## 2.1.0 (June 14, 2021)
 * Enhancements
    * Converted persistent history files from pickle to compressed JSON

--- a/README.md
+++ b/README.md
@@ -130,10 +130,9 @@ Instructions for implementing each feature follow.
       - Optionally, `cmd2.with_argparser(.., with_unknown_args=True)` can be used to pass all unknown arguments as a list
 
     ```Python
-    import argparse
-    from cmd2 import with_argparser
+    from cmd2 import Cmd2ArgumentParser, with_argparser
 
-    argparser = argparse.ArgumentParser()
+    argparser = Cmd2ArgumentParser()
     argparser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     argparser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     argparser.add_argument('words', nargs='+', help='words to say')
@@ -232,7 +231,6 @@ Example cmd2 application (**examples/example.py**):
 """
 A sample application for cmd2.
 """
-import argparse
 import random
 import sys
 import cmd2
@@ -256,7 +254,7 @@ class CmdLineApp(cmd2.Cmd):
         # Make maxrepeats settable at runtime
         self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command'))
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -280,7 +278,7 @@ class CmdLineApp(cmd2.Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    mumble_parser = argparse.ArgumentParser()
+    mumble_parser = cmd2.Cmd2ArgumentParser()
     mumble_parser.add_argument('-r', '--repeat', type=int, help='how many times to repeat')
     mumble_parser.add_argument('words', nargs='+', help='words to say')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,11 @@ jobs:
       Python39:
         python.version: '3.9'
         NOXSESSION: 'tests-3.9'
+#      Python310:
+#        python.version: '3.10.0b2'
+#        NOXSESSION: 'tests-3.10'
     # Increase the maxParallel value to simultaneously run the job for all versions in the matrix (max 10 for free open-source)
-    maxParallel: 4
+    maxParallel: 10
 
   steps:
     # Set the UsePythonVersion task to reference the matrix variable for its Python version

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -975,7 +975,12 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
         # positionals, optionals and user-defined groups
         for action_group in self._action_groups:
-            if action_group.title == 'optional arguments':
+            if sys.version_info >= (3, 10):
+                default_options_group = action_group.title == 'options'
+            else:
+                default_options_group = action_group.title == 'optional arguments'
+
+            if default_options_group:
                 # check if the arguments are required, group accordingly
                 req_args = []
                 opt_args = []
@@ -992,7 +997,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
                 formatter.end_section()
 
                 # now display truly optional arguments
-                formatter.start_section(action_group.title)
+                formatter.start_section('optional arguments')
                 formatter.add_text(action_group.description)
                 formatter.add_arguments(opt_args)
                 formatter.end_section()

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -405,7 +405,7 @@ class Cmd(cmd.Cmd):
 
         # Check for command line args
         if allow_cli_args:
-            parser = argparse.ArgumentParser()
+            parser = DEFAULT_ARGUMENT_PARSER()
             parser.add_argument('-t', '--test', action="store_true", help='Test against transcript(s) in FILE (wildcards OK)')
             callopts, callargs = parser.parse_known_args()
 

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -288,7 +288,7 @@ def with_argparser(
 
     :Example:
 
-    >>> parser = argparse.ArgumentParser()
+    >>> parser = cmd2.Cmd2ArgumentParser()
     >>> parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     >>> parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     >>> parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -302,7 +302,7 @@ def with_argparser(
 
     :Example with unknown args:
 
-    >>> parser = argparse.ArgumentParser()
+    >>> parser = cmd2.Cmd2ArgumentParser()
     >>> parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     >>> parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     >>> parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -131,8 +131,9 @@ class Settable:
                          validation using str_to_bool(). The val_type function should raise an exception if it fails.
                          This exception will be caught and printed by Cmd.do_set().
         :param description: string describing this setting
-        :param settable_object: Object to configure with the set command
-        :param settable_attrib_name: Attribute name to be modified. Defaults to `name` if not specified.
+        :param settable_object: object to which the instance attribute belongs (e.g. self)
+        :param settable_attrib_name: name which displays to the user in the output of the set command.
+                                     Defaults to `name` if not specified.
         :param onchange_cb: optional function or method to call when the value of this settable is altered
                             by the set command. (e.g. onchange_cb=self.debug_changed)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'cmd2'
-copyright = '2010-2020, cmd2 contributors'
+copyright = '2010-2021, cmd2 contributors'
 author = 'cmd2 contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/examples/first_app.rst
+++ b/docs/examples/first_app.rst
@@ -96,7 +96,7 @@ can shout and talk piglatin. We will also use some built in methods for
 this code to ``first_app.py``, so that the ``speak_parser`` attribute and the
 ``do_speak()`` method are part of the ``CmdLineApp()`` class::
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/docs/features/argument_processing.rst
+++ b/docs/features/argument_processing.rst
@@ -55,10 +55,9 @@ method, which will contain the results of ``ArgumentParser.parse_args()``.
 
 Here's what it looks like::
 
-      import argparse
-      from cmd2 import with_argparser
+      from cmd2 import Cmd2ArgumentParser, with_argparser
 
-      argparser = argparse.ArgumentParser()
+      argparser = Cmd2ArgumentParser()
       argparser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
       argparser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
       argparser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -106,10 +105,9 @@ docstring for the ``do_*`` method is used to set the description for the
 
 With this code::
 
-   import argparse
-   from cmd2 import with_argparser
+   from cmd2 import Cmd2ArgumentParser, with_argparser
 
-   argparser = argparse.ArgumentParser()
+   argparser = Cmd2ArgumentParser()
    argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argparser(argparser)
@@ -137,10 +135,9 @@ the ``help tag`` command displays:
 If you would prefer you can set the ``description`` while instantiating the
 ``argparse.ArgumentParser`` and leave the docstring on your method empty::
 
-   import argparse
-   from cmd2 import with_argparser
+   from cmd2 import Cmd2ArgumentParser, with_argparser
 
-   argparser = argparse.ArgumentParser(description='create an html tag')
+   argparser = Cmd2ArgumentParser(description='create an html tag')
    argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argparser(argparser)
@@ -166,11 +163,10 @@ Now when the user enters ``help tag`` they see:
 
 To add additional text to the end of the generated help message, use the ``epilog`` variable::
 
-   import argparse
-   from cmd2 import with_argparser
+   from cmd2 import Cmd2ArgumentParser, with_argparser
 
-   argparser = argparse.ArgumentParser(description='create an html tag',
-                                       epilog='This command cannot generate tags with no content, like <br/>.')
+   argparser = Cmd2ArgumentParser(description='create an html tag',
+                                  epilog='This command cannot generate tags with no content, like <br/>.')
    argparser.add_argument('tag', help='tag')
    argparser.add_argument('content', nargs='+', help='content to surround with tag')
    @with_argparser(argparser)
@@ -265,10 +261,9 @@ strings, then decorate the command method with the
 
 Here's what it looks like::
 
-    import argparse
-    from cmd2 import with_argparser
+    from cmd2 import Cmd2ArgumentParser, with_argparser
 
-    dir_parser = argparse.ArgumentParser()
+    dir_parser = Cmd2ArgumentParser()
     dir_parser.add_argument('-l', '--long', action='store_true', help="display in long format with one item per line")
 
     @with_argparser(dir_parser, with_unknown_args=True)

--- a/examples/arg_decorators.py
+++ b/examples/arg_decorators.py
@@ -42,7 +42,7 @@ class ArgparsingApp(cmd2.Cmd):
         self.poutput('{} {}'.format(size, args.unit))
 
     # do_pow parser
-    pow_parser = argparse.ArgumentParser()
+    pow_parser = cmd2.Cmd2ArgumentParser()
     pow_parser.add_argument('base', type=int)
     pow_parser.add_argument('exponent', type=int, choices=range(-5, 6))
 

--- a/examples/arg_print.py
+++ b/examples/arg_print.py
@@ -9,7 +9,6 @@ experiment with and understand how command and argument parsing work.
 
 It also serves as an example of how to create shortcuts.
 """
-import argparse
 
 import cmd2
 
@@ -40,7 +39,7 @@ class ArgumentAndOptionPrinter(cmd2.Cmd):
         """Print the argument list this basic command is called with (with quotes preserved)."""
         self.poutput('rprint was called with the following list of arguments: {!r}'.format(arglist))
 
-    oprint_parser = argparse.ArgumentParser()
+    oprint_parser = cmd2.Cmd2ArgumentParser()
     oprint_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     oprint_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     oprint_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -51,7 +50,7 @@ class ArgumentAndOptionPrinter(cmd2.Cmd):
         """Print the options and argument list this options command was called with."""
         self.poutput('oprint was called with the following\n\toptions: {!r}'.format(args))
 
-    pprint_parser = argparse.ArgumentParser()
+    pprint_parser = cmd2.Cmd2ArgumentParser()
     pprint_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     pprint_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     pprint_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/examples/cmd_as_argument.py
+++ b/examples/cmd_as_argument.py
@@ -38,7 +38,7 @@ class CmdLineApp(cmd2.Cmd):
         # Make maxrepeats settable at runtime
         self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -62,7 +62,7 @@ class CmdLineApp(cmd2.Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    mumble_parser = argparse.ArgumentParser()
+    mumble_parser = cmd2.Cmd2ArgumentParser()
     mumble_parser.add_argument('-r', '--repeat', type=int, help='how many times to repeat')
     mumble_parser.add_argument('words', nargs='+', help='words to say')
 
@@ -86,7 +86,7 @@ class CmdLineApp(cmd2.Cmd):
 def main(argv=None):
     """Run when invoked from the operating system shell"""
 
-    parser = argparse.ArgumentParser(description='Commands as arguments')
+    parser = cmd2.Cmd2ArgumentParser(description='Commands as arguments')
     command_help = 'optional command to run, if no command given, enter an interactive shell'
     parser.add_argument('command', nargs='?', help=command_help)
     arg_help = 'optional arguments for command'

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -23,7 +23,6 @@ Always
     poutput(), pfeedback(), and ppaged() never strip ANSI style sequences,
     regardless of the output destination
 """
-import argparse
 from typing import (
     Any,
 )
@@ -54,7 +53,7 @@ class CmdLineApp(cmd2.Cmd):
         # Should ANSI color output be allowed
         self.allow_style = ansi.STYLE_TERMINAL
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/examples/decorator_example.py
+++ b/examples/decorator_example.py
@@ -37,7 +37,7 @@ class CmdLineApp(cmd2.Cmd):
         # Setting this true makes it run a shell command if a cmd2/cmd command doesn't exist
         # self.default_to_shell = True
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -60,7 +60,7 @@ class CmdLineApp(cmd2.Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    tag_parser = argparse.ArgumentParser()
+    tag_parser = cmd2.Cmd2ArgumentParser()
     tag_parser.add_argument('tag', help='tag')
     tag_parser.add_argument('content', nargs='+', help='content to surround with tag')
 
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     import sys
 
     # You can do your custom Argparse parsing here to meet your application's needs
-    parser = argparse.ArgumentParser(description='Process the arguments however you like.')
+    parser = cmd2.Cmd2ArgumentParser(description='Process the arguments however you like.')
 
     # Add a few arguments which aren't really used, but just to get the gist
     parser.add_argument('-p', '--port', type=int, help='TCP port')

--- a/examples/example.py
+++ b/examples/example.py
@@ -10,7 +10,6 @@ Running `python example.py -t transcript_regex.txt` will run all the commands in
 the transcript against example.py, verifying that the output produced matches
 the transcript.
 """
-import argparse
 import random
 
 import cmd2
@@ -34,7 +33,7 @@ class CmdLineApp(cmd2.Cmd):
         self.maxrepeats = 3
         self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -58,7 +57,7 @@ class CmdLineApp(cmd2.Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    mumble_parser = argparse.ArgumentParser()
+    mumble_parser = cmd2.Cmd2ArgumentParser()
     mumble_parser.add_argument('-r', '--repeat', type=int, help='how many times to repeat')
     mumble_parser.add_argument('words', nargs='+', help='words to say')
 

--- a/examples/first_app.py
+++ b/examples/first_app.py
@@ -12,7 +12,6 @@ A simple application using cmd2 which demonstrates 8 key features:
     * Multiline Commands
     * History
 """
-import argparse
 
 import cmd2
 
@@ -29,7 +28,7 @@ class FirstApp(cmd2.Cmd):
         self.maxrepeats = 3
         self.add_settable(cmd2.Settable('maxrepeats', int, 'max repetitions for speak command', self))
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -6,7 +6,6 @@ presented as part of her PyCon 2010 talk.
 
 It demonstrates many features of cmd2.
 """
-import argparse
 
 import cmd2
 import cmd2.ansi
@@ -75,7 +74,7 @@ class Pirate(cmd2.Cmd):
         """Sing a colorful song."""
         self.poutput(cmd2.ansi.style(arg, fg=self.songcolor))
 
-    yo_parser = argparse.ArgumentParser()
+    yo_parser = cmd2.Cmd2ArgumentParser()
     yo_parser.add_argument('--ho', type=int, default=2, help="How often to chant 'ho'")
     yo_parser.add_argument('-c', '--commas', action='store_true', help='Intersperse commas')
     yo_parser.add_argument('beverage', help='beverage to drink with the chant')

--- a/examples/plumbum_colors.py
+++ b/examples/plumbum_colors.py
@@ -25,7 +25,6 @@ Always
 
 WARNING: This example requires the plumbum package, which isn't normally required by cmd2.
 """
-import argparse
 
 from plumbum.colors import (
     bg,
@@ -88,7 +87,7 @@ class CmdLineApp(cmd2.Cmd):
         # Should ANSI color output be allowed
         self.allow_style = ansi.STYLE_TERMINAL
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     speak_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     speak_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')

--- a/examples/python_scripting.py
+++ b/examples/python_scripting.py
@@ -20,7 +20,6 @@ scripts inside a cmd2 application via the run_pyscript command and the
 This application and the "examples/scripts/conditional.py" script serve as an
 example for one way in which this can be done.
 """
-import argparse
 import os
 
 import cmd2
@@ -95,7 +94,7 @@ class CmdLineApp(cmd2.Cmd):
         # Tab complete only directories
         return self.path_complete(text, line, begidx, endidx, path_filter=os.path.isdir)
 
-    dir_parser = argparse.ArgumentParser()
+    dir_parser = cmd2.Cmd2ArgumentParser()
     dir_parser.add_argument('-l', '--long', action='store_true', help="display in long format with one item per line")
 
     @cmd2.with_argparser(dir_parser, with_unknown_args=True)

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -6,14 +6,13 @@
 This example shows an easy way for a single command to have many subcommands, each of which takes different arguments
 and provides separate contextual help.
 """
-import argparse
 
 import cmd2
 
 sport_item_strs = ['Bat', 'Basket', 'Basketball', 'Football', 'Space Ball']
 
 # create the top-level parser for the base command
-base_parser = argparse.ArgumentParser()
+base_parser = cmd2.Cmd2ArgumentParser()
 base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
 # create the parser for the "foo" subcommand
@@ -39,7 +38,7 @@ sport_arg = parser_sport.add_argument('sport', help='Enter name of a sport', cho
 
 # create the top-level parser for the alternate command
 # The alternate command doesn't provide its own help flag
-base2_parser = argparse.ArgumentParser(add_help=False)
+base2_parser = cmd2.Cmd2ArgumentParser(add_help=False)
 base2_subparsers = base2_parser.add_subparsers(title='subcommands', help='subcommand help')
 
 # create the parser for the "foo" subcommand

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def docs(session):
     )
 
 
-@nox.session(python=['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.2'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9', '3.10'])
 @nox.parametrize('plugin', [None, 'ext_test', 'template', 'coverage'])
 def tests(session, plugin):
     if plugin is None:

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -39,7 +39,7 @@ class ArgparseApp(cmd2.Cmd):
         ns.custom_stuff = "custom"
         return ns
 
-    say_parser = argparse.ArgumentParser()
+    say_parser = cmd2.Cmd2ArgumentParser()
     say_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     say_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     say_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -65,7 +65,7 @@ class ArgparseApp(cmd2.Cmd):
         if keyword_arg is not None:
             print(keyword_arg)
 
-    tag_parser = argparse.ArgumentParser(description='create a html tag')
+    tag_parser = cmd2.Cmd2ArgumentParser(description='create a html tag')
     tag_parser.add_argument('tag', help='tag')
     tag_parser.add_argument('content', nargs='+', help='content to surround with tag')
 
@@ -74,7 +74,7 @@ class ArgparseApp(cmd2.Cmd):
         self.stdout.write('<{0}>{1}</{0}>'.format(args.tag, ' '.join(args.content)))
         self.stdout.write('\n')
 
-    @cmd2.with_argparser(argparse.ArgumentParser(), ns_provider=namespace_provider)
+    @cmd2.with_argparser(cmd2.Cmd2ArgumentParser(), ns_provider=namespace_provider)
     def do_test_argparse_ns(self, args):
         self.stdout.write('{}'.format(args.custom_stuff))
 
@@ -92,7 +92,7 @@ class ArgparseApp(cmd2.Cmd):
     def do_preservelist(self, arglist):
         self.stdout.write('{}'.format(arglist))
 
-    known_parser = argparse.ArgumentParser()
+    known_parser = cmd2.Cmd2ArgumentParser()
     known_parser.add_argument('-p', '--piglatin', action='store_true', help='atinLay')
     known_parser.add_argument('-s', '--shout', action='store_true', help='N00B EMULATION MODE')
     known_parser.add_argument('-r', '--repeat', type=int, help='output [n] times')
@@ -117,11 +117,11 @@ class ArgparseApp(cmd2.Cmd):
         if keyword_arg is not None:
             print(keyword_arg)
 
-    @cmd2.with_argparser(argparse.ArgumentParser(), preserve_quotes=True, with_unknown_args=True)
+    @cmd2.with_argparser(cmd2.Cmd2ArgumentParser(), preserve_quotes=True, with_unknown_args=True)
     def do_test_argparse_with_list_quotes(self, args, extra):
         self.stdout.write('{}'.format(' '.join(extra)))
 
-    @cmd2.with_argparser(argparse.ArgumentParser(), ns_provider=namespace_provider, with_unknown_args=True)
+    @cmd2.with_argparser(cmd2.Cmd2ArgumentParser(), ns_provider=namespace_provider, with_unknown_args=True)
     def do_test_argparse_with_list_ns(self, args, extra):
         self.stdout.write('{}'.format(args.custom_stuff))
 
@@ -208,14 +208,14 @@ def test_argparse_quoted_arguments_multiple(argparse_app):
 
 def test_argparse_help_docstring(argparse_app):
     out, err = run_cmd(argparse_app, 'help say')
-    assert out[0].startswith('usage: say')
+    assert out[0].startswith('Usage: say')
     assert out[1] == ''
     assert out[2] == 'Repeat what you tell me to.'
 
 
 def test_argparse_help_description(argparse_app):
     out, err = run_cmd(argparse_app, 'help tag')
-    assert out[0].startswith('usage: tag')
+    assert out[0].startswith('Usage: tag')
     assert out[1] == ''
     assert out[2] == 'create a html tag'
 
@@ -263,7 +263,7 @@ class SubcommandApp(cmd2.Cmd):
         self.poutput('((%s))' % args.z)
 
     # create the top-level parser for the base command
-    base_parser = argparse.ArgumentParser()
+    base_parser = cmd2.Cmd2ArgumentParser()
     base_subparsers = base_parser.add_subparsers(dest='subcommand', metavar='SUBCOMMAND')
     base_subparsers.required = True
 
@@ -338,13 +338,13 @@ def test_subcommand_bar(subcommand_app):
 
 def test_subcommand_invalid(subcommand_app):
     out, err = run_cmd(subcommand_app, 'base baz')
-    assert err[0].startswith('usage: base')
-    assert err[1].startswith("base: error: argument SUBCOMMAND: invalid choice: 'baz'")
+    assert err[0].startswith('Usage: base')
+    assert err[1].startswith("Error: argument SUBCOMMAND: invalid choice: 'baz'")
 
 
 def test_subcommand_base_help(subcommand_app):
     out, err = run_cmd(subcommand_app, 'help base')
-    assert out[0].startswith('usage: base')
+    assert out[0].startswith('Usage: base')
     assert out[1] == ''
     assert out[2] == 'Base command help'
 
@@ -352,46 +352,46 @@ def test_subcommand_base_help(subcommand_app):
 def test_subcommand_help(subcommand_app):
     # foo has no aliases
     out, err = run_cmd(subcommand_app, 'help base foo')
-    assert out[0].startswith('usage: base foo')
+    assert out[0].startswith('Usage: base foo')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     # bar has aliases (usage should never show alias name)
     out, err = run_cmd(subcommand_app, 'help base bar')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base bar_1')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base bar_2')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     # helpless has aliases and no help text (usage should never show alias name)
     out, err = run_cmd(subcommand_app, 'help base helpless')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base helpless_1')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base helpless_2')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
 
 def test_subcommand_invalid_help(subcommand_app):
     out, err = run_cmd(subcommand_app, 'help base baz')
-    assert out[0].startswith('usage: base')
+    assert out[0].startswith('Usage: base')
 
 
 def test_add_another_subcommand(subcommand_app):

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -3,7 +3,6 @@
 """
 Cmd2 unit/functional testing
 """
-import argparse
 import builtins
 import io
 import os
@@ -1365,7 +1364,7 @@ def test_select_ctrl_c(outsim_app, monkeypatch, capsys):
 
 
 class HelpNoDocstringApp(cmd2.Cmd):
-    greet_parser = argparse.ArgumentParser()
+    greet_parser = cmd2.Cmd2ArgumentParser()
     greet_parser.add_argument('-s', '--shout', action="store_true", help="N00B EMULATION MODE")
 
     @cmd2.with_argparser(greet_parser, with_unknown_args=True)
@@ -1383,11 +1382,12 @@ def test_help_with_no_docstring(capsys):
     assert err == ''
     assert (
         out
-        == """usage: greet [-h] [-s]
+        == """Usage: greet [-h] [-s]
 
 optional arguments:
   -h, --help   show this help message and exit
   -s, --shout  N00B EMULATION MODE
+
 """
     )
 
@@ -1396,7 +1396,7 @@ class MultilineApp(cmd2.Cmd):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, multiline_commands=['orate'], **kwargs)
 
-    orate_parser = argparse.ArgumentParser()
+    orate_parser = cmd2.Cmd2ArgumentParser()
     orate_parser.add_argument('-s', '--shout', action="store_true", help="N00B EMULATION MODE")
 
     @cmd2.with_argparser(orate_parser, with_unknown_args=True)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -6,7 +6,6 @@ Unit/functional testing for readline tab completion functions in the cmd2.py mod
 These are primarily tests related to readline completer functions which handle tab completion of cmd2/cmd commands,
 file system paths, and shell commands.
 """
-import argparse
 import enum
 import os
 import sys
@@ -1184,7 +1183,7 @@ class SubcommandsWithUnknownExample(cmd2.Cmd):
         self.poutput('Sport is {}'.format(args.sport))
 
     # create the top-level parser for the base command
-    base_parser = argparse.ArgumentParser()
+    base_parser = cmd2.Cmd2ArgumentParser()
     base_subparsers = base_parser.add_subparsers(title='subcommands', help='subcommand help')
 
     # create the parser for the "foo" subcommand

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -3,7 +3,6 @@
 """
 Cmd2 functional testing based on transcript
 """
-import argparse
 import os
 import random
 import re
@@ -46,7 +45,7 @@ class CmdLineApp(cmd2.Cmd):
 
         self.intro = 'This is an intro banner ...'
 
-    speak_parser = argparse.ArgumentParser()
+    speak_parser = cmd2.Cmd2ArgumentParser()
     speak_parser.add_argument('-p', '--piglatin', action="store_true", help="atinLay")
     speak_parser.add_argument('-s', '--shout', action="store_true", help="N00B EMULATION MODE")
     speak_parser.add_argument('-r', '--repeat', type=int, help="output [n] times")
@@ -69,7 +68,7 @@ class CmdLineApp(cmd2.Cmd):
     do_say = do_speak  # now "say" is a synonym for "speak"
     do_orate = do_speak  # another synonym, but this one takes multi-line input
 
-    mumble_parser = argparse.ArgumentParser()
+    mumble_parser = cmd2.Cmd2ArgumentParser()
     mumble_parser.add_argument('-r', '--repeat', type=int, help="output [n] times")
 
     @cmd2.with_argparser(mumble_parser, with_unknown_args=True)

--- a/tests/transcripts/from_cmdloop.txt
+++ b/tests/transcripts/from_cmdloop.txt
@@ -2,16 +2,16 @@
 # so you can see where they are.
 
 (Cmd) help say
-usage: speak [-h] [-p] [-s] [-r REPEAT]/ */
+Usage: speak [-h] [-p] [-s] [-r REPEAT]/ */
 
 Repeats what you tell me to./ */
 
 optional arguments:/ */
-  -h, --help            show this help message and exit/ */
-  -p, --piglatin        atinLay/ */
-  -s, --shout           N00B EMULATION MODE/ */
-  -r REPEAT, --repeat REPEAT/ */
-                        output [n] times
+  -h, --help           show this help message and exit/ */
+  -p, --piglatin       atinLay/ */
+  -s, --shout          N00B EMULATION MODE/ */
+  -r, --repeat REPEAT  output [n] times/ */
+
 (Cmd) say goodnight, Gracie
 goodnight, Gracie
 (Cmd) say -ps --repeat=5 goodnight, Gracie

--- a/tests_isolated/test_commandset/test_argparse_subcommands.py
+++ b/tests_isolated/test_commandset/test_argparse_subcommands.py
@@ -4,8 +4,6 @@
 reproduces test_argparse.py except with SubCommands
 """
 
-import argparse
-
 import pytest
 
 import cmd2
@@ -36,7 +34,7 @@ class SubcommandSet(cmd2.CommandSet):
         self._cmd.poutput('((%s))' % args.z)
 
     # create the top-level parser for the base command
-    base_parser = argparse.ArgumentParser()
+    base_parser = cmd2.Cmd2ArgumentParser()
     base_subparsers = base_parser.add_subparsers(dest='subcommand', metavar='SUBCOMMAND')
     base_subparsers.required = True
 
@@ -85,13 +83,13 @@ def test_subcommand_bar(subcommand_app):
 
 def test_subcommand_invalid(subcommand_app):
     out, err = run_cmd(subcommand_app, 'base baz')
-    assert err[0].startswith('usage: base')
-    assert err[1].startswith("base: error: argument SUBCOMMAND: invalid choice: 'baz'")
+    assert err[0].startswith('Usage: base')
+    assert err[1].startswith("Error: argument SUBCOMMAND: invalid choice: 'baz'")
 
 
 def test_subcommand_base_help(subcommand_app):
     out, err = run_cmd(subcommand_app, 'help base')
-    assert out[0].startswith('usage: base')
+    assert out[0].startswith('Usage: base')
     assert out[1] == ''
     assert out[2] == 'Base command help'
 
@@ -99,43 +97,43 @@ def test_subcommand_base_help(subcommand_app):
 def test_subcommand_help(subcommand_app):
     # foo has no aliases
     out, err = run_cmd(subcommand_app, 'help base foo')
-    assert out[0].startswith('usage: base foo')
+    assert out[0].startswith('Usage: base foo')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     # bar has aliases (usage should never show alias name)
     out, err = run_cmd(subcommand_app, 'help base bar')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base bar_1')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base bar_2')
-    assert out[0].startswith('usage: base bar')
+    assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     # helpless has aliases and no help text (usage should never show alias name)
     out, err = run_cmd(subcommand_app, 'help base helpless')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base helpless_1')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
     out, err = run_cmd(subcommand_app, 'help base helpless_2')
-    assert out[0].startswith('usage: base helpless')
+    assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'positional arguments:'
 
 
 def test_subcommand_invalid_help(subcommand_app):
     out, err = run_cmd(subcommand_app, 'help base baz')
-    assert out[0].startswith('usage: base')
+    assert out[0].startswith('Usage: base')

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -861,7 +861,7 @@ class CommandSetWithPathComplete(cmd2.CommandSet):
         """dummy variable prevents this from being autoloaded in other tests"""
         super(CommandSetWithPathComplete, self).__init__()
 
-    parser = argparse.ArgumentParser()
+    parser = cmd2.Cmd2ArgumentParser()
     parser.add_argument('path', nargs='+', help='paths', completer=cmd2.Cmd.path_complete)
 
     @cmd2.with_argparser(parser)


### PR DESCRIPTION
Fixes #1121 