### PR TITLE
Updated some commands to use SimpleTable in their output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.0 (TBD, 2021)
+* Enhancements
+    * Using `SimpleTable` in the output for the following commands to improve appearance.
+        * help
+        * set (command and tab completion of Settables)
+        * alias tab completion
+        * macro tab completion
+    * Tab completion of `CompletionItems` now includes divider row comprised of `Cmd.ruler` character.
+    * Removed `--verbose` flag from set command since descriptions always show now.
+
 ## 2.1.2 (July 5, 2021)
 * Enhancements
     * Added the following accessor methods for cmd2-specific attributes to the `argparse.Action` class

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -578,7 +578,7 @@ class ArgparseCompleter:
             cols.append(Column(destination.upper(), width=token_width))
             cols.append(Column(desc_header, width=desc_width))
 
-            hint_table = SimpleTable(cols, divider_char=None)
+            hint_table = SimpleTable(cols, divider_char=self._cmd2_app.ruler)
             table_data = [[item, item.description] for item in completion_items]
             self._cmd2_app.formatted_completions = hint_table.generate_table(table_data, row_spacing=0)
 

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -151,6 +151,7 @@ Since descriptive_header and CompletionItem.description are just strings, you
 can format them in such a way to have multiple columns::
 
     ITEM_ID     Item Name            Checked Out    Due Date
+    ==========================================================
     1           My item              True           02/02/2022
     2           Another item         False
     3           Yet another item     False

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -130,6 +130,7 @@ tokens with descriptions instead of just a table of tokens::
 
     The user sees this:
         ITEM_ID     Item Name
+        ============================
         1           My item
         2           Another item
         3           Yet another item

--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -545,7 +545,7 @@ class SimpleTable(TableCreator):
         :param column_spacing: how many spaces to place between columns. Defaults to 2.
         :param tab_width: all tabs will be replaced with this many spaces. If a row's fill_char is a tab,
                           then it will be converted to one space.
-        :param divider_char: optional character used to build the header divider row. Set this to None if you don't
+        :param divider_char: optional character used to build the header divider row. Set this to blank or None if you don't
                              want a divider row. Defaults to dash. (Cannot be a line breaking character)
         :raises: ValueError if column_spacing is less than 0
         :raises: ValueError if tab_width is less than 1
@@ -555,6 +555,9 @@ class SimpleTable(TableCreator):
         if column_spacing < 0:
             raise ValueError("Column spacing cannot be less than 0")
         self.inter_cell = column_spacing * SPACE
+
+        if divider_char == '':
+            divider_char = None
 
         if divider_char is not None:
             if len(ansi.strip_style(divider_char)) != 1:

--- a/cmd2/table_creator.py
+++ b/cmd2/table_creator.py
@@ -604,19 +604,19 @@ class SimpleTable(TableCreator):
         header = self.generate_row(inter_cell=self.inter_cell)
         header_buf.write(header)
 
-        # Create the divider if necessary
-        if self.divider_char is not None:
-            total_width = self.total_width()
-            divider_char_width = ansi.style_aware_wcswidth(self.divider_char)
+        # Add the divider if necessary
+        divider = self.generate_divider()
+        if divider:
+            header_buf.write('\n' + divider)
 
