### PR TITLE
Refactored custom argparse completers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 * Bug Fixes
   * Fixed extra space appended to each alias by "alias list" command
 * Enhancements
-  * New function `set_default_command_completer_type()` allows developer to extend and modify the
-    behavior of `ArgparseCompleter`. 
+  * New function `set_default_ap_completer_type()` allows developer to extend and modify the
+    behavior of `ArgparseCompleter`.
+  * Added `ArgumentParser.get_ap_completer_type()` and `ArgumentParser.set_ap_completer_type()`. These
+    methods allow developers to enable custom tab completion behavior for a given parser by using a custom
+    `ArgparseCompleter`-based class.
   * New function `register_argparse_argument_parameter()` allows developers to specify custom 
     parameters to be passed to the argparse parser's `add_argument()` method. These parameters will
     become accessible in the resulting argparse Action object when modifying `ArgparseCompleter` behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * Added `ArgumentParser.get_ap_completer_type()` and `ArgumentParser.set_ap_completer_type()`. These
     methods allow developers to enable custom tab completion behavior for a given parser by using a custom
     `ArgparseCompleter`-based class.
+  * Added `ap_completer_type` keyword arg to `Cmd2ArgumentParser.__init__()` which saves a call
+    to `set_ap_completer_type()`. This keyword will also work in `add_parser()` when creating subcommands.
   * New function `register_argparse_argument_parameter()` allows developers to specify custom 
     parameters to be passed to the argparse parser's `add_argument()` method. These parameters will
     become accessible in the resulting argparse Action object when modifying `ArgparseCompleter` behavior.

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -25,7 +25,7 @@ from .argparse_custom import (
     Cmd2AttributeWrapper,
     CompletionItem,
     register_argparse_argument_parameter,
-    set_default_argument_parser,
+    set_default_argument_parser_type,
 )
 
 # Check if user has defined a module that sets a custom value for argparse_custom.DEFAULT_ARGUMENT_PARSER.
@@ -38,7 +38,7 @@ if cmd2_parser_module is not None:
 
     importlib.import_module(cmd2_parser_module)
 
-from .argparse_completer import set_default_command_completer_type
+from .argparse_completer import set_default_ap_completer_type
 
 from .cmd2 import Cmd
 from .command_definition import CommandSet, with_default_category
