### PR TITLE
Attempt a Python path hack to get ReadTheDocs build working

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,12 @@ add these directories to sys.path here. If the directory is relative to the
 documentation root, use os.path.abspath to make it absolute, like shown here.
 """
 
+import sys
+from os.path import abspath, dirname
+
+# Make sure we get the version of this copy of cmd2
+sys.path.insert(1, dirname(dirname(abspath(__file__))))
+
 # Import for custom theme from Read the Docs
 import sphinx_rtd_theme
 


### PR DESCRIPTION
Attempt a Python path hack to get ReadTheDocs build working. I'm taking the idea for this from [Django's conf.py](https://github.com/django/django/blob/main/docs/conf.py#L28)