-            # Make divider as wide as table and use padding if width of
-            # divider_char does not divide evenly into table width.
-            divider = self.divider_char * (total_width // divider_char_width)
-            divider += SPACE * (total_width % divider_char_width)
-
-            header_buf.write('\n')
-            header_buf.write(divider)
         return header_buf.getvalue()
+
+    def generate_divider(self) -> str:
+        """Generate divider row"""
+        if self.divider_char is None:
+            return ''
+
+        return utils.align_left('', fill_char=self.divider_char, width=self.total_width())
 
     def generate_data_row(self, row_data: Sequence[Any]) -> str:
         """

--- a/docs/features/builtin_commands.rst
+++ b/docs/features/builtin_commands.rst
@@ -102,16 +102,22 @@ within a running application:
 
 .. code-block:: text
 
-    (Cmd) set --verbose
-    allow_style: 'Terminal'   # Allow ANSI text style sequences in output (valid values: Terminal, Always, Never)
-    always_show_hint: False   # Display tab completion hint even when completion suggestions print
-    debug: True               # Show full traceback on exception
-    echo: False               # Echo command issued into output
-    editor: 'vi'              # Program used by 'edit'
-    feedback_to_output: False # Include nonessentials in '|', '>' results
-    max_completion_items: 50  # Maximum number of CompletionItems to display during tab completion
-    quiet: False              # Don't print nonessential feedback
-    timing: False             # Report execution times
+    (Cmd) set
+    Name                  Value                           Description
+    ==================================================================================================================
+    allow_style           Terminal                        Allow ANSI text style sequences in output (valid values:
+                                                          Terminal, Always, Never)
+    always_show_hint      False                           Display tab completion hint even when completion suggestions
+                                                          print
+    debug                 True                            Show full traceback on exception
+    echo                  False                           Echo command issued into output
+    editor                vi                              Program used by 'edit'
+    feedback_to_output    False                           Include nonessentials in '|', '>' results
+    max_completion_items  50                              Maximum number of CompletionItems to display during tab
+                                                          completion
+    quiet                 False                           Don't print nonessential feedback
+    timing                False                           Report execution times
+
 
 Any of these user-settable parameters can be set while running your app with
 the ``set`` command like so:

--- a/docs/features/settings.rst
+++ b/docs/features/settings.rst
@@ -134,10 +134,10 @@ changes a setting, and will receive both the old value and the new value.
 
 .. code-block:: text
 
-   (Cmd) set --verbose | grep sunny
-   sunny: False                # Is it sunny outside?
-   (Cmd) set --verbose | grep degrees
-   degrees_c: 22               # Temperature in Celsius
+   (Cmd) set | grep sunny
+   sunny                 False                           Is it sunny outside?
+   (Cmd) set | grep degrees
+   degrees_c             22                              Temperature in Celsius
    (Cmd) sunbathe
    Too dim.
    (Cmd) set degrees_c 41

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,29 +104,23 @@ SHORTCUTS_TXT = """Shortcuts for other commands:
 @@: _relative_run_script
 """
 
-# Output from the show command with default settings
-SHOW_TXT = """allow_style: 'Terminal'
-always_show_hint: False
-debug: False
-echo: False
-editor: 'vim'
-feedback_to_output: False
-max_completion_items: 50
-quiet: False
-timing: False
-"""
-
-SHOW_LONG = """
-allow_style: 'Terminal'   # Allow ANSI text style sequences in output (valid values: Terminal, Always, Never)
-always_show_hint: False   # Display tab completion hint even when completion suggestions print
-debug: False              # Show full traceback on exception
-echo: False               # Echo command issued into output
-editor: 'vim'             # Program used by 'edit'
-feedback_to_output: False # Include nonessentials in '|', '>' results
-max_completion_items: 50  # Maximum number of CompletionItems to display during tab completion
-quiet: False              # Don't print nonessential feedback
-timing: False             # Report execution times
-"""
+# Output from the set command
+SET_TXT = (
+    "Name                  Value                           Description                                                 \n"
+    "==================================================================================================================\n"
+    "allow_style           Terminal                        Allow ANSI text style sequences in output (valid values:    \n"
+    "                                                      Terminal, Always, Never)                                    \n"
+    "always_show_hint      False                           Display tab completion hint even when completion suggestions\n"
+    "                                                      print                                                       \n"
+    "debug                 False                           Show full traceback on exception                            \n"
+    "echo                  False                           Echo command issued into output                             \n"
+    "editor                vim                             Program used by 'edit'                                      \n"
+    "feedback_to_output    False                           Include nonessentials in '|', '>' results                   \n"
+    "max_completion_items  50                              Maximum number of CompletionItems to display during tab     \n"
+    "                                                      completion                                                  \n"
+    "quiet                 False                           Don't print nonessential feedback                           \n"
+    "timing                False                           Report execution times                                      \n"
+)
 
 
 def normalize(block):

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -725,10 +725,14 @@ def test_completion_items(ac_app, num_aliases, show_description):
 
     assert bool(ac_app.formatted_completions) == show_description
     if show_description:
-        # If show_description is True, the table will show both the alias name and result
-        first_result_line = normalize(ac_app.formatted_completions)[1]
-        assert 'fake_alias0' in first_result_line
-        assert 'help' in first_result_line
+        # If show_description is True, the table will show both the alias name and value
+        description_displayed = False
+        for line in ac_app.formatted_completions.splitlines():
+            if 'fake_alias0' in line and 'help' in line:
+                description_displayed = True
+                break
+
+        assert description_displayed
 
 
 def test_completion_item_choices(ac_app):
@@ -742,10 +746,14 @@ def test_completion_item_choices(ac_app):
     assert len(ac_app.completion_matches) == len(ac_app.completion_item_choices)
     assert len(ac_app.display_matches) == len(ac_app.completion_item_choices)
 
-    # Make sure a completion table was created
-    first_result_line = normalize(ac_app.formatted_completions)[1]
-    assert 'choice_1' in first_result_line
-    assert 'A description' in first_result_line
+    # The table will show both the choice and description
+    description_displayed = False
+    for line in ac_app.formatted_completions.splitlines():
+        if 'choice_1' in line and 'A description' in line:
+            description_displayed = True
+            break
+
+    assert description_displayed
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table_creator.py
+++ b/tests/test_table_creator.py
@@ -364,9 +364,12 @@ def test_simple_table_creation():
 
     # No divider
     st = SimpleTable([column_1, column_2], divider_char=None)
-    table = st.generate_table(row_data)
+    no_divider_1 = st.generate_table(row_data)
 
-    assert table == (
+    st = SimpleTable([column_1, column_2], divider_char='')
+    no_divider_2 = st.generate_table(row_data)
+
+    assert no_divider_1 == no_divider_2 == (
         'Col 1             Col 2           \n'
         'Col 1 Row 1       Col 2 Row 1     \n'
         '\n'

--- a/tests/transcripts/regex_set.txt
+++ b/tests/transcripts/regex_set.txt
@@ -3,14 +3,25 @@
 # The regex for editor will match whatever program you use.
 # Regexes on prompts just make the trailing space obvious
 
+(Cmd) set allow_style Terminal
+allow_style - was: '/.*/'
+now: 'Terminal'
+(Cmd) set editor vim
+editor - was: '/.*/'
+now: 'vim'
 (Cmd) set
-allow_style: /'(Terminal|Always|Never)'/
-always_show_hint: False
-debug: False
-echo: False
-editor: /'.*'/
-feedback_to_output: False
-max_completion_items: 50
-maxrepeats: 3
-quiet: False
-timing: False
+Name                  Value                           Description/ +/
+==================================================================================================================
+allow_style           Terminal                        Allow ANSI text style sequences in output (valid values:/ +/
+                                                      Terminal, Always, Never)/ +/
+always_show_hint      False                           Display tab completion hint even when completion suggestions
+                                                      print/ +/
+debug                 False                           Show full traceback on exception/ +/
+echo                  False                           Echo command issued into output/ +/
+editor                vim                             Program used by 'edit'/ +/
+feedback_to_output    False                           Include nonessentials in '|', '>' results/ +/
+max_completion_items  50                              Maximum number of CompletionItems to display during tab/ +/
+                                                      completion/ +/
+maxrepeats            3                               Max number of `--repeat`s allowed/ +/
+quiet                 False                           Don't print nonessential feedback/ +/
+timing                False                           Report execution times/ +/

--- a/tests_isolated/test_commandset/conftest.py
+++ b/tests_isolated/test_commandset/conftest.py
@@ -107,28 +107,6 @@ SHORTCUTS_TXT = """Shortcuts for other commands:
 @@: _relative_run_script
 """
 
-# Output from the show command with default settings
-SHOW_TXT = """allow_style: 'Terminal'
-debug: False
-echo: False
-editor: 'vim'
-feedback_to_output: False
-max_completion_items: 50
-quiet: False
-timing: False
-"""
-
-SHOW_LONG = """
-allow_style: 'Terminal'   # Allow ANSI text style sequences in output (valid values: Terminal, Always, Never)
-debug: False              # Show full traceback on exception
-echo: False               # Echo command issued into output
-editor: 'vim'             # Program used by 'edit'
-feedback_to_output: False # Include nonessentials in '|', '>' results
-max_completion_items: 50  # Maximum number of CompletionItems to display during tab completion
-quiet: False              # Don't print nonessential feedback
-timing: False             # Report execution times
-"""
-
 
 def normalize(block):
     """Normalize a block of text to perform comparison.

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -987,9 +987,10 @@ def test_commandset_settables():
 
     # verify the settable shows up
     out, err = run_cmd(app, 'set')
-    assert 'arbitrary_value: 5' in out
+    any(['arbitrary_value' in line and '5' in line for line in out])
+
     out, err = run_cmd(app, 'set arbitrary_value')
-    assert out == ['arbitrary_value: 5']
+    any(['arbitrary_value' in line and '5' in line for line in out])
 
     # change the value and verify the value changed
     out, err = run_cmd(app, 'set arbitrary_value 10')
@@ -999,7 +1000,7 @@ now: 10
 """
     assert out == normalize(expected)
     out, err = run_cmd(app, 'set arbitrary_value')
-    assert out == ['arbitrary_value: 10']
+    any(['arbitrary_value' in line and '10' in line for line in out])
 
     # can't add to cmd2 now because commandset already has this settable
     with pytest.raises(KeyError):
@@ -1058,9 +1059,10 @@ Parameter 'arbitrary_value' not supported (type 'set' for list of parameters).
     assert 'some.arbitrary_value' in app.settables.keys()
 
     out, err = run_cmd(app, 'set')
-    assert 'some.arbitrary_value: 5' in out
+    any(['some.arbitrary_value' in line and '5' in line for line in out])
+
     out, err = run_cmd(app, 'set some.arbitrary_value')
-    assert out == ['some.arbitrary_value: 5']
+    any(['some.arbitrary_value' in line and '5' in line for line in out])
 
     # verify registering a commandset with duplicate prefix and settable names fails
     with pytest.raises(CommandSetRegistrationError):


### PR DESCRIPTION
* Enhancements
    * Using `SimpleTable` in the output for the following commands to improve appearance.
        * help
        * set (command and tab completion of Settables)
        * alias tab completion
        * macro tab completion
    * Tab completion of `CompletionItems` now includes divider row comprised of `Cmd.ruler` character.
    * Removed `--verbose` flag from set command since descriptions always show now.

Closes #1091 