@@ -63,8 +63,8 @@ __all__: List[str] = [
     'Cmd2AttributeWrapper',
     'CompletionItem',
     'register_argparse_argument_parameter',
-    'set_default_argument_parser',
-    'set_default_command_completer_type',
+    'set_default_argument_parser_type',
+    'set_default_ap_completer_type',
     # Cmd2
     'Cmd',
     'CommandResult',

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -30,7 +30,7 @@ from .constants import (
     INFINITY,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .cmd2 import (
         Cmd,
     )

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -407,9 +407,15 @@ class ArgparseCompleter:
                                 if action.dest != argparse.SUPPRESS:
                                     parent_tokens[action.dest] = [token]
 
-                                completer = ArgparseCompleter(
-                                    self._subcommand_action.choices[token], self._cmd2_app, parent_tokens=parent_tokens
-                                )
+                                parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
+                                completer_type: Optional[
+                                    Type[ArgparseCompleter]
+                                ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
+                                if completer_type is None:
+                                    completer_type = DEFAULT_AP_COMPLETER
+
+                                completer = completer_type(parser, self._cmd2_app, parent_tokens=parent_tokens)
+
                                 return completer.complete(
                                     text, line, begidx, endidx, tokens[token_index + 1 :], cmd_set=cmd_set
                                 )
@@ -609,7 +615,14 @@ class ArgparseCompleter:
         if self._subcommand_action is not None:
             for token_index, token in enumerate(tokens):
                 if token in self._subcommand_action.choices:
-                    completer = ArgparseCompleter(self._subcommand_action.choices[token], self._cmd2_app)
+                    parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
+                    completer_type: Optional[
+                        Type[ArgparseCompleter]
+                    ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
+                    if completer_type is None:
+                        completer_type = DEFAULT_AP_COMPLETER
+
+                    completer = completer_type(parser, self._cmd2_app)
                     return completer.complete_subcommand_help(text, line, begidx, endidx, tokens[token_index + 1 :])
                 elif token_index == len(tokens) - 1:
                     # Since this is the last token, we will attempt to complete it
@@ -629,7 +642,14 @@ class ArgparseCompleter:
         if self._subcommand_action is not None:
             for token_index, token in enumerate(tokens):
                 if token in self._subcommand_action.choices:
-                    completer = ArgparseCompleter(self._subcommand_action.choices[token], self._cmd2_app)
+                    parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
+                    completer_type: Optional[
+                        Type[ArgparseCompleter]
+                    ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
+                    if completer_type is None:
+                        completer_type = DEFAULT_AP_COMPLETER
+
+                    completer = completer_type(parser, self._cmd2_app)
                     return completer.format_help(tokens[token_index + 1 :])
                 else:
                     break
@@ -740,14 +760,15 @@ class ArgparseCompleter:
         return self._format_completions(arg_state, results)
 
 
-DEFAULT_COMMAND_COMPLETER: Type[ArgparseCompleter] = ArgparseCompleter
+# The default ArgparseCompleter class for a cmd2 app
+DEFAULT_AP_COMPLETER: Type[ArgparseCompleter] = ArgparseCompleter
 
 
-def set_default_command_completer_type(completer_type: Type[ArgparseCompleter]) -> None:
+def set_default_ap_completer_type(completer_type: Type[ArgparseCompleter]) -> None:
     """
-    Set the default command completer type. It must be a sub-class of the ArgparseCompleter.
+    Set the default ArgparseCompleter class for a cmd2 app.
 
     :param completer_type: Type that is a subclass of ArgparseCompleter.
     """
-    global DEFAULT_COMMAND_COMPLETER
-    DEFAULT_COMMAND_COMPLETER = completer_type
+    global DEFAULT_AP_COMPLETER
+    DEFAULT_AP_COMPLETER = completer_type

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -408,11 +408,7 @@ class ArgparseCompleter:
                                     parent_tokens[action.dest] = [token]
 
                                 parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
-                                completer_type: Optional[
-                                    Type[ArgparseCompleter]
-                                ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
-                                if completer_type is None:
-                                    completer_type = DEFAULT_AP_COMPLETER
+                                completer_type = self._cmd2_app._determine_ap_completer_type(parser)
 
                                 completer = completer_type(parser, self._cmd2_app, parent_tokens=parent_tokens)
 
@@ -616,11 +612,7 @@ class ArgparseCompleter:
             for token_index, token in enumerate(tokens):
                 if token in self._subcommand_action.choices:
                     parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
-                    completer_type: Optional[
-                        Type[ArgparseCompleter]
-                    ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
-                    if completer_type is None:
-                        completer_type = DEFAULT_AP_COMPLETER
+                    completer_type = self._cmd2_app._determine_ap_completer_type(parser)
 
                     completer = completer_type(parser, self._cmd2_app)
                     return completer.complete_subcommand_help(text, line, begidx, endidx, tokens[token_index + 1 :])
@@ -643,11 +635,7 @@ class ArgparseCompleter:
             for token_index, token in enumerate(tokens):
                 if token in self._subcommand_action.choices:
                     parser: argparse.ArgumentParser = self._subcommand_action.choices[token]
-                    completer_type: Optional[
-                        Type[ArgparseCompleter]
-                    ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
-                    if completer_type is None:
-                        completer_type = DEFAULT_AP_COMPLETER
+                    completer_type = self._cmd2_app._determine_ap_completer_type(parser)
 
                     completer = completer_type(parser, self._cmd2_app)
                     return completer.format_help(tokens[token_index + 1 :])

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1252,7 +1252,16 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         conflict_handler: str = 'error',
         add_help: bool = True,
         allow_abbrev: bool = True,
+        *,
+        ap_completer_type: Optional[Type['ArgparseCompleter']] = None,
     ) -> None:
+        """
+        # Custom parameter added by cmd2
+
+        :param ap_completer_type: optional parameter which specifies a subclass of ArgparseCompleter for custom tab completion
+                                  behavior on this parser. If this is None or not present, then cmd2 will use
+                                  argparse_completer.DEFAULT_AP_COMPLETER when tab completing this parser's arguments
+        """
         super(Cmd2ArgumentParser, self).__init__(
             prog=prog,
             usage=usage,
@@ -1267,6 +1276,8 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
             add_help=add_help,
             allow_abbrev=allow_abbrev,
         )
+
+        self.set_ap_completer_type(ap_completer_type)  # type: ignore[attr-defined]
 
     # noinspection PyProtectedMember
     def add_subparsers(self, **kwargs: Any) -> argparse._SubParsersAction:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1841,6 +1841,23 @@ class Cmd(cmd.Cmd):
                 # Display matches using actual display function. This also redraws the prompt and input lines.
                 orig_pyreadline_display(matches_to_display)
 
+    @staticmethod
+    def _determine_ap_completer_type(parser: argparse.ArgumentParser) -> Type[argparse_completer.ArgparseCompleter]:
+        """
+        Determine what type of ArgparseCompleter to use on a given parser. If the parser does not have one
+        set, then use argparse_completer.DEFAULT_AP_COMPLETER.
+
+        :param parser: the parser to examine
+        :return: type of ArgparseCompleter
+        """
+        completer_type: Optional[
+            Type[argparse_completer.ArgparseCompleter]
+        ] = parser.get_ap_completer_type()  # type: ignore[attr-defined]
+
+        if completer_type is None:
+            completer_type = argparse_completer.DEFAULT_AP_COMPLETER
+        return completer_type
+
     def _perform_completion(
         self, text: str, line: str, begidx: int, endidx: int, custom_settings: Optional[utils.CustomCompletionSettings] = None
     ) -> None:
@@ -1910,9 +1927,7 @@ class Cmd(cmd.Cmd):
                         cmd_set = self._cmd_to_command_sets[command] if command in self._cmd_to_command_sets else None
 
                         # Create the argparse completer
-                        completer_type = argparser.get_ap_completer_type()  # type: ignore[attr-defined]
-                        if completer_type is None:
-                            completer_type = argparse_completer.DEFAULT_AP_COMPLETER
+                        completer_type = self._determine_ap_completer_type(argparser)
                         completer = completer_type(argparser, self)
 
                         completer_func = functools.partial(
@@ -1932,9 +1947,7 @@ class Cmd(cmd.Cmd):
         # Otherwise we are completing the command token or performing custom completion
         else:
             # Create the argparse completer
-            completer_type = custom_settings.parser.get_ap_completer_type()  # type: ignore[attr-defined]
-            if completer_type is None:
-                completer_type = argparse_completer.DEFAULT_AP_COMPLETER
+            completer_type = self._determine_ap_completer_type(custom_settings.parser)
             completer = completer_type(custom_settings.parser, self)
 
             completer_func = functools.partial(

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -43,7 +43,6 @@ CLASS_ATTR_DEFAULT_HELP_CATEGORY = 'cmd2_default_help_category'
 
 # The argparse parser for the command
 CMD_ATTR_ARGPARSER = 'argparser'
-CMD_ATTR_COMPLETER = 'command_completer'
 
 # Whether or not tokens are unquoted before sending to argparse
 CMD_ATTR_PRESERVE_QUOTES = 'preserve_quotes'

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -10,15 +10,11 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     Union,
 )
 
 from . import (
     constants,
-)
-from .argparse_completer import (
-    ArgparseCompleter,
 )
 from .argparse_custom import (
     Cmd2AttributeWrapper,
@@ -275,7 +271,6 @@ def with_argparser(
     ns_provider: Optional[Callable[..., argparse.Namespace]] = None,
     preserve_quotes: bool = False,
     with_unknown_args: bool = False,
-    completer: Optional[Type[ArgparseCompleter]] = None,
 ) -> Callable[[ArgparseCommandFunc], RawCommandFuncOptionalBoolReturn]:
     """A decorator to alter a cmd2 method to populate its ``args`` argument by parsing arguments
     with the given instance of argparse.ArgumentParser.
@@ -286,7 +281,6 @@ def with_argparser(
                         state data that affects parsing.
     :param preserve_quotes: if ``True``, then arguments passed to argparse maintain their quotes
     :param with_unknown_args: if true, then capture unknown args
-    :param completer: CommandCompleter type. Defaults to ArgparseCompleter if unspecified.
     :return: function that gets passed argparse-parsed args in a ``Namespace``
              A :class:`cmd2.argparse_custom.Cmd2AttributeWrapper` called ``cmd2_statement`` is included
              in the ``Namespace`` to provide access to the :class:`cmd2.Statement` object that was created when
@@ -397,7 +391,6 @@ def with_argparser(
 
         # Set some custom attributes for this command
         setattr(cmd_wrapper, constants.CMD_ATTR_ARGPARSER, parser)
-        setattr(cmd_wrapper, constants.CMD_ATTR_COMPLETER, completer)
         setattr(cmd_wrapper, constants.CMD_ATTR_PRESERVE_QUOTES, preserve_quotes)
 
         return cmd_wrapper

--- a/examples/custom_parser.py
+++ b/examples/custom_parser.py
@@ -7,7 +7,7 @@ import sys
 from cmd2 import (
     Cmd2ArgumentParser,
     ansi,
-    set_default_argument_parser,
+    set_default_argument_parser_type,
 )
 
 
@@ -38,4 +38,4 @@ class CustomParser(Cmd2ArgumentParser):
 
 
 # Now set the default parser for a cmd2 app
-set_default_argument_parser(CustomParser)
+set_default_argument_parser_type(CustomParser)

--- a/examples/override_parser.py
+++ b/examples/override_parser.py
@@ -7,7 +7,7 @@ The following code shows how to override it with your own parser class.
 """
 
 # First set a value called argparse.cmd2_parser_module with the module that defines the custom parser.
-# See the code for custom_parser.py. It simply defines a parser and calls cmd2.set_default_argument_parser()
+# See the code for custom_parser.py. It simply defines a parser and calls cmd2.set_default_argument_parser_type()
 # with the custom parser's type.
 import argparse
 

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -1182,11 +1182,11 @@ class CustomCompleterApp(cmd2.Cmd):
 @pytest.fixture
 def custom_completer_app():
 
-    argparse_completer.set_default_command_completer_type(CustomCompleter)
+    argparse_completer.set_default_ap_completer_type(CustomCompleter)
     app = CustomCompleterApp()
     app.stdout = StdSim(app.stdout)
     yield app
-    argparse_completer.set_default_command_completer_type(argparse_completer.ArgparseCompleter)
+    argparse_completer.set_default_ap_completer_type(argparse_completer.ArgparseCompleter)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refactored custom ArgparseCompleter functionality so they will now be set using methods on ArgumentParser objects.
This fixes issue where subcommands did not use the correct custom ArgparseCompleter type.
