### PR TITLE
Fix Nonetype error when building with PyInstaller and no-console flag.

### DIFF
--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -70,42 +70,43 @@ if 'pyreadline3' in sys.modules:
     )
 
     # Check if we are running in a terminal
-    if sys.stdout.isatty():  # pragma: no cover
-        # noinspection PyPep8Naming,PyUnresolvedReferences
-        def enable_win_vt100(handle: HANDLE) -> bool:
-            """
-            Enables VT100 character sequences in a Windows console
-            This only works on Windows 10 and up
-            :param handle: the handle on which to enable vt100
-            :return: True if vt100 characters are enabled for the handle
-            """
-            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+    if sys.stdout:
+        if sys.stdout.isatty():  # pragma: no cover
+            # noinspection PyPep8Naming,PyUnresolvedReferences
+            def enable_win_vt100(handle: HANDLE) -> bool:
+                """
+                Enables VT100 character sequences in a Windows console
+                This only works on Windows 10 and up
+                :param handle: the handle on which to enable vt100
+                :return: True if vt100 characters are enabled for the handle
+                """
+                ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 
-            # Get the current mode for this handle in the console
-            cur_mode = DWORD(0)
-            readline.rl.console.GetConsoleMode(handle, byref(cur_mode))
+                # Get the current mode for this handle in the console
+                cur_mode = DWORD(0)
+                readline.rl.console.GetConsoleMode(handle, byref(cur_mode))
 
-            retVal = False
+                retVal = False
 
-            # Check if ENABLE_VIRTUAL_TERMINAL_PROCESSING is already enabled
-            if (cur_mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0:
-                retVal = True
+                # Check if ENABLE_VIRTUAL_TERMINAL_PROCESSING is already enabled
+                if (cur_mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0:
+                    retVal = True
 
-            elif readline.rl.console.SetConsoleMode(handle, cur_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING):
-                # Restore the original mode when we exit
-                atexit.register(readline.rl.console.SetConsoleMode, handle, cur_mode)
-                retVal = True
+                elif readline.rl.console.SetConsoleMode(handle, cur_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING):
+                    # Restore the original mode when we exit
+                    atexit.register(readline.rl.console.SetConsoleMode, handle, cur_mode)
+                    retVal = True
 
-            return retVal
+                return retVal
 
-        # Enable VT100 sequences for stdout and stderr
-        STD_OUT_HANDLE = -11
-        STD_ERROR_HANDLE = -12
-        # noinspection PyUnresolvedReferences
-        vt100_stdout_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_OUT_HANDLE))
-        # noinspection PyUnresolvedReferences
-        vt100_stderr_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_ERROR_HANDLE))
-        vt100_support = vt100_stdout_support and vt100_stderr_support
+            # Enable VT100 sequences for stdout and stderr
+            STD_OUT_HANDLE = -11
+            STD_ERROR_HANDLE = -12
+            # noinspection PyUnresolvedReferences
+            vt100_stdout_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_OUT_HANDLE))
+            # noinspection PyUnresolvedReferences
+            vt100_stderr_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_ERROR_HANDLE))
+            vt100_support = vt100_stdout_support and vt100_stderr_support
 
     ############################################################################################################
     # pyreadline3 is incomplete in terms of the Python readline API. Add the missing functions we need.

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -70,43 +70,42 @@ if 'pyreadline3' in sys.modules:
     )
 
     # Check if we are running in a terminal
