### PR TITLE
Switch to pyreadline3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Enhancements
   * Added broader exception handling when enabling clipboard functionality via `pyperclip`.
   * Added `PassThroughException` to `__init__.py` imports.
+  * cmd2 now uses pyreadline3 when running any version of Python on Windows
 * Deletions (potentially breaking changes)
   * Deleted `cmd2.fg` and `cmd2.bg` which were deprecated in 2.3.0. Use `cmd2.Fg` and `cmd2.Bg` instead.
 

--- a/Pipfile
+++ b/Pipfile
@@ -22,8 +22,7 @@ ipython = "*"
 isort = "*"
 mock = {version = "*",markers = "python_version < '3.6'"}
 mypy = "*"
-pyreadline = {version = "*",sys_platform = "== 'win32'",markers = "python_version < '3.8'"}
-pyreadline3 = {version = "*",sys_platform = "== 'win32'",markers = "python_version >= '3.8'"}
+pyreadline3 = {version = ">=3.4",sys_platform = "== 'win32'"}
 pytest = "*"
 pytest-cov = "*"
 pytest-mock = "*"

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -155,7 +155,7 @@ else:
 
     if rl_type == RlType.PYREADLINE:
 
-        # Save the original pyreadline display completion function since we need to override it and restore it
+        # Save the original pyreadline3 display completion function since we need to override it and restore it
         # noinspection PyProtectedMember,PyUnresolvedReferences
         orig_pyreadline_display = readline.rl.mode._display_completions
 
@@ -1747,7 +1747,7 @@ class Cmd(cmd.Cmd):
             padding = 2 * ' '
 
         elif rl_type == RlType.PYREADLINE:
-            # Add 3 to the padding of 1 that pyreadline uses for a total of 4.
+            # Add 3 to the padding of 1 that pyreadline3 uses for a total of 4.
             padding = 3 * ' '
 
         else:
@@ -1820,7 +1820,7 @@ class Cmd(cmd.Cmd):
             rl_force_redisplay()
 
     def _display_matches_pyreadline(self, matches: List[str]) -> None:  # pragma: no cover
-        """Prints a match list using pyreadline's _display_completions()
+        """Prints a match list using pyreadline3's _display_completions()
 
         :param matches: the tab completion matches to display
         """
@@ -1841,7 +1841,7 @@ class Cmd(cmd.Cmd):
                 # Redraw the prompt and input lines
                 rl_force_redisplay()
 
-            # Otherwise use pyreadline's formatter
+            # Otherwise use pyreadline3's formatter
             else:
                 # Check if we should show display_matches
                 if self.display_matches:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3066,9 +3066,10 @@ class Cmd(cmd.Cmd):
 
             # Set up readline for our tab completion needs
             if rl_type == RlType.GNU:
-                # Set GNU readline's rl_basic_quote_characters to NULL so it won't automatically add a closing quote
-                # We don't need to worry about setting rl_completion_suppress_quote since we never declared
-                # rl_completer_quote_characters.
+                # GNU readline automatically adds a closing quote if the text being completed has an opening quote.
+                # We don't want this behavior since cmd2 only adds a closing quote when self.allow_closing_quote is True.
+                # To fix this behavior, set readline's rl_basic_quote_characters to NULL. We don't need to worry about setting
+                # rl_completion_suppress_quote since we never declared rl_completer_quote_characters.
                 readline_settings.basic_quotes = cast(bytes, ctypes.cast(rl_basic_quote_characters, ctypes.c_void_p).value)
                 rl_basic_quote_characters.value = None
 

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -26,13 +26,12 @@ from typing import (
 # The workaround for Python environments using libedit is to install the gnureadline Python library.
 #########################################################################################################################
 
-# Prefer statically linked gnureadline if available due to issues with libedit
+# Prefer statically linked gnureadline if installed due to compatibility issues with libedit
 try:
     # noinspection PyPackageRequirements
     import gnureadline as readline  # type: ignore[import]
 except ImportError:
-    # Try to import readline, but allow failure for convenience in Windows unit testing.
-    # Note: If this actually fails, you should install gnureadline on Linux/Mac or pyreadline on Windows.
+    # Note: If this actually fails, you should install gnureadline on Linux/Mac or pyreadline3 on Windows.
     try:
         # noinspection PyUnresolvedReferences
         import readline  # type: ignore[no-redef]
@@ -57,8 +56,8 @@ vt100_support = False
 # Explanation for why Readline wasn't loaded
 _rl_warn_reason = ''
 
-# The order of this check matters since importing pyreadline/pyreadline3 will also show readline in the modules list
-if 'pyreadline' in sys.modules or 'pyreadline3' in sys.modules:
+# The order of this check matters since importing pyreadline3 will also show readline in the modules list
+if 'pyreadline3' in sys.modules:
     rl_type = RlType.PYREADLINE
 
     import atexit
@@ -109,7 +108,7 @@ if 'pyreadline' in sys.modules or 'pyreadline3' in sys.modules:
         vt100_support = vt100_stdout_support and vt100_stderr_support
 
     ############################################################################################################
-    # pyreadline is incomplete in terms of the Python readline API. Add the missing functions we need.
+    # pyreadline3 is incomplete in terms of the Python readline API. Add the missing functions we need.
     ############################################################################################################
     # readline.redisplay()
     try:
@@ -125,7 +124,7 @@ if 'pyreadline' in sys.modules or 'pyreadline3' in sys.modules:
         # noinspection PyProtectedMember,PyUnresolvedReferences
         def pyreadline_remove_history_item(pos: int) -> None:
             """
