### PR TITLE
Defragment readline history for multiline commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * `cmd2` 2.5 supports Python 3.8+ (removed support for Python 3.6 and 3.7)
 * Bug Fixes
   * Fixed issue where persistent history file was not saved upon SIGHUP and SIGTERM signals.
+  * Multiline commands are no longer fragmented in up-arrow history.
 * Enhancements
   * Removed dependency on `attrs` and replaced with [dataclasses](https://docs.python.org/3/library/dataclasses.html)
   * add `allow_clipboard` initialization parameter and attribute to disable ability to
@@ -11,7 +12,6 @@
   * Fall back to bz2 compression of history file when lzma is not installed.
 * Deletions (potentially breaking changes)
   * Removed `apply_style` from `Cmd.pwarning()`.
-
 
 ## 2.4.3 (January 27, 2023)
 * Bug Fixes

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -581,8 +581,15 @@ class StatementParser:
 
             # take everything from the end of the first match group to
             # the end of the line as the arguments (stripping leading
-            # and trailing spaces)
-            args = line[match.end(1) :].strip()
+            # and unquoted trailing whitespace)
+            args = line[match.end(1) :].lstrip()
+            try:
+                shlex_split(args)
+            except ValueError:
+                # Unclosed quote. Leave trailing whitespace.
+                pass
+            else:
+                args = args.rstrip()
             # if the command is empty that means the input was either empty
             # or something weird like '>'. args should be empty if we couldn't
             # parse a command

--- a/cmd2/rl_utils.py
+++ b/cmd2/rl_utils.py
@@ -38,7 +38,7 @@ except ImportError:
 
 
 class RlType(Enum):
-    """Readline library types we recognize"""
+    """Readline library types we support"""
 
     GNU = 1
     PYREADLINE = 2
@@ -151,7 +151,7 @@ elif 'gnureadline' in sys.modules or 'readline' in sys.modules:
             rl_type = RlType.GNU
             vt100_support = sys.stdout.isatty()
 
-# Check if readline was loaded
+# Check if we loaded a supported version of readline
 if rl_type == RlType.NONE:  # pragma: no cover
     if not _rl_warn_reason:
         _rl_warn_reason = (

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -422,6 +422,27 @@ def test_multiline_histitem(parser):
     assert pr_lines[0].endswith('multiline foo bar')
 
 
+def test_multiline_with_quotes_histitem(parser):
+    # Test that spaces and newlines in quotes are preserved
+    from cmd2.history import (
+        History,
+    )
+
+    line = 'Look, "There are newlines\n  and spaces  \n "\n in\nquotes.\n;\n'
+    statement = parser.parse(line)
+    history = History()
+    history.append(statement)
+    assert len(history) == 1
+    hist_item = history[0]
+    assert hist_item.raw == line
+
+    # Since spaces and newlines in quotes are preserved, this history entry spans multiple lines.
+    pr_lines = hist_item.pr(1).splitlines()
+    assert pr_lines[0].endswith('Look, "There are newlines')
+    assert pr_lines[1] == '  and spaces  '
+    assert pr_lines[2] == ' " in quotes.;'
+
+
 def test_multiline_histitem_verbose(parser):
     from cmd2.history import (
         History,
@@ -437,6 +458,16 @@ def test_multiline_histitem_verbose(parser):
     pr_lines = hist_item.pr(1, verbose=True).splitlines()
     assert pr_lines[0].endswith('multiline foo')
     assert pr_lines[1] == 'bar'
+
+
+def test_single_line_format_blank(parser):
+    from cmd2.history import (
+        single_line_format,
+    )
+
+    line = ""
+    statement = parser.parse(line)
+    assert single_line_format(statement) == line
 
 
 def test_history_item_instantiate():

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -843,6 +843,25 @@ def test_parse_command_only_quoted_args(parser):
     assert statement.output_to == ''
 
 
+def test_parse_command_only_unclosed_quote(parser):
+    # Quoted trailing spaces will be preserved
+    line = 'command with unclosed "quote     '
+    statement = parser.parse_command_only(line)
+    assert statement == 'with unclosed "quote     '
+    assert statement.args == statement
+    assert statement.arg_list == []
+    assert statement.command == 'command'
+    assert statement.command_and_args == line
+    assert statement.multiline_command == ''
+    assert statement.raw == line
+    assert statement.multiline_command == ''
+    assert statement.terminator == ''
+    assert statement.suffix == ''
+    assert statement.pipe_to == ''
+    assert statement.output == ''
+    assert statement.output_to == ''
+
+
 @pytest.mark.parametrize(
     'line,args',
     [


### PR DESCRIPTION
Fixes #1297 

Combine individual lines of a multiline command into a single line for readline history.
Spaces and newlines in quotes are preserved so those strings will span multiple lines.
Non-verbose cmd2 history uses the same format as readline history entries.