### PR TITLE
[WIP] Start deprecation of Python 3.6

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,8 +46,8 @@ The tables below list all prerequisites along with the minimum required version 
 #### Prerequisites to run cmd2 applications
 
 | Prerequisite                                        | Minimum Version |
-| --------------------------------------------------- | --------------- |
-| [python](https://www.python.org/downloads/)         | `3.6`           |
+| --------------------------------------------------- |-----------------|
+| [python](https://www.python.org/downloads/)         | `3.7`           |
 | [attrs](https://github.com/python-attrs/attrs)      | `16.3`          |
 | [pyperclip](https://github.com/asweigart/pyperclip) | `1.6`           |
 | [setuptools](https://pypi.org/project/setuptools/)  | `34.4`          |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0 (TBD)
+* Breaking Change
+  * `cmd2` 2.5 supports Python 3.7+ (removed support for Python 3.6)
+
 ## 2.4.3 (January 27, 2023)
 * Bug Fixes
   * Fixed ValueError caused when passing `Cmd.columnize()` strings wider than `display_width`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On all operating systems, the latest stable version of `cmd2` can be installed u
 pip install -U cmd2
 ```
 
-cmd2 works with Python 3.6+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
+cmd2 works with Python 3.7+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
 
 For information on other installation options, see
 [Installation Instructions](https://cmd2.readthedocs.io/en/latest/overview/installation.html) in the cmd2

--- a/docs/features/transcripts.rst
+++ b/docs/features/transcripts.rst
@@ -127,8 +127,8 @@ If your output has slashes in it, you will need to escape those slashes so the
 stuff between them is not interpred as a regular expression. In this
 transcript::
 
-   (Cmd) say cd /usr/local/lib/python3.6/site-packages
-   /usr/local/lib/python3.6/site-packages
+   (Cmd) say cd /usr/local/lib/python3.11/site-packages
+   /usr/local/lib/python3.11/site-packages
 
 the output contains slashes. The text between the first slash and the second
 slash, will be interpreted as a regular expression, and those two slashes will
@@ -136,8 +136,8 @@ not be included in the comparison. When replayed, this transcript would
 therefore fail. To fix it, we could either write a regular expression to match
 the path instead of specifying it verbatim, or we can escape the slashes::
 
-   (Cmd) say cd /usr/local/lib/python3.6/site-packages
-   \/usr\/local\/lib\/python3.6\/site-packages
+   (Cmd) say cd /usr/local/lib/python3.11/site-packages
+   \/usr\/local\/lib\/python3.11\/site-packages
 
 .. warning::
 

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -7,7 +7,7 @@ Installation Instructions
 .. _setuptools: https://pypi.org/project/setuptools
 .. _PyPI: https://pypi.org
 
-``cmd2`` works on Linux, macOS, and Windows. It requires Python 3.6 or
+``cmd2`` works on Linux, macOS, and Windows. It requires Python 3.7 or
 higher, pip_, and setuptools_. If you've got all that, then you can just:
 
 .. code-block:: shell
@@ -30,7 +30,7 @@ higher, pip_, and setuptools_. If you've got all that, then you can just:
 Prerequisites
 -------------
 
-If you have Python 3 >=3.6 installed from `python.org
+If you have Python 3 >=3.7 installed from `python.org
 <https://www.python.org>`_, you will already have pip_ and setuptools_, but may
 need to upgrade to the latest versions:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=['3.10'])
+@nox.session(python=['3.11'])
 def docs(session):
     session.install(
         'sphinx',
@@ -41,7 +41,7 @@ def tests(session, plugin):
         )
 
 
-@nox.session(python=['3.8', '3.9', '3.10'])
+@nox.session(python=['3.8', '3.9', '3.10', '3.11'])
 @nox.parametrize('step', ['mypy', 'flake8'])
 def validate(session, step):
     session.install('invoke', './[validate]')

--- a/plugins/ext_test/build-pyenvs.sh
+++ b/plugins/ext_test/build-pyenvs.sh
@@ -23,7 +23,7 @@
 # virtualenvs will be added to '.python-version'. Feel free to modify
 # this list, but note that this script intentionally won't install
 # dev, rc, or beta python releases
-declare -a pythons=("3.7" "3.6" "3.8" "3.9")
+declare -a pythons=("3.7" "3.8" "3.9", "3.10", "3.11")
 
 # function to find the latest patch of a minor version of python
 function find_latest_version {

--- a/plugins/ext_test/noxfile.py
+++ b/plugins/ext_test/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
+@nox.session(python=['3.7', '3.8', '3.9', '3.10', '3.11'])
 def tests(session):
     session.install('invoke', './[test]')
     session.run('invoke', 'pytest', '--junit', '--no-pty')

--- a/plugins/ext_test/setup.py
+++ b/plugins/ext_test/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     license='MIT',
     package_data=PACKAGE_DATA,
     packages=['cmd2_ext_test'],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=['cmd2 >= 2, <3'],
     setup_requires=['setuptools >= 42', 'setuptools_scm >= 3.4'],
     classifiers=[
@@ -43,11 +43,11 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     # dependencies for development and testing
     # $ pip install -e .[dev]

--- a/plugins/template/README.md
+++ b/plugins/template/README.md
@@ -233,8 +233,6 @@ If you prefer to create these virtualenvs by hand, do the following:
 $ cd cmd2_abbrev
 $ pyenv install 3.7.0
 $ pyenv virtualenv -p python3.7 3.7.0 cmd2-3.7
-$ pyenv install 3.6.5
-$ pyenv virtualenv -p python3.6 3.6.5 cmd2-3.6
 $ pyenv install 3.8.5
 $ pyenv virtualenv -p python3.8 3.8.5 cmd2-3.8
 $ pyenv install 3.9.0
@@ -243,7 +241,7 @@ $ pyenv virtualenv -p python3.9 3.9.0 cmd2-3.9
 
 Now set pyenv to make all three of those available at the same time:
 ```
-$ pyenv local cmd2-3.7 cmd2-3.6 cmd2-3.8 cmd2-3.9
+$ pyenv local cmd2-3.7 cmd2-3.8 cmd2-3.9
 ```
 
 Whether you ran the script, or did it by hand, you now have isolated virtualenvs
@@ -253,16 +251,10 @@ utilize.
 
 | Command     | python | virtualenv |
 | ----------- | ------ | ---------- |
-| `python`    | 3.7.0  | cmd2-3.6   |
-| `python3`   | 3.7.0  | cmd2-3.6   |
 | `python3.7` | 3.7.0  | cmd2-3.7   |
-| `python3.6` | 3.6.5  | cmd2-3.6   |
 | `python3.8` | 3.8.5  | cmd2-3.8   |
 | `python3.9` | 3.9.0  | cmd2-3.9   |
-| `pip`       | 3.7.0  | cmd2-3.6   |
-| `pip3`      | 3.7.0  | cmd2-3.6   |
 | `pip3.7`    | 3.7.0  | cmd2-3.7   |
-| `pip3.6`    | 3.6.5  | cmd2-3.6   |
 | `pip3.8`    | 3.8.5  | cmd2-3.8   |
 | `pip3.9`    | 3.9.0  | cmd2-3.9   |
 

--- a/plugins/template/setup.py
+++ b/plugins/template/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     url='https://github.com/python-cmd2/cmd2-plugin-template',
     license='MIT',
     packages=['cmd2_myplugin'],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=['cmd2 >= 2, <3'],
     setup_requires=['setuptools_scm'],
     classifiers=[
@@ -34,7 +34,6 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ Intended Audience :: System Administrators
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines(),
@@ -104,7 +104,7 @@ setup(
     package_data=PACKAGE_DATA,
     packages=['cmd2'],
     keywords='command prompt console cmd',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     setup_requires=SETUP_REQUIRES,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
This is a WIP PR intended to remove support for Python 3.6 and make sure support for Python 3.11 is solid.

Remaining work to be done includes:
- Replace use of `attrs` with data classes and remove dependency on `attrs`
- Revisit type hinting to make sure we are following best practices
- Make sure all CI stuff is passing on all OSes and versions supported