### PR TITLE
Deleted set_choices_provider() and set_completer() which were deprected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (TBD, 2021)
+* Deletions (potentially breaking changes)
+    * Deleted ``set_choices_provider()`` and ``set_completer()`` which were deprecated in 2.1.2
+    
 ## 2.1.2 (July 5, 2021)
 * Enhancements
     * Added the following accessor methods for cmd2-specific attributes to the `argparse.Action` class

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -528,31 +528,6 @@ setattr(argparse.Action, 'set_completer', _action_set_completer)
 
 
 ############################################################################################################
-# Deprecated wrappers
-############################################################################################################
-def set_choices_provider(action: argparse.Action, choices_provider: ChoicesProviderFunc) -> None:  # pragma: no cover
-    import warnings
-
-    warnings.warn(
-        'This function will be deprecated in version 2.2.0. Use `action.set_choices_provider(choices_provider)` instead.',
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
-    action.set_choices_provider(choices_provider)  # type: ignore[attr-defined]
-
-
-def set_completer(action: argparse.Action, completer: CompleterFunc) -> None:  # pragma: no cover
-    import warnings
-
-    warnings.warn(
-        'This function will be deprecated in version 2.2.0. Use `action.set_completer(completer)` instead.',
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
-    action.set_completer(completer)  # type: ignore[attr-defined]
-
-
-############################################################################################################
 # Patch argparse.Action with accessors for descriptive_header attribute
 ############################################################################################################
 def _action_get_descriptive_header(self: argparse.Action) -> Optional[str]:


### PR DESCRIPTION
Deleted `set_choices_provider()` and `set_completer()` which were deprecated in 2.1.2