### PR TITLE
Placed default_suggestion_message on its own line.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,6 @@ pytest-mock = "*"
 sphinx = "*"
 sphinx-autobuild = "*"
 sphinx-rtd-theme = "*"
-tableformatter="*"
 twine = ">=1.11"
 
 [pipenv]

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -297,6 +297,9 @@ class Cmd(cmd.Cmd):
                                    instantiate and register all commands. If False, CommandSets
                                    must be manually installed with `register_command_set`.
         :param allow_clipboard: If False, cmd2 will disable clipboard interactions
+        :param suggest_similar_command: If ``True``, ``cmd2`` will attempt to suggest the most
+                                        similar command when the user types a command that does
+                                        not exist. Default: ``False``.
         """
         # Check if py or ipy need to be disabled in this instance
         if not include_py:
@@ -404,7 +407,7 @@ class Cmd(cmd.Cmd):
         self.help_error = "No help on {}"
 
         # The error that prints when a non-existent command is run
-        self.default_error = "{} is not a recognized command, alias, or macro"
+        self.default_error = "{} is not a recognized command, alias, or macro."
 
         # If non-empty, this string will be displayed if a broken pipe error occurs
         self.broken_pipe_warning = ''
@@ -3092,11 +3095,10 @@ class Cmd(cmd.Cmd):
             return self.do_shell(statement.command_and_args)
         else:
             err_msg = self.default_error.format(statement.command)
-            if self.suggest_similar_command:
-                suggested_command = self._suggest_similar_command(statement.command)
-                if suggested_command:
-                    err_msg = err_msg + ' ' + self.default_suggestion_message.format(suggested_command)
-            # Set apply_style to False so default_error's style is not overridden
+            if self.suggest_similar_command and (suggested_command := self._suggest_similar_command(statement.command)):
+                err_msg += f"\n{self.default_suggestion_message.format(suggested_command)}"
+
+            # Set apply_style to False so styles for default_error and default_suggestion_message are not overridden
             self.perror(err_msg, apply_style=False)
             return None
 

--- a/docs/api/cmd.rst
+++ b/docs/api/cmd.rst
@@ -9,7 +9,7 @@ cmd2.Cmd
     .. attribute:: default_error
 
       The error message displayed when a non-existent command is run.
-      Default: ``{} is not a recognized command, alias, or macro``
+      Default: ``{} is not a recognized command, alias, or macro.``
 
     .. attribute:: help_error
 
@@ -75,6 +75,5 @@ cmd2.Cmd
 
     .. attribute:: suggest_similar_command
 
-        If ``True``, ``cmd2`` will suggest the most similar command when the user
-        types a command that does not exist.
-        Default: ``False``.
+        If ``True``, ``cmd2`` will attempt to suggest the most similar command
+        when the user types a command that does not exist. Default: ``False``.

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -29,6 +29,9 @@ from cmd2 import (
     plugin,
     utils,
 )
+from cmd2.rl_utils import (
+    readline,  # This ensures gnureadline is used in macOS tests
+)
 
 from .conftest import (
     HELP_HISTORY,

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -333,7 +333,7 @@ def test_base_error_suggest_command(base_app):
         old_suggest_similar_command = base_app.suggest_similar_command
         base_app.suggest_similar_command = True
         out, err = run_cmd(base_app, 'historic')
-        assert "history" in err[0]
+        assert "history" in err[1]
     finally:
         base_app.suggest_similar_command = old_suggest_similar_command
 


### PR DESCRIPTION
Reformatted how `default_suggestion_message` appears.

Before
```
hist is not a recognized command, alias, or macro Did you mean history?
```

After
```
hist is not a recognized command, alias, or macro.
Did you mean history?
```