### PR TITLE
Updates cmd2 External Test Plugin URL

### DIFF
--- a/docs/plugins/external_test.rst
+++ b/docs/plugins/external_test.rst
@@ -5,7 +5,7 @@ Overview
 ~~~~~~~~
 
 .. _cmd2_external_test_plugin:
-   https://github.com/python-cmd2/cmd2/tree/cmdset_settables/plugins/ext_test
+   https://github.com/python-cmd2/cmd2/tree/master/plugins/ext_test
 
 The `External Test Plugin <cmd2_external_test_plugin_>`_ supports testing of a cmd2 application by exposing access cmd2
 commands with the same context as from within a cmd2 :ref:`Python Scripts <scripting-python-scripts>`.  This interface


### PR DESCRIPTION
Updates cmd2 External Test Plugin URL

Old one points to a branch which no longer exists.