### PR TITLE
Remove dependencies which were only used for Python < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,7 @@ Topic :: Software Development :: Libraries :: Python Modules
 SETUP_REQUIRES = ['setuptools >= 34.4', 'setuptools_scm >= 3.0']
 
 INSTALL_REQUIRES = [
-    'importlib_metadata>=1.6.0;python_version<"3.8"',
     'pyperclip >= 1.6',
-    'typing_extensions; python_version<"3.8"',
     'wcwidth >= 0.1.7',
 ]
 


### PR DESCRIPTION
Remove dependencies which were only used for Python < 3.8 since cmd2 2.5.0 now requires Python 3.8+.

Specifically removed:
- importlib_metadata
- typing_extensions