### PR TITLE
Fix a pytest warning on 3.0 branch about an invalid escape sequence

### DIFF
--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -49,8 +49,8 @@ class CmdLineApp(cmd2.Cmd):
     speak_parser.add_argument('-p', '--piglatin', action="store_true", help="atinLay")
     speak_parser.add_argument('-s', '--shout', action="store_true", help="N00B EMULATION MODE")
 
-    # Escape open bracket since help text can contain markup
-    speak_parser.add_argument('-r', '--repeat', type=int, help="output \[n] times")
+    # Escape open bracket since help text can contain rich markup
+    speak_parser.add_argument('-r', '--repeat', type=int, help=r"output \[n] times")
 
     @cmd2.with_argparser(speak_parser, with_unknown_args=True)
     def do_speak(self, opts, arg):


### PR DESCRIPTION
Fix a pytest warning on 3.0 branch about an invalid escape sequence