### PR TITLE
Fixed regression in Cmd.select converting "Any" type argument to string

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3865,7 +3865,7 @@ class Cmd(cmd.Cmd):
         self.last_result = True
         return True
 
-    def select(self, opts: Union[str, List[str], List[Tuple[Any, Optional[str]]]], prompt: str = 'Your choice? ') -> str:
+    def select(self, opts: Union[str, List[str], List[Tuple[Any, Optional[str]]]], prompt: str = 'Your choice? ') -> Any:
         """Presents a numbered menu to the user.  Modeled after
         the bash shell's SELECT.  Returns the item chosen.
 
@@ -3910,7 +3910,7 @@ class Cmd(cmd.Cmd):
                 choice = int(response)
                 if choice < 1:
                     raise IndexError
-                return str(fulloptions[choice - 1][0])
+                return fulloptions[choice - 1][0]
             except (ValueError, IndexError):
                 self.poutput(f"'{response}' isn't a valid choice. Pick a number between 1 and {len(fulloptions)}:")
 


### PR DESCRIPTION
It appears that in https://github.com/python-cmd2/cmd2/commit/50d302913328931ecc9f61293892ac8f9aa61890 the behaviour of `Cmd.select` was subtly changed. This PR reverts the behaviour and updates the type signature of `Cmd.select` to match.

Prior to this change, when calling`Cmd2.select([(1, "One")])` the integer `1` would be returned, while after the changed the string `"1"` started being returned. The docstring and argument type of `List[Tuple[Any, Optional[str]]]]` would seem to indicate that the value passed in should be returned unmodified as per the previous behaviour.

For what its worth this affected us updating our dependencies today, as we use `.select` as a method of allowing users to select a function to be executed, i.e.

```python3
funcs = [
    (doX, "Do X"),
    (doY, "Do Y")
]

func = self.select(funcs, "What would you like to do?")
func() # previously this worked, post-regression func is of type 'str' and the call fails
```