### PR TITLE
Add [project] configuration to pyproject.toml

### DIFF
--- a/plugins/ext_test/tasks.py
+++ b/plugins/ext_test/tasks.py
@@ -157,7 +157,7 @@ namespace_clean.add_task(clean_all, 'all')
 def sdist(context):
     """Create a source distribution"""
     with context.cd(TASK_ROOT_STR):
-        context.run('python setup.py sdist')
+        context.run('python -m build --sdist')
 
 
 namespace.add_task(sdist)
@@ -167,7 +167,7 @@ namespace.add_task(sdist)
 def wheel(context):
     """Build a wheel distribution"""
     with context.cd(TASK_ROOT_STR):
-        context.run('python setup.py bdist_wheel')
+        context.run('python -m build --wheel')
 
 
 namespace.add_task(wheel)

--- a/plugins/template/tasks.py
+++ b/plugins/template/tasks.py
@@ -170,7 +170,7 @@ namespace_clean.add_task(clean_all, 'all')
 @invoke.task(pre=[clean_all])
 def sdist(context):
     """Create a source distribution"""
-    context.run('python setup.py sdist')
+    context.run('python -m build --sdist')
 
 
 namespace.add_task(sdist)
@@ -179,7 +179,7 @@ namespace.add_task(sdist)
 @invoke.task(pre=[clean_all])
 def wheel(context):
     """Build a wheel distribution"""
-    context.run('python setup.py bdist_wheel')
+    context.run('python -m build --wheel')
 
 
 namespace.add_task(wheel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "gnureadline; os_name=='darwin'",
+    "gnureadline; platform_system == 'Darwin'",
     "pyperclip",
-    "pyreadline3; os_name=='nt'",
+    "pyreadline3; platform_system == 'Windows'",
     "wcwidth",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,84 @@
 requires = ["build", "setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "cmd2"
+dynamic = ["version"]
+description = "cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python"
+authors = [{ name = "cmd2 Contributors" }]
+readme = "README.md"
+requires-python = ">=3.8"
+keywords = [
+    "CLI",
+    "cmd",
+    "command",
+    "interactive",
+    "prompt",
+    "Python",
+]
+license = { file = "LICENSE" }
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "gnureadline; os_name=='darwin'",
+    "pyperclip",
+    "pyreadline3; os_name=='nt'",
+    "wcwidth",
+]
+
+[project.optional-dependencies]
+build = [
+    "build",
+    "setuptools",
+    "setuptools-scm",
+]
+dev = [
+    "codecov",
+    "doc8",
+    "invoke",
+    "mypy",
+    "nox",
+    "pytest",
+    "pytest-cov",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-autobuild",
+    "ruff",
+    "twine",
+]
+docs = [
+    "setuptools",
+    "setuptools_scm",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-autobuild",
+]
+test = [
+    "codecov",
+    "coverage",
+    "pytest",
+    "pytest-cov",
+]
+validate = [
+    "mypy",
+    "ruff",
+    "types-setuptools",
+]
+
 [tool.doc8]
 ignore-path = [
     "__pycache__",
@@ -232,3 +310,5 @@ docstring-code-format = false
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
 docstring-code-line-length = "dynamic"
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "nox",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "sphinx",
     "sphinx-rtd-theme",
     "sphinx-autobuild",
@@ -73,6 +74,7 @@ test = [
     "coverage",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
 ]
 validate = [
     "mypy",

--- a/tasks.py
+++ b/tasks.py
@@ -309,7 +309,7 @@ namespace.add_task(validatetag)
 def sdist(context):
     """Create a source distribution"""
     with context.cd(TASK_ROOT_STR):
-        context.run('python setup.py sdist')
+        context.run('python -m build --sdist')
 
 
 namespace.add_task(sdist)
@@ -319,7 +319,7 @@ namespace.add_task(sdist)
 def wheel(context):
     """Build a wheel distribution"""
     with context.cd(TASK_ROOT_STR):
-        context.run('python setup.py bdist_wheel')
+        context.run('python -m build --wheel')
 
 
 namespace.add_task(wheel)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -484,14 +484,14 @@ def test_path_completion_no_text(cmd2_app):
 
 def test_path_completion_no_path(cmd2_app):
     # Run path complete with search text that isn't preceded by a path. This should use CWD as the path.
-    text = 's'
+    text = 'p'
     line = 'shell ls {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)
     completions_no_text = cmd2_app.path_complete(text, line, begidx, endidx)
 
     # Run path complete with path set to the CWD
-    text = os.getcwd() + os.path.sep + 's'
+    text = os.getcwd() + os.path.sep + text
     line = 'shell ls {}'.format(text)
     endidx = len(line)
     begidx = endidx - len(text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -289,15 +289,9 @@ def pr_none():
 def test_proc_reader_send_sigint(pr_none):
     assert pr_none._proc.poll() is None
     pr_none.send_sigint()
-
-    wait_start = time.monotonic()
     pr_none.wait()
-    wait_finish = time.monotonic()
 
-    # Make sure the process exited before sleep of 5 seconds finished
-    # 3 seconds accounts for some delay but is long enough for the process to exit
-    assert wait_finish - wait_start < 3
-
+    # Mac sure a SIGINT killed the process
     ret_code = pr_none._proc.poll()
     if sys.platform.startswith('win'):
         assert ret_code is not None


### PR DESCRIPTION
Add `[project]` configuration to `pyproject.toml`

The only thing that is preventing us from deleting `setup.py` at this point is the fact that there are multiple packages in the source tree due to the ones under the `plugins` directory.

Also:
- Ruggedized a couple unit tests