### PR TITLE
Add support for uv venvs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,13 @@ from importlib.metadata import version as get_version
 from os.path import abspath, dirname
 
 # Make sure we get the version of this copy of cmd2
-sys.path.insert(1, dirname(dirname(abspath(__file__))))
+root_path = dirname(dirname(abspath(__file__)))
+cmd2_ext_test_path = f'{root_path}/plugins/ext_test/'
+sys.path.insert(1, root_path)  # cmd2
+sys.path.insert(2, cmd2_ext_test_path)  # cmd2_ext_test
 
 # Import for custom theme from Read the Docs
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # noqa E402
 
 # -- General configuration -----------------------------------------------------
 
@@ -179,9 +182,13 @@ autodoc_default_options = {'member-order': 'bysource'}
 # Ignore nitpicky warnings from autodoc which are occurring for very new versions of Sphinx and autodoc
 # They seem to be happening because autodoc is now trying to add hyperlinks to docs for typehint classes
 nitpick_ignore = [
-    ('py:class', 'cmd2.decorators.CommandParent'),
-    ('py:obj', 'cmd2.decorators.CommandParent'),
+    ('py:class', 'ArgparseCommandFunc'),
     ('py:class', 'argparse._SubParsersAction'),
+    ('py:class', 'cmd2.decorators.CommandParent'),
     ('py:class', 'cmd2.utils._T'),
+    ('py:class', 'CommandParent'),
+    ('py:class', 'frame'),
+    ('py:class', 'RawCommandFuncOptionalBoolReturn'),
     ('py:class', 'types.FrameType'),
+    ('py:obj', 'cmd2.decorators.CommandParent'),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ dev = [
     "pytest-cov",
     "pytest-mock",
     "sphinx",
-    "sphinx-rtd-theme",
     "sphinx-autobuild",
+    "sphinx-rtd-theme",
     "ruff",
     "twine",
 ]
@@ -66,8 +66,8 @@ docs = [
     "setuptools",
     "setuptools_scm",
     "sphinx",
-    "sphinx-rtd-theme",
     "sphinx-autobuild",
+    "sphinx-rtd-theme",
 ]
 test = [
     "codecov",
@@ -317,3 +317,19 @@ docstring-code-line-length = "dynamic"
 packages = ["cmd2"]
 
 [tool.setuptools_scm]
+
+[tool.uv]
+dev-dependencies = [
+    "codecov",
+    "doc8",
+    "invoke",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "sphinx",
+    "sphinx-autobuild",
+    "sphinx-rtd-theme",
+    "ruff",
+    "twine",
+]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -290,9 +290,9 @@ def test_proc_reader_send_sigint(pr_none):
     assert pr_none._proc.poll() is None
     pr_none.send_sigint()
     pr_none.wait()
-
-    # Mac sure a SIGINT killed the process
     ret_code = pr_none._proc.poll()
+
+    # Make sure a SIGINT killed the process
     if sys.platform.startswith('win'):
         assert ret_code is not None
     else:


### PR DESCRIPTION
# Summary
Add support for [uv](https://github.com/astral-sh/uv) venvs. `uv` is an extremely *fast* Python package and project manager, written in Rust. It is a single tool to replace pip, pip-tools, pipx, poetry, pyenv, twine, virtualenv, and more.

`uv` is an order of magnitude or two faster than `pipenv`.

## Testing
```sh
uv venv
uv run inv format
uv run inv lint
uv run inv mypy
uv run inv pytest
uv run inv doc8
uv run inv docs
```

### Unrelated

Fix a spelling typo in a unit-test comment