### PR TITLE
Try to fix a bug where the ReadTheDocs build can't find cmd2 version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 
 pyperclip
 setuptools
-setuptools-scm
+setuptools-scm<8
 Sphinx
 sphinx-autobuild
 sphinx-rtd-theme


### PR DESCRIPTION
Try to fix a bug where the ReadTheDocs build can't find the `cmd2.__version__`