### PR TITLE
Removed 'noinspection' comments since they are PyCharm-specific.

### DIFF
--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -224,7 +224,6 @@ class BgColor(AnsiSequence):
 ####################################################################################
 # Implementations intended for direct use
 ####################################################################################
-# noinspection PyPep8Naming
 class Cursor:
     """Create ANSI sequences to alter the cursor position"""
 

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -61,7 +61,6 @@ DEFAULT_DESCRIPTIVE_HEADER = 'Description'
 ARG_TOKENS = 'arg_tokens'
 
 
-# noinspection PyProtectedMember
 def _build_hint(parser: argparse.ArgumentParser, arg_action: argparse.Action) -> str:
     """Build tab completion hint for a given argument"""
     # Check if hinting is disabled for this argument
@@ -82,7 +81,6 @@ def _single_prefix_char(token: str, parser: argparse.ArgumentParser) -> bool:
     return len(token) == 1 and token[0] in parser.prefix_chars
 
 
-# noinspection PyProtectedMember
 def _looks_like_flag(token: str, parser: argparse.ArgumentParser) -> bool:
     """
     Determine if a token looks like a flag. Unless an argument has nargs set to argparse.REMAINDER,
@@ -144,7 +142,6 @@ class _ArgumentState:
             self.max = self.action.nargs
 
 
-# noinspection PyProtectedMember
 class _UnfinishedFlagError(CompletionError):
     def __init__(self, flag_arg_state: _ArgumentState) -> None:
         """
@@ -171,7 +168,6 @@ class _NoResultsError(CompletionError):
         super().__init__(_build_hint(parser, arg_action), apply_style=False)
 
 
-# noinspection PyProtectedMember
 class ArgparseCompleter:
     """Automatic command line tab completion based on argparse parameters"""
 

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -237,8 +237,6 @@ sub-parser from a sub-parsers group. See
 import argparse
 import re
 import sys