-    if sys.stdout:
-        if sys.stdout.isatty():  # pragma: no cover
-            # noinspection PyPep8Naming,PyUnresolvedReferences
-            def enable_win_vt100(handle: HANDLE) -> bool:
-                """
-                Enables VT100 character sequences in a Windows console
-                This only works on Windows 10 and up
-                :param handle: the handle on which to enable vt100
-                :return: True if vt100 characters are enabled for the handle
-                """
-                ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+    if sys.stdout and sys.stdout.isatty():  # pragma: no cover
+        # noinspection PyPep8Naming,PyUnresolvedReferences
+        def enable_win_vt100(handle: HANDLE) -> bool:
+            """
+            Enables VT100 character sequences in a Windows console
+            This only works on Windows 10 and up
+            :param handle: the handle on which to enable vt100
+            :return: True if vt100 characters are enabled for the handle
+            """
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 
-                # Get the current mode for this handle in the console
-                cur_mode = DWORD(0)
-                readline.rl.console.GetConsoleMode(handle, byref(cur_mode))
+            # Get the current mode for this handle in the console
+            cur_mode = DWORD(0)
+            readline.rl.console.GetConsoleMode(handle, byref(cur_mode))
 
-                retVal = False
+            retVal = False
 
-                # Check if ENABLE_VIRTUAL_TERMINAL_PROCESSING is already enabled
-                if (cur_mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0:
-                    retVal = True
+            # Check if ENABLE_VIRTUAL_TERMINAL_PROCESSING is already enabled
+            if (cur_mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0:
+                retVal = True
 
-                elif readline.rl.console.SetConsoleMode(handle, cur_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING):
-                    # Restore the original mode when we exit
-                    atexit.register(readline.rl.console.SetConsoleMode, handle, cur_mode)
-                    retVal = True
+            elif readline.rl.console.SetConsoleMode(handle, cur_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING):
+                # Restore the original mode when we exit
+                atexit.register(readline.rl.console.SetConsoleMode, handle, cur_mode)
+                retVal = True
 
-                return retVal
+            return retVal
 
-            # Enable VT100 sequences for stdout and stderr
-            STD_OUT_HANDLE = -11
-            STD_ERROR_HANDLE = -12
-            # noinspection PyUnresolvedReferences
-            vt100_stdout_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_OUT_HANDLE))
-            # noinspection PyUnresolvedReferences
-            vt100_stderr_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_ERROR_HANDLE))
-            vt100_support = vt100_stdout_support and vt100_stderr_support
+        # Enable VT100 sequences for stdout and stderr
+        STD_OUT_HANDLE = -11
+        STD_ERROR_HANDLE = -12
+        # noinspection PyUnresolvedReferences
+        vt100_stdout_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_OUT_HANDLE))
+        # noinspection PyUnresolvedReferences
+        vt100_stderr_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_ERROR_HANDLE))
+        vt100_support = vt100_stdout_support and vt100_stderr_support
 
     ############################################################################################################
     # pyreadline3 is incomplete in terms of the Python readline API. Add the missing functions we need.

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -70,7 +70,7 @@ if 'pyreadline3' in sys.modules:
     )
 
     # Check if we are running in a terminal
-    if sys.stdout and sys.stdout.isatty():  # pragma: no cover
+    if sys.stdout is not None and sys.stdout.isatty():  # pragma: no cover
         # noinspection PyPep8Naming,PyUnresolvedReferences
         def enable_win_vt100(handle: HANDLE) -> bool:
             """


### PR DESCRIPTION
If building a PyInstaller application with the `--noconsole` option and if any library imports `cmd2`, the application will fail with the following traceback:

```
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    import cmd2
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "cmd2\__init__.py", line 53, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "cmd2\cmd2.py", line 125, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "cmd2\rl_utils.py", line 73, in <module>
AttributeError: 'NoneType' object has no attribute 'isatty'
```
The error can be replicated using the following code and building with `pyinstaller -F --distpath . --noconsole test.py`:
```
# test.py
import cmd2
from tkinter import *

root = Tk()
a = Label(root, text ="Hello World")
a.pack()
root.mainloop()
```
This was tested and reproduced using Windows 11, `Python 3.10.4`, and `cmd2 2.4.3`. 

This simple fix checks if `sys.stdout` is `None` before checking for `sys.stdout.isatty()`. 