### PR TITLE
Remove tests_isolated from default tests run with pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.2 (November 3, 2024)
+* Bug Fixes
+  * Fixed default `pytest` execution when not using cmd2's custom `invoke` command via `inv pytest`
+
 # 2.5.1 (November 2, 2024)
 * Bug Fixes
   * Fixed readline bug when using `ipy` command with `gnureadline` and Python 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ warn_unused_ignores = false
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
-    "tests_isolated",
 ]
 addopts = [
     "--cov=cmd2",


### PR DESCRIPTION
Remove `tests_isolated` from default tests run with `pytest` when run by itself on the whole directory and not using `inv pytest`.

This is to prevent `pytest` from running tests together which need to be isolated and avoiding confusion for consumers such as Linux distros.

In the future we should try to fix these tests so they don't need to be run isolated from others.