### PR TITLE
Suggest most simillar command

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -547,7 +547,7 @@ class Cmd(cmd.Cmd):
         return [
             cmdset
             for cmdset in self._installed_command_sets
-            if type(cmdset) == commandset_type or (subclass_match and isinstance(cmdset, commandset_type))
+            if type(cmdset) == commandset_type or (subclass_match and isinstance(cmdset, commandset_type))  # noqa: E721
         ]
 
     def find_commandset_for_command(self, command_name: str) -> Optional[CommandSet]:
@@ -5551,7 +5551,7 @@ class Cmd(cmd.Cmd):
                 func_self = None
                 candidate_sets: List[CommandSet] = []
                 for installed_cmd_set in self._installed_command_sets:
-                    if type(installed_cmd_set) == func_class:
+                    if type(installed_cmd_set) == func_class:  # noqa: E721
                         # Case 2: CommandSet is an exact type match for the function's CommandSet
                         func_self = installed_cmd_set
                         break

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -1274,8 +1274,9 @@ def similarity_function(s1: str, s2: str) -> float:
 MIN_SIMIL_TO_CONSIDER = 0.7
 
 
-def suggest_similar(requested_command: str, options: Iterable[str],
-                    similarity_function_to_use: Optional[Callable[[str, str], float]] = None) -> Optional[str]:
+def suggest_similar(
+        requested_command: str, options: Iterable[str], similarity_function_to_use: Optional[Callable[[str, str], float]] = None
+) -> Optional[str]:
     """
     Given a requested command and an iterable of possible options
     returns the most similar (if any is similar)

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -1275,7 +1275,7 @@ MIN_SIMIL_TO_CONSIDER = 0.7
 
 
 def suggest_similar(
-        requested_command: str, options: Iterable[str], similarity_function_to_use: Optional[Callable[[str, str], float]] = None
+    requested_command: str, options: Iterable[str], similarity_function_to_use: Optional[Callable[[str, str], float]] = None
 ) -> Optional[str]:
     """
     Given a requested command and an iterable of possible options
