### PR TITLE
Fixed duplicate subparser name in test_add_parser_custom_completer

### DIFF
--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -1371,5 +1371,5 @@ def test_add_parser_custom_completer():
     no_custom_completer_parser = subparsers.add_parser(name="no_custom_completer")
     assert no_custom_completer_parser.get_ap_completer_type() is None  # type: ignore[attr-defined]
 
-    custom_completer_parser = subparsers.add_parser(name="no_custom_completer", ap_completer_type=CustomCompleter)
+    custom_completer_parser = subparsers.add_parser(name="custom_completer", ap_completer_type=CustomCompleter)
     assert custom_completer_parser.get_ap_completer_type() is CustomCompleter  # type: ignore[attr-defined]


### PR DESCRIPTION
If I'm not mistaken, the use of the same name for both subparsers was
not intentional but a typo.  In Python 3.11, this is an error and causes
the test to fail.

Fixes #1228