### PR TITLE
Fix YAML indentation error in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
       interval: "weekly"
 
 - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
+  directory: "/"
+  schedule:
       interval: "weekly"


### PR DESCRIPTION
Fix YAML indentation error in dependabot.yml which caused pip dependency scanning to not run