-
-# noinspection PyUnresolvedReferences,PyProtectedMember
 from argparse import (
     ONE_OR_MORE,
     ZERO_OR_MORE,
@@ -307,7 +305,6 @@ class CompletionItem(str):
     def __new__(cls, value: object, *args: Any, **kwargs: Any) -> 'CompletionItem':
         return super(CompletionItem, cls).__new__(cls, value)
 
-    # noinspection PyUnusedLocal
     def __init__(self, value: object, description: str = '', *args: Any) -> None:
         """
         CompletionItem Initializer
@@ -731,11 +728,9 @@ def register_argparse_argument_parameter(param_name: str, param_type: Optional[T
 
 
 # Save original _ActionsContainer.add_argument so we can call it in our wrapper
-# noinspection PyProtectedMember
 orig_actions_container_add_argument = argparse._ActionsContainer.add_argument
 
 
-# noinspection PyProtectedMember
 def _add_argument_wrapper(
     self: argparse._ActionsContainer,
     *args: Any,
@@ -870,7 +865,6 @@ def _add_argument_wrapper(
 
 
 # Overwrite _ActionsContainer.add_argument with our wrapper
-# noinspection PyProtectedMember
 setattr(argparse._ActionsContainer, 'add_argument', _add_argument_wrapper)
 
 ############################################################################################################
@@ -878,11 +872,9 @@ setattr(argparse._ActionsContainer, 'add_argument', _add_argument_wrapper)
 ############################################################################################################
 
 # Save original ArgumentParser._get_nargs_pattern so we can call it in our wrapper
-# noinspection PyProtectedMember
 orig_argument_parser_get_nargs_pattern = argparse.ArgumentParser._get_nargs_pattern
 
 
-# noinspection PyProtectedMember
 def _get_nargs_pattern_wrapper(self: argparse.ArgumentParser, action: argparse.Action) -> str:
     # Wrapper around ArgumentParser._get_nargs_pattern behavior to support nargs ranges
     nargs_range = action.get_nargs_range()  # type: ignore[attr-defined]
@@ -904,18 +896,15 @@ def _get_nargs_pattern_wrapper(self: argparse.ArgumentParser, action: argparse.A
 
 
 # Overwrite ArgumentParser._get_nargs_pattern with our wrapper
-# noinspection PyProtectedMember
 setattr(argparse.ArgumentParser, '_get_nargs_pattern', _get_nargs_pattern_wrapper)
 
 
 ############################################################################################################
 # Patch ArgumentParser._match_argument with our wrapper to support nargs ranges
 ############################################################################################################
-# noinspection PyProtectedMember
 orig_argument_parser_match_argument = argparse.ArgumentParser._match_argument
 
 
-# noinspection PyProtectedMember
 def _match_argument_wrapper(self: argparse.ArgumentParser, action: argparse.Action, arg_strings_pattern: str) -> int:
     # Wrapper around ArgumentParser._match_argument behavior to support nargs ranges
     nargs_pattern = self._get_nargs_pattern(action)
@@ -931,7 +920,6 @@ def _match_argument_wrapper(self: argparse.ArgumentParser, action: argparse.Acti
 
 
 # Overwrite ArgumentParser._match_argument with our wrapper
-# noinspection PyProtectedMember
 setattr(argparse.ArgumentParser, '_match_argument', _match_argument_wrapper)
 
 
@@ -945,7 +933,6 @@ setattr(argparse.ArgumentParser, '_match_argument', _match_argument_wrapper)
 ATTR_AP_COMPLETER_TYPE = 'ap_completer_type'
 
 
-# noinspection PyPep8Naming
 def _ArgumentParser_get_ap_completer_type(self: argparse.ArgumentParser) -> Optional[Type['ArgparseCompleter']]:
     """
     Get the ap_completer_type attribute of an argparse ArgumentParser.
@@ -963,7 +950,6 @@ def _ArgumentParser_get_ap_completer_type(self: argparse.ArgumentParser) -> Opti
 setattr(argparse.ArgumentParser, 'get_ap_completer_type', _ArgumentParser_get_ap_completer_type)
 
 
-# noinspection PyPep8Naming
 def _ArgumentParser_set_ap_completer_type(self: argparse.ArgumentParser, ap_completer_type: Type['ArgparseCompleter']) -> None:
     """
     Set the ap_completer_type attribute of an argparse ArgumentParser.
@@ -984,7 +970,6 @@ setattr(argparse.ArgumentParser, 'set_ap_completer_type', _ArgumentParser_set_ap
 ############################################################################################################
 # Patch ArgumentParser._check_value to support CompletionItems as choices
 ############################################################################################################
-# noinspection PyPep8Naming
 def _ArgumentParser_check_value(self: argparse.ArgumentParser, action: argparse.Action, value: Any) -> None:
     """
     Custom override of ArgumentParser._check_value that supports CompletionItems as choices.
@@ -1018,7 +1003,6 @@ setattr(argparse.ArgumentParser, '_check_value', _ArgumentParser_check_value)
 ############################################################################################################
 
 
-# noinspection PyPep8Naming,PyProtectedMember
 def _SubParsersAction_remove_parser(self: argparse._SubParsersAction, name: str) -> None:  # type: ignore
     """
     Removes a sub-parser from a sub-parsers group. Used to remove subcommands from a parser.
@@ -1047,7 +1031,6 @@ def _SubParsersAction_remove_parser(self: argparse._SubParsersAction, name: str)
             del self._name_parser_map[cur_name]
 
 
-# noinspection PyProtectedMember
 setattr(argparse._SubParsersAction, 'remove_parser', _SubParsersAction_remove_parser)
 
 
@@ -1059,11 +1042,9 @@ setattr(argparse._SubParsersAction, 'remove_parser', _SubParsersAction_remove_pa
 ############################################################################################################
 
 
-# noinspection PyCompatibility,PyShadowingBuiltins
 class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
     """Custom help formatter to configure ordering of help text"""
 
-    # noinspection PyProtectedMember
     def _format_usage(
         self,
         usage: Optional[str],
@@ -1126,7 +1107,6 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
                 # End cmd2 customization
 
                 # helper for wrapping lines
-                # noinspection PyMissingOrEmptyDocstring,PyShadowingNames
                 def get_lines(parts: List[str], indent: str, prefix: Optional[str] = None) -> List[str]:
                     lines: List[str] = []
                     line: List[str] = []
@@ -1209,7 +1189,6 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
                 return ', '.join(action.option_strings) + ' ' + args_string
             # End cmd2 customization
 
-    # noinspection PyMethodMayBeStatic
     def _determine_metavar(
         self,
         action: argparse.Action,
@@ -1234,7 +1213,6 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
     ) -> Callable[[int], Tuple[str, ...]]:
         metavar = self._determine_metavar(action, default_metavar)
 
-        # noinspection PyMissingOrEmptyDocstring
         def format(tuple_size: int) -> Tuple[str, ...]:
             if isinstance(metavar, tuple):
                 return metavar
@@ -1243,7 +1221,6 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
 
         return format
 
-    # noinspection PyProtectedMember
     def _format_args(self, action: argparse.Action, default_metavar: Union[str, Tuple[str, ...]]) -> str:
         """Customized to handle ranged nargs and make other output less verbose"""
         metavar = self._determine_metavar(action, default_metavar)
@@ -1272,7 +1249,6 @@ class Cmd2HelpFormatter(argparse.RawTextHelpFormatter):
         return super()._format_args(action, default_metavar)  # type: ignore[arg-type]
 
 
-# noinspection PyCompatibility
 class Cmd2ArgumentParser(argparse.ArgumentParser):
     """Custom ArgumentParser class that improves error and help output"""
 
@@ -1317,7 +1293,6 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
         self.set_ap_completer_type(ap_completer_type)  # type: ignore[attr-defined]
 
-    # noinspection PyProtectedMember
     def add_subparsers(self, **kwargs: Any) -> argparse._SubParsersAction:  # type: ignore
         """
         Custom override. Sets a default title if one was not given.
@@ -1346,7 +1321,6 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         formatted_message = ansi.style_error(formatted_message)
         self.exit(2, f'{formatted_message}\n\n')
 
-    # noinspection PyProtectedMember
     def format_help(self) -> str:
         """Copy of format_help() from argparse.ArgumentParser with tweaks to separately display required parameters"""
         formatter = self._get_formatter()

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -161,7 +161,6 @@ else:
 
     if rl_type == RlType.PYREADLINE:
         # Save the original pyreadline3 display completion function since we need to override it and restore it
-        # noinspection PyProtectedMember,PyUnresolvedReferences
         orig_pyreadline_display = readline.rl.mode._display_completions
 
     elif rl_type == RlType.GNU:
@@ -1177,7 +1176,6 @@ class Cmd(cmd.Cmd):
         """
         self.print_to(self.stdout, msg, end=end, style=ansi.style_output if apply_style else None, paged=paged, chop=chop)
 
-    # noinspection PyMethodMayBeStatic
     def perror(
         self,
         msg: Any = '',
@@ -1385,7 +1383,6 @@ class Cmd(cmd.Cmd):
         if rl_type == RlType.GNU:
             readline.set_completion_display_matches_hook(self._display_matches_gnu_readline)
         elif rl_type == RlType.PYREADLINE:
-            # noinspection PyUnresolvedReferences
             readline.rl.mode._display_completions = self._display_matches_pyreadline
 
     def tokens_for_completion(self, line: str, begidx: int, endidx: int) -> Tuple[List[str], List[str]]:
@@ -1452,7 +1449,6 @@ class Cmd(cmd.Cmd):
 
         return tokens, raw_tokens
 
-    # noinspection PyMethodMayBeStatic, PyUnusedLocal
     def basic_complete(
         self,
         text: str,
@@ -1643,7 +1639,6 @@ class Cmd(cmd.Cmd):
 
         return matches
 
-    # noinspection PyUnusedLocal
     def path_complete(
         self, text: str, line: str, begidx: int, endidx: int, *, path_filter: Optional[Callable[[str], bool]] = None
     ) -> List[str]:
@@ -1963,7 +1958,6 @@ class Cmd(cmd.Cmd):
 
                 # rl_display_match_list() expects matches to be in argv format where
                 # substitution is the first element, followed by the matches, and then a NULL.
-                # noinspection PyCallingNonCallable,PyTypeChecker
                 strings_array = cast(List[Optional[bytes]], (ctypes.c_char_p * (1 + len(encoded_matches) + 1))())
 
                 # Copy in the encoded strings and add a NULL to the end
@@ -2226,7 +2220,6 @@ class Cmd(cmd.Cmd):
         :param custom_settings: used when not tab completing the main command line
         :return: the next possible completion for text or None
         """
-        # noinspection PyBroadException
         try:
             if state == 0:
                 self._reset_completion_defaults()
@@ -2404,7 +2397,6 @@ class Cmd(cmd.Cmd):
         # Filter out hidden and disabled commands
         return [topic for topic in all_topics if topic not in self.hidden_commands and topic not in self.disabled_commands]
 
-    # noinspection PyUnusedLocal
     def sigint_handler(self, signum: int, _: Optional[FrameType]) -> None:
         """Signal handler for SIGINTs which typically come from Ctrl-C events.
 
@@ -3007,7 +2999,6 @@ class Cmd(cmd.Cmd):
         target = constants.COMMAND_FUNC_PREFIX + command
         return target if callable(getattr(self, target, None)) else ''
 
-    # noinspection PyMethodOverriding
     def onecmd(self, statement: Union[Statement, str], *, add_to_history: bool = True) -> bool:
         """This executes the actual do_* method for a command.
 
@@ -3052,7 +3043,6 @@ class Cmd(cmd.Cmd):
             if 'shell' not in self.exclude_from_history:
                 self.history.append(statement)
 
-            # noinspection PyTypeChecker
             return self.do_shell(statement.command_and_args)
         else:
             err_msg = self.default_error.format(statement.command)
@@ -3130,7 +3120,7 @@ class Cmd(cmd.Cmd):
 
                 # Disable completion
                 if completion_mode == utils.CompletionMode.NONE:
-                    # noinspection PyUnusedLocal
+
                     def complete_none(text: str, state: int) -> Optional[str]:  # pragma: no cover
                         return None
 
@@ -3161,7 +3151,6 @@ class Cmd(cmd.Cmd):
             if completion_mode != utils.CompletionMode.COMMANDS or history is not None:
                 saved_history = []
                 for i in range(1, readline.get_current_history_length() + 1):
-                    # noinspection PyArgumentList
                     saved_history.append(readline.get_history_item(i))
 
                 readline.clear_history()
@@ -3300,7 +3289,6 @@ class Cmd(cmd.Cmd):
                 readline.set_completion_display_matches_hook(None)
                 rl_basic_quote_characters.value = readline_settings.basic_quotes
             elif rl_type == RlType.PYREADLINE:
-                # noinspection PyUnresolvedReferences
                 readline.rl.mode._display_completions = orig_pyreadline_display
 
     def _cmdloop(self) -> None:
@@ -4035,7 +4023,6 @@ class Cmd(cmd.Cmd):
         self.poutput()
 
         # self.last_result will be set by do_quit()
-        # noinspection PyTypeChecker
         return self.do_quit('')
 
     quit_parser = argparse_custom.DEFAULT_ARGUMENT_PARSER(description="Exit this application")
@@ -4171,7 +4158,6 @@ class Cmd(cmd.Cmd):
                 try:
                     orig_value = settable.get_value()
                     new_value = settable.set_value(utils.strip_quotes(args.value))
-                # noinspection PyBroadException
                 except Exception as ex:
                     self.perror(f"Error setting {args.param}: {ex}")
                 else:
@@ -4307,7 +4293,6 @@ class Cmd(cmd.Cmd):
         if rl_type != RlType.NONE:
             # Save cmd2 history
             for i in range(1, readline.get_current_history_length() + 1):
-                # noinspection PyArgumentList
                 cmd2_env.history.append(readline.get_history_item(i))
 
             readline.clear_history()
@@ -4341,7 +4326,6 @@ class Cmd(cmd.Cmd):
                 if rl_type == RlType.GNU:
                     readline.set_completion_display_matches_hook(None)
                 elif rl_type == RlType.PYREADLINE:
-                    # noinspection PyUnresolvedReferences
                     readline.rl.mode._display_completions = orig_pyreadline_display
 
                 # Save off the current completer and set a new one in the Python console
@@ -4376,7 +4360,6 @@ class Cmd(cmd.Cmd):
             # Save py's history
             self._py_history.clear()
             for i in range(1, readline.get_current_history_length() + 1):
-                # noinspection PyArgumentList
                 self._py_history.append(readline.get_history_item(i))
 
             readline.clear_history()
@@ -4472,7 +4455,6 @@ class Cmd(cmd.Cmd):
 
             # Check if we are running Python code
             if py_code_to_run:
-                # noinspection PyBroadException
                 try:
                     interp.runcode(py_code_to_run)  # type: ignore[arg-type]
                 except BaseException:
@@ -4490,7 +4472,6 @@ class Cmd(cmd.Cmd):
 
                 saved_cmd2_env = None
 
-                # noinspection PyBroadException
                 try:
                     # Get sigint protection while we set up the Python shell environment
                     with self.sigint_protection:
@@ -4571,7 +4552,6 @@ class Cmd(cmd.Cmd):
 
     ipython_parser = argparse_custom.DEFAULT_ARGUMENT_PARSER(description="Run an interactive IPython shell")
 
-    # noinspection PyPackageRequirements
     @with_argparser(ipython_parser)
     def do_ipy(self, _: argparse.Namespace) -> Optional[bool]:  # pragma: no cover
         """
@@ -4754,7 +4734,6 @@ class Cmd(cmd.Cmd):
                 self.run_editor(fname)
 
                 # self.last_resort will be set by do_run_script()
-                # noinspection PyTypeChecker
                 return self.do_run_script(utils.quote_string(fname))
             finally:
                 os.remove(fname)
@@ -5044,7 +5023,6 @@ class Cmd(cmd.Cmd):
         if file_path:
             command += " " + utils.quote_string(os.path.expanduser(file_path))
 
-        # noinspection PyTypeChecker
         self.do_shell(command)
 
     @property
@@ -5156,7 +5134,6 @@ class Cmd(cmd.Cmd):
         relative_path = os.path.join(self._current_script_dir or '', file_path)
 
         # self.last_result will be set by do_run_script()
-        # noinspection PyTypeChecker
         return self.do_run_script(utils.quote_string(relative_path))
 
     def _run_transcript_tests(self, transcript_paths: List[str]) -> None:
@@ -5199,7 +5176,6 @@ class Cmd(cmd.Cmd):
         sys.argv = [sys.argv[0]]  # the --test argument upsets unittest.main()
         testcase = TestMyAppCase()
         stream = cast(TextIO, utils.StdSim(sys.stderr))
-        # noinspection PyTypeChecker
         runner = unittest.TextTestRunner(stream=stream)
         start_time = time.time()
         test_results = runner.run(testcase)
@@ -5283,7 +5259,6 @@ class Cmd(cmd.Cmd):
                     sys.stderr.write(terminal_str)
                     sys.stderr.flush()
                 elif rl_type == RlType.PYREADLINE:
-                    # noinspection PyUnresolvedReferences
                     readline.rl.mode.console.write(terminal_str)
 
                 # Update Readline's prompt before we redraw it

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -191,14 +191,11 @@ def with_argument_list(
         return cmd_wrapper
 
     if callable(func_arg):
-        # noinspection PyTypeChecker
         return arg_decorator(func_arg)
     else:
-        # noinspection PyTypeChecker
         return arg_decorator
 
 
-# noinspection PyProtectedMember
 def _set_parser_prog(parser: argparse.ArgumentParser, prog: str) -> None:
     """
     Recursively set prog attribute of a parser and all of its subparsers so that the root command
@@ -412,7 +409,6 @@ def with_argparser(
 
         return cmd_wrapper
 
-    # noinspection PyTypeChecker
     return arg_decorator
 
 
@@ -476,5 +472,4 @@ def as_subcommand_to(
 
         return func
 
-    # noinspection PyTypeChecker
     return arg_decorator

--- a/cmd2/exceptions.py
+++ b/cmd2/exceptions.py
@@ -61,7 +61,6 @@ class CompletionError(Exception):
         """
         self.apply_style = apply_style
 
-        # noinspection PyArgumentList
         super().__init__(*args)
 
 

--- a/cmd2/history.py
+++ b/cmd2/history.py
@@ -145,7 +145,6 @@ class History(List[HistoryItem]):
         """Start a new session, thereby setting the next index as the first index in the new session."""
         self.session_start_index = len(self)
 
-    # noinspection PyMethodMayBeStatic
     def _zero_based_index(self, onebased: Union[int, str]) -> int:
         """Convert a one-based index to a zero-based index."""
         result = int(onebased)

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -28,12 +28,10 @@ from typing import (
 
 # Prefer statically linked gnureadline if installed due to compatibility issues with libedit
 try:
-    # noinspection PyPackageRequirements
     import gnureadline as readline  # type: ignore[import]
 except ImportError:
     # Note: If this actually fails, you should install gnureadline on Linux/Mac or pyreadline3 on Windows.
     try:
-        # noinspection PyUnresolvedReferences
         import readline  # type: ignore[no-redef]
     except ImportError:  # pragma: no cover
         pass
@@ -71,7 +69,7 @@ if 'pyreadline3' in sys.modules:
 
     # Check if we are running in a terminal
     if sys.stdout is not None and sys.stdout.isatty():  # pragma: no cover
-        # noinspection PyPep8Naming,PyUnresolvedReferences
+
         def enable_win_vt100(handle: HANDLE) -> bool:
             """
             Enables VT100 character sequences in a Windows console
@@ -101,9 +99,7 @@ if 'pyreadline3' in sys.modules:
         # Enable VT100 sequences for stdout and stderr
         STD_OUT_HANDLE = -11
         STD_ERROR_HANDLE = -12
-        # noinspection PyUnresolvedReferences
         vt100_stdout_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_OUT_HANDLE))
-        # noinspection PyUnresolvedReferences
         vt100_stderr_support = enable_win_vt100(readline.rl.console.GetStdHandle(STD_ERROR_HANDLE))
         vt100_support = vt100_stdout_support and vt100_stderr_support
 
@@ -114,14 +110,13 @@ if 'pyreadline3' in sys.modules:
     try:
         getattr(readline, 'redisplay')
     except AttributeError:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
         readline.redisplay = readline.rl.mode._update_line
 
     # readline.remove_history_item()
     try:
         getattr(readline, 'remove_history_item')
     except AttributeError:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
+
         def pyreadline_remove_history_item(pos: int) -> None:
             """
             An implementation of remove_history_item() for pyreadline3
@@ -168,7 +163,6 @@ else:
     rl_warning = ''
 
 
-# noinspection PyProtectedMember,PyUnresolvedReferences
 def rl_force_redisplay() -> None:  # pragma: no cover
     """
     Causes readline to display the prompt and input text wherever the cursor is and start
@@ -191,7 +185,6 @@ def rl_force_redisplay() -> None:  # pragma: no cover
         readline.rl.mode._update_line()
 
 
-# noinspection PyProtectedMember, PyUnresolvedReferences
 def rl_get_point() -> int:  # pragma: no cover
     """
     Returns the offset of the current cursor position in rl_line_buffer
@@ -206,7 +199,6 @@ def rl_get_point() -> int:  # pragma: no cover
         return 0
 
 
-# noinspection PyUnresolvedReferences
 def rl_get_prompt() -> str:  # pragma: no cover
     """Gets Readline's current prompt"""
     if rl_type == RlType.GNU:
@@ -229,7 +221,6 @@ def rl_get_prompt() -> str:  # pragma: no cover
     return rl_unescape_prompt(prompt)
 
 
-# noinspection PyUnresolvedReferences
 def rl_set_prompt(prompt: str) -> None:  # pragma: no cover
     """
     Sets Readline's prompt

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -671,7 +671,6 @@ class ProcReader:
 
         # Run until process completes
         while self._proc.poll() is None:
-            # noinspection PyUnresolvedReferences
             available = read_stream.peek()  # type: ignore[attr-defined]
             if available:
                 read_stream.read(len(available))

--- a/examples/argparse_completion.py
+++ b/examples/argparse_completion.py
@@ -43,7 +43,6 @@ class ArgparseCompletion(Cmd):
             return self.sport_item_strs
         raise CompletionError("debug must be true")
 
-    # noinspection PyMethodMayBeStatic
     def choices_completion_item(self) -> List[CompletionItem]:
         """Return CompletionItem instead of strings. These give more context to what's being tab completed."""
         fancy_item = "These things can\ncontain newlines and\n"
@@ -51,7 +50,6 @@ class ArgparseCompletion(Cmd):
         items = {1: "My item", 2: "Another item", 3: "Yet another item", 4: fancy_item}
         return [CompletionItem(item_id, description) for item_id, description in items.items()]
 
-    # noinspection PyMethodMayBeStatic
     def choices_arg_tokens(self, arg_tokens: Dict[str, List[str]]) -> List[str]:
         """
         If a choices or completer function/method takes a value called arg_tokens, then it will be

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -53,7 +53,6 @@ class Pirate(cmd2.Cmd):
             stop = True
         return stop
 
-    # noinspection PyUnusedLocal
     def do_loot(self, arg):
         """Seize booty from a passing ship."""
         self.gold += 1

--- a/examples/read_input.py
+++ b/examples/read_input.py
@@ -63,7 +63,6 @@ class ReadInputApp(cmd2.Cmd):
         else:
             self.custom_history.append(input_str)
 
-    # noinspection PyMethodMayBeStatic
     def choices_provider(self) -> List[str]:
         """Example choices provider function"""
         return ["from_provider_1", "from_provider_2", "from_provider_3"]

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -58,7 +58,6 @@ def test_style_bg(bg_color):
     assert ansi.style(base_str, bg=bg_color) == ansi_str
 
 
-# noinspection PyTypeChecker
 def test_style_invalid_types():
     # Use a BgColor with fg
     with pytest.raises(TypeError):

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -38,7 +38,6 @@ standalone_choices = ['standalone', 'provider']
 standalone_completions = ['standalone', 'completer']
 
 
-# noinspection PyUnusedLocal
 def standalone_choice_provider(cli: cmd2.Cmd) -> List[str]:
     return standalone_choices
 
@@ -47,7 +46,6 @@ def standalone_completer(cli: cmd2.Cmd, text: str, line: str, begidx: int, endid
     return cli.basic_complete(text, line, begidx, endidx, standalone_completions)
 
 
-# noinspection PyMethodMayBeStatic,PyUnusedLocal,PyProtectedMember
 class ArgparseCompleterTester(cmd2.Cmd):
     """Cmd2 app that exercises ArgparseCompleter class"""
 
@@ -234,7 +232,6 @@ class ArgparseCompleterTester(cmd2.Cmd):
     nargs_parser.add_argument(
         "--optional", help="a flag with an optional value", nargs=argparse.OPTIONAL, choices=optional_choices
     )
-    # noinspection PyTypeChecker
     nargs_parser.add_argument("--range", help="a flag with nargs range", nargs=(1, 2), choices=range_choices)
     nargs_parser.add_argument(
         "--remainder", help="a flag wanting remaining", nargs=argparse.REMAINDER, choices=remainder_choices
@@ -345,7 +342,6 @@ class ArgparseCompleterTester(cmd2.Cmd):
 @pytest.fixture
 def ac_app():
     app = ArgparseCompleterTester()
-    # noinspection PyTypeChecker
     app.stdout = StdSim(app.stdout)
     return app
 
@@ -1043,7 +1039,7 @@ def test_autocomp_hint_no_help_text(ac_app, capsys):
         not out
         == '''
 Hint:
-  NO_HELP_POS            
+  NO_HELP_POS
 
 '''
     )

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -146,7 +146,6 @@ def test_apcustom_narg_tuple_negative():
     assert 'Negative numbers are invalid for nargs range' in str(excinfo.value)
 
 
-# noinspection PyUnresolvedReferences
 def test_apcustom_narg_tuple_zero_base():
     parser = Cmd2ArgumentParser()
     arg = parser.add_argument('arg', nargs=(0,))
@@ -167,7 +166,6 @@ def test_apcustom_narg_tuple_zero_base():
     assert "arg{0..3}" in parser.format_help()
 
 
-# noinspection PyUnresolvedReferences
 def test_apcustom_narg_tuple_one_base():
     parser = Cmd2ArgumentParser()
     arg = parser.add_argument('arg', nargs=(1,))
@@ -182,7 +180,6 @@ def test_apcustom_narg_tuple_one_base():
     assert "arg{1..5}" in parser.format_help()
 
 
-# noinspection PyUnresolvedReferences
 def test_apcustom_narg_tuple_other_ranges():
     # Test range with no upper bound on max
     parser = Cmd2ArgumentParser()
@@ -321,7 +318,6 @@ def test_completion_items_as_choices(capsys):
     ##############################################################
     choices = [CompletionItem(1, "Description One"), CompletionItem(2, "Two")]
     parser = Cmd2ArgumentParser()
-    # noinspection PyTypeChecker
     parser.add_argument("choices_arg", type=int, choices=choices)
 
     # First test valid choices. Confirm the parsed data matches the correct type of int.

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -968,7 +968,6 @@ def test_statement_as_dict(parser):
 
 def test_is_valid_command_invalid(mocker, parser):
     # Non-string command
-    # noinspection PyTypeChecker
     valid, errmsg = parser.is_valid_command(5)
     assert not valid and 'must be a string' in errmsg
 


### PR DESCRIPTION
These comments are PyCharm-specific and we've relied on external static analyzers for years.