### PR TITLE
Use latest version of mypy and fix type hinting accordingly

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,6 @@ gnureadline = {version = "*",sys_platform = "== 'darwin'"}
 invoke = "*"
 ipython = "*"
 isort = "*"
-mock = {version = "*",markers = "python_version < '3.6'"}
 mypy = "*"
 pyreadline3 = {version = ">=3.4",sys_platform = "== 'win32'"}
 pytest = "*"

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 [![Latest Version](https://img.shields.io/pypi/v/cmd2.svg?style=flat-square&label=latest%20stable%20version)](https://pypi.python.org/pypi/cmd2/)
 [![GitHub Actions](https://github.com/python-cmd2/cmd2/workflows/CI/badge.svg)](https://github.com/python-cmd2/cmd2/actions?query=workflow%3ACI)
-[![Azure Build status](https://python-cmd2.visualstudio.com/cmd2/_apis/build/status/python-cmd2.cmd2?branch=master)](https://python-cmd2.visualstudio.com/cmd2/_build/latest?definitionId=1&branch=master)
 [![codecov](https://codecov.io/gh/python-cmd2/cmd2/branch/master/graph/badge.svg)](https://codecov.io/gh/python-cmd2/cmd2)
 [![Documentation Status](https://readthedocs.org/projects/cmd2/badge/?version=latest)](http://cmd2.readthedocs.io/en/latest/?badge=latest)
 <a href="https://discord.gg/RpVG6tk"><img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg" alt="Chat"></a>
 
 
 <p align="center">
-  <a href="#main-features">Main Features</a> •
+  <a href="#the-developers-toolbox">Develper's Toolbox</a> •
+  <a href="#philosophy">Philosophy</a> •
   <a href="#installation">Installation</a> •
+  <a href="#documentation">Documentation</a> •
   <a href="#tutorials">Tutorials</a> •
+  <a href="#hello-world">Hello World</a> •
   <a href="#projects-using-cmd2">Projects using cmd2</a> •
-  <a href="#version-two-notes">Version 2.0 Notes</a>
 </p>
 
 [![Screenshot](https://raw.githubusercontent.com/python-cmd2/cmd2/master/cmd2.png)](https://youtu.be/DDU_JH6cFsA)

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1033,7 +1033,7 @@ setattr(argparse.ArgumentParser, '_check_value', _ArgumentParser_check_value)
 ############################################################################################################
 
 # noinspection PyPep8Naming,PyProtectedMember
-def _SubParsersAction_remove_parser(self: argparse._SubParsersAction, name: str) -> None:
+def _SubParsersAction_remove_parser(self: Any, name: str) -> None:
     """
     Removes a sub-parser from a sub-parsers group. Used to remove subcommands from a parser.
 
@@ -1333,7 +1333,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         self.set_ap_completer_type(ap_completer_type)  # type: ignore[attr-defined]
 
     # noinspection PyProtectedMember
-    def add_subparsers(self, **kwargs: Any) -> argparse._SubParsersAction:
+    def add_subparsers(self, **kwargs: Any) -> Any:
         """
         Custom override. Sets a default title if one was not given.
 

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1033,7 +1033,7 @@ setattr(argparse.ArgumentParser, '_check_value', _ArgumentParser_check_value)
 ############################################################################################################
 
 # noinspection PyPep8Naming,PyProtectedMember
-def _SubParsersAction_remove_parser(self: Any, name: str) -> None:
+def _SubParsersAction_remove_parser(self: argparse._SubParsersAction, name: str) -> None:  # type: ignore
     """
     Removes a sub-parser from a sub-parsers group. Used to remove subcommands from a parser.
 
@@ -1333,7 +1333,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         self.set_ap_completer_type(ap_completer_type)  # type: ignore[attr-defined]
 
     # noinspection PyProtectedMember
-    def add_subparsers(self, **kwargs: Any) -> Any:
+    def add_subparsers(self, **kwargs: Any) -> argparse._SubParsersAction:  # type: ignore
         """
         Custom override. Sets a default title if one was not given.
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -4426,7 +4426,7 @@ class Cmd(cmd.Cmd):
                 local_vars['self'] = self
 
             # Configure IPython
-            config = TraitletsLoader.Config()
+            config = TraitletsLoader.Config()  # type: ignore
             config.InteractiveShell.banner2 = (
                 'Entering an IPython shell. Type exit, quit, or Ctrl-D to exit.\n'
                 f'Run CLI commands with: {self.py_bridge_name}("command ...")\n'
@@ -5256,7 +5256,7 @@ class Cmd(cmd.Cmd):
         import signal
 
         original_sigint_handler = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, self.sigint_handler)
+        signal.signal(signal.SIGINT, self.sigint_handler)  # type: ignore
 
         # Grab terminal lock before the command line prompt has been drawn by readline
         self.terminal_lock.acquire()

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -16,7 +16,6 @@ from enum import (
     Enum,
 )
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -37,15 +36,6 @@ from .argparse_custom import (
     ChoicesProviderFunc,
     CompleterFunc,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    import cmd2  # noqa: F401
-
-    PopenTextIO = subprocess.Popen[bytes]
-
-else:
-    PopenTextIO = subprocess.Popen
-
 
 _T = TypeVar('_T')
 
@@ -588,7 +578,7 @@ class ProcReader:
     If neither are pipes, then the process will run normally and no output will be captured.
     """
 
-    def __init__(self, proc: PopenTextIO, stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
+    def __init__(self, proc: subprocess.Popen[str], stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
         """
         ProcReader initializer
         :param proc: the Popen process being read from
@@ -670,12 +660,15 @@ class ProcReader:
                 self._write_bytes(write_stream, available)
 
     @staticmethod
-    def _write_bytes(stream: Union[StdSim, TextIO], to_write: bytes) -> None:
+    def _write_bytes(stream: Union[StdSim, TextIO], to_write: Union[bytes, str]) -> None:
         """
         Write bytes to a stream
         :param stream: the stream being written to
         :param to_write: the bytes being written
         """
+        if isinstance(to_write, str):
+            to_write = to_write.encode()
+
         try:
             stream.buffer.write(to_write)
         except BrokenPipeError:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -16,6 +16,7 @@ from enum import (
     Enum,
 )
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -36,6 +37,13 @@ from .argparse_custom import (
     ChoicesProviderFunc,
     CompleterFunc,
 )
+
+if TYPE_CHECKING:  # pragma: no cover
+    import cmd2  # noqa: F401
+
+    PopenTextIO = subprocess.Popen[str]
+else:
+    PopenTextIO = subprocess.Popen
 
 _T = TypeVar('_T')
 
@@ -578,7 +586,7 @@ class ProcReader:
     If neither are pipes, then the process will run normally and no output will be captured.
     """
 
-    def __init__(self, proc: subprocess.Popen[str], stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
+    def __init__(self, proc: PopenTextIO, stdout: Union[StdSim, TextIO], stderr: Union[StdSim, TextIO]) -> None:
         """
         ProcReader initializer
         :param proc: the Popen process being read from

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ EXTRAS_REQUIRE = {
         'doc8',
         'flake8',
         'invoke',
-        'mypy==0.902',
+        'mypy',
         'nox',
         "pytest>=4.6",
         'pytest-cov',
@@ -80,7 +80,7 @@ EXTRAS_REQUIRE = {
     ],
     'validate': [
         'flake8',
-        'mypy==0.902',
+        'mypy',
         'types-pkg-resources',
     ],
 }

--- a/tasks.py
+++ b/tasks.py
@@ -353,3 +353,14 @@ def flake8(context):
 
 
 namespace.add_task(flake8)
+
+
+# Black and isort auto-formatting
+@invoke.task()
+def format(context):
+    """Run black and isort auto-formatting for code style enforcement"""
+    with context.cd(TASK_ROOT_STR):
+        context.run("black . && isort .")
+
+
+namespace.add_task(format)


### PR DESCRIPTION
Use latest version of mypy and fix type hinting accordingly

Also:
- Update Pipfile to never require mock since we only support Python 3.6+
- Remove Azure Pipelines badge from Readme and fix section links there
- Added an "inv format" task to run black and isort to auto-format all code before a commit