-            An implementation of remove_history_item() for pyreadline
+            An implementation of remove_history_item() for pyreadline3
             :param pos: The 0-based position in history to remove
             """
             # Save of the current location of the history cursor
@@ -162,7 +161,7 @@ if rl_type == RlType.NONE:  # pragma: no cover
     if not _rl_warn_reason:
         _rl_warn_reason = (
             "no supported version of readline was found. To resolve this, install\n"
-            "pyreadline on Windows or gnureadline on Linux/Mac."
+            "pyreadline3 on Windows or gnureadline on Linux/Mac."
         )
     rl_warning = "Readline features including tab completion have been disabled because\n" + _rl_warn_reason + '\n\n'
 else:

--- a/docs/overview/integrating.rst
+++ b/docs/overview/integrating.rst
@@ -26,13 +26,10 @@ Windows Considerations
 
 If you would like to use :ref:`features/completion:Completion`, and you want
 your application to run on Windows, you will need to ensure you install the
-``pyreadline3`` or ``pyreadline`` package. Make sure to include the following
+``pyreadline3`` package. Make sure to include the following
 in your ``setup.py``::
 
   install_requires=[
     'cmd2>=1,<2',
-    ":sys_platform=='win32'": [
-        "pyreadline ; python_version<'3.8'",
-        "pyreadline3 ; python_version>='3.8'",  # pyreadline3 is a drop-in replacement for Python 3.8 and above
-    ],
+    ":sys_platform=='win32'": ['pyreadline3'],
   ]

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,8 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    # Windows also requires pyreadline or the replacement, pyreadline3, to ensure tab completion works
-    ":sys_platform=='win32' and python_version<'3.8'": ["pyreadline"],
-    ":sys_platform=='win32' and python_version>='3.8'": ["pyreadline3"],
+    # Windows also requires pyreadline3 to ensure tab completion works
+    ":sys_platform=='win32'": ['pyreadline3'],
     # Extra dependencies for running unit tests
     'test': [
         "gnureadline; sys_platform=='darwin'",  # include gnureadline on macOS to ensure it is available in nox env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,21 +21,12 @@ from pytest import (
 )
 
 import cmd2
+from cmd2.rl_utils import (
+    readline,
+)
 from cmd2.utils import (
     StdSim,
 )
-
-# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
-try:
-    import gnureadline as readline
-except ImportError:
-    # Try to import readline, but allow failure for convenience in Windows unit testing
-    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
-    try:
-        # noinspection PyUnresolvedReferences
-        import readline
-    except ImportError:
-        pass
 
 
 def verify_help_text(

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -16,18 +16,6 @@ from .conftest import (
     run_cmd,
 )
 
-# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
-try:
-    import gnureadline as readline
-except ImportError:
-    # Try to import readline, but allow failure for convenience in Windows unit testing
-    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
-    try:
-        # noinspection PyUnresolvedReferences
-        import readline
-    except ImportError:
-        pass
-
 
 class ArgparseApp(cmd2.Cmd):
     def __init__(self):

--- a/tests_isolated/test_commandset/conftest.py
+++ b/tests_isolated/test_commandset/conftest.py
@@ -24,21 +24,12 @@ from pytest import (
 )
 
 import cmd2
+from cmd2.rl_utils import (
+    readline,
+)
 from cmd2.utils import (
     StdSim,
 )
-
-# Prefer statically linked gnureadline if available (for macOS compatibility due to issues with libedit)
-try:
-    import gnureadline as readline
-except ImportError:
-    # Try to import readline, but allow failure for convenience in Windows unit testing
-    # Note: If this actually fails, you should install readline on Linux or Mac or pyreadline on Windows
-    try:
-        # noinspection PyUnresolvedReferences
-        import readline
-    except ImportError:
-        pass
 
 
 def verify_help_text(


### PR DESCRIPTION
- cmd2 now uses pyreadline3 when running any version of Python on Windows
- Improved some readline-related comments