### PR TITLE
Added accessor methods for cmd2-specific attributes to the argparse.Action class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.1.2 (TBD, 2021)
+* Enhancements
+    * Added the following accessor methods for cmd2-specific attributes to the `argparse.Action` class
+        * `get_choices_callable()`
+        * `set_choices_provider()`
+        * `set_completer()`
+        * `get_descriptive_header()`
+        * `set_descriptive_header()`
+        * `get_nargs_range()`
+        * `set_nargs_range()`
+        * `get_suppress_tab_hint()`
+        * `set_suppress_tab_hint()`
+    
+* Deprecations
+    * Now that `set_choices_provider()` and `set_completer()` have been added as methods to the
+      `argparse.Action` class, the standalone functions of the same name will be removed in version
+      2.2.0. To update to the new convention, do the following:
+        * Change `set_choices_provider(action, provider)` to `action.set_choices_provider(provider)`
+        * Change `set_completer(action, completer)` to `action.set_completer(completer)`
+
 ## 2.1.1 (June 17, 2021)
 * Bug Fixes
    * Fixed handling of argparse's default options group name which was changed in Python 3.10

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -13,7 +13,6 @@ from collections import (
     deque,
 )
 from typing import (
-    Any,
     Dict,
     List,
     Optional,
@@ -27,12 +26,7 @@ from . import (
     constants,
 )
 from .argparse_custom import (
-    ATTR_CHOICES_CALLABLE,
-    ATTR_DESCRIPTIVE_COMPLETION_HEADER,
-    ATTR_NARGS_RANGE,
-    ATTR_SUPPRESS_TAB_HINT,
     ChoicesCallable,
-    ChoicesProviderFuncBase,
     ChoicesProviderFuncWithTokens,
     CompletionItem,
     generate_range_error,
@@ -60,7 +54,7 @@ ARG_TOKENS = 'arg_tokens'
 def _build_hint(parser: argparse.ArgumentParser, arg_action: argparse.Action) -> str:
     """Build tab completion hint for a given argument"""
     # Check if hinting is disabled for this argument
-    suppress_hint = getattr(arg_action, ATTR_SUPPRESS_TAB_HINT, False)
+    suppress_hint = arg_action.get_suppress_tab_hint()  # type: ignore[attr-defined]
     if suppress_hint or arg_action.help == argparse.SUPPRESS:
         return ''
     else:
@@ -116,7 +110,7 @@ class _ArgumentState:
         self.is_remainder = self.action.nargs == argparse.REMAINDER
 
         # Check if nargs is a range
-        nargs_range = getattr(self.action, ATTR_NARGS_RANGE, None)
+        nargs_range = self.action.get_nargs_range()  # type: ignore[attr-defined]
         if nargs_range is not None:
             self.min = nargs_range[0]
             self.max = nargs_range[1]
@@ -562,7 +556,7 @@ class ArgparseCompleter:
                 tuple_index = min(len(destination) - 1, arg_state.count)
                 destination = destination[tuple_index]
 
-            desc_header = getattr(arg_state.action, ATTR_DESCRIPTIVE_COMPLETION_HEADER, None)
+            desc_header = arg_state.action.get_descriptive_header()  # type: ignore[attr-defined]
             if desc_header is None:
                 desc_header = DEFAULT_DESCRIPTIVE_HEADER
 
@@ -665,7 +659,7 @@ class ArgparseCompleter:
                 if not isinstance(choice, str):
                     arg_choices[index] = str(choice)  # type: ignore[unreachable]
         else:
-            choices_attr = getattr(arg_state.action, ATTR_CHOICES_CALLABLE, None)
+            choices_attr = arg_state.action.get_choices_callable()  # type: ignore[attr-defined]
             if choices_attr is None:
                 return []
             arg_choices = choices_attr

--- a/docs/api/argparse_custom.rst
+++ b/docs/api/argparse_custom.rst
@@ -3,3 +3,29 @@ cmd2.argparse_custom
 
 .. automodule:: cmd2.argparse_custom
     :members:
+
+
+Added Accessor Methods
+----------------------
+.. autofunction:: _action_get_choices_callable
+
+.. autofunction:: _action_set_choices_provider
+
+.. autofunction:: _action_set_completer
+
+.. autofunction:: _action_get_descriptive_header
+
+.. autofunction:: _action_set_descriptive_header
+
+.. autofunction:: _action_get_nargs_range
+
+.. autofunction:: _action_set_nargs_range
+
+.. autofunction:: _action_get_suppress_tab_hint
+
+.. autofunction:: _action_set_suppress_tab_hint
+
+
+Subcommand Removal
+------------------
+.. autofunction:: _SubParsersAction_remove_parser


### PR DESCRIPTION
* Added accessor methods for cmd2-specific attributes to the `argparse.Action` class.
* Deprecated `set_choices_provider()` and `set_completer()` functions in favor of these new methods.