@@ -1285,7 +1285,6 @@ def suggest_similar(
     :param options: The list of avaiable commands to search for the most similar
     :param similarity_function_to_use: An optional callable to use to compare commands
     :returns The most similar command or None if no one is similar
-
     """
     proposed_command = None
     best_simil = MIN_SIMIL_TO_CONSIDER

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -12,7 +12,9 @@ import subprocess
 import sys
 import threading
 import unicodedata
-from difflib import SequenceMatcher
+from difflib import (
+    SequenceMatcher,
+)
 from enum import (
     Enum,
 )
@@ -1278,14 +1280,14 @@ def suggest_similar(
     requested_command: str, options: Iterable[str], similarity_function_to_use: Optional[Callable[[str, str], float]] = None
 ) -> Optional[str]:
     """
-    Given a requested command and an iterable of possible options
-    returns the most similar (if any is similar)
+    Given a requested command and an iterable of possible options returns the most similar (if any is similar)
 
     :param requested_command: The command entered by the user
-    :param options: The list of avaiable commands to search for the most similar
+    :param options: The list of available commands to search for the most similar
     :param similarity_function_to_use: An optional callable to use to compare commands
-    :returns The most similar command or None if no one is similar
+    :return: The most similar command or None if no one is similar
     """
+
     proposed_command = None
     best_simil = MIN_SIMIL_TO_CONSIDER
     requested_command_to_compare = requested_command.lower()

--- a/docs/api/cmd.rst
+++ b/docs/api/cmd.rst
@@ -72,3 +72,9 @@ cmd2.Cmd
         the operating system pasteboard. If ``False``, this capability will not
         be allowed. See :ref:`features/clipboard:Clipboard Integration` for more
         information.
+
+    .. attribute:: suggest_similar_command
+
+        If ``True``, ``cmd2`` will suggest the most similar command when the user
+        types a command that does not exist.
+        Default: ``False``.

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -97,3 +97,5 @@ Miscellaneous
 .. autofunction:: cmd2.utils.alphabetical_sort
 
 .. autofunction:: cmd2.utils.natural_sort
+
+.. autofunction:: cmd2.utils.suggest_similar

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -99,3 +99,4 @@ Miscellaneous
 .. autofunction:: cmd2.utils.natural_sort
 
 .. autofunction:: cmd2.utils.suggest_similar
+

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -323,6 +323,16 @@ def test_base_error(base_app):
     assert "is not a recognized command" in err[0]
 
 
+def test_base_error_suggest_command(base_app):
+    try:
+        old_suggest_similar_command = base_app.suggest_similar_command
+        base_app.suggest_similar_command = True
+        out, err = run_cmd(base_app, 'historic')
+        assert "history" in err[0]
+    finally:
+        base_app.suggest_similar_command = old_suggest_similar_command
+
+
 def test_run_script(base_app, request):
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'script.txt')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -872,3 +872,37 @@ def test_find_editor_not_specified():
     with mock.patch.dict(os.environ, {'PATH': 'fake_dir'}, clear=True):
         editor = cu.find_editor()
     assert editor is None
+
+
+def test_similarity():
+    suggested_command = cu.suggest_similar("comand", ["command", "UNRELATED", "NOT_SIMILAR"])
+    assert suggested_command == "command"
+    suggested_command = cu.suggest_similar("command", ["COMMAND", "acommands"])
+    assert suggested_command == "COMMAND"
+
+
+def test_similarity_without_good_canididates():
+    suggested_command = cu.suggest_similar("comand", ["UNRELATED", "NOT_SIMILAR"])
+    assert suggested_command is None
+    suggested_command = cu.suggest_similar("comand", [])
+    assert suggested_command is None
+
+
+def test_similarity_overwrite_function():
+    suggested_command = cu.suggest_similar("test", ["history", "test"])
+    assert suggested_command == 'test'
+
+    def custom_similarity_function(s1, s2):
+        return 1.0 if 'history' in (s1, s2) else 0.0
+
+    suggested_command = cu.suggest_similar("test", ["history", "test"],
+                                           similarity_function_to_use=custom_similarity_function)
+    assert suggested_command == 'history'
+
+    suggested_command = cu.suggest_similar("history", ["history", "test"],
+                                           similarity_function_to_use=custom_similarity_function)
+    assert suggested_command == 'history'
+
+    suggested_command = cu.suggest_similar("test", ["test"],
+                                           similarity_function_to_use=custom_similarity_function)
+    assert suggested_command is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -889,20 +889,18 @@ def test_similarity_without_good_canididates():
 
 
 def test_similarity_overwrite_function():
-    suggested_command = cu.suggest_similar("test", ["history", "test"])
+    options = ["history", "test"]
+    suggested_command = cu.suggest_similar("test", options)
     assert suggested_command == 'test'
 
     def custom_similarity_function(s1, s2):
         return 1.0 if 'history' in (s1, s2) else 0.0
 
-    suggested_command = cu.suggest_similar("test", ["history", "test"],
-                                           similarity_function_to_use=custom_similarity_function)
+    suggested_command = cu.suggest_similar("test", options, similarity_function_to_use=custom_similarity_function)
     assert suggested_command == 'history'
 
-    suggested_command = cu.suggest_similar("history", ["history", "test"],
-                                           similarity_function_to_use=custom_similarity_function)
+    suggested_command = cu.suggest_similar("history", options, similarity_function_to_use=custom_similarity_function)
     assert suggested_command == 'history'
 
-    suggested_command = cu.suggest_similar("test", ["test"],
-                                           similarity_function_to_use=custom_similarity_function)
+    suggested_command = cu.suggest_similar("test", ["test"], similarity_function_to_use=custom_similarity_function)
     assert suggested_command is None


### PR DESCRIPTION
closes #1271 
The app can be configured to suggest the most similar command. In that case, the most similar command of the visible commands (more similar than a threshold) will be suggested and added to the default error message.

By default SequenceMatcher.ratio() from the standard library is used but a subclass can define _suggest_similar_command with a new algorithm.