### PR TITLE
Make Sphinx documentation build not dependent on nox

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install python prerequisites
-        run: pip install -U --user pip setuptools setuptools-scm sphinx sphinx-autobuild sphinx-rtd-theme
+        run: pip install -U --user pip setuptools setuptools-scm sphinx sphinx-autobuild sphinx-rtd-theme . plugins/ext_test
       - name: Sphinx documentation build
         run: python -m sphinx -M html docs docs/_build -nvWT

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install python prerequisites
-        run: pip install -U --user pip setuptools setuptools-scm nox
+        run: pip install -U --user pip setuptools setuptools-scm sphinx sphinx-autobuild sphinx-rtd-theme
       - name: Sphinx documentation build
-        run: python -m nox --non-interactive --session docs
+        run: python -m sphinx -M html docs docs/_build -nvWT

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,22 +1,6 @@
 import nox
 
 
-@nox.session(python=['3.12'])
-def docs(session):
-    session.install(
-        'sphinx',
-        'sphinx-rtd-theme',
-        '.',
-        'plugins/ext_test',
-    )
-    session.chdir('docs')
-    tmpdir = session.create_tmp()
-
-    session.run(
-        'sphinx-build', '-a', '-W', '-T', '-b', 'html', '-d', '{}/doctrees'.format(tmpdir), '.', '{}/html'.format(tmpdir)
-    )
-
-
 @nox.session(python=['3.8', '3.9', '3.10', '3.11', '3.12', '3.13'])
 @nox.parametrize('plugin', [None, 'ext_test', 'template', 'coverage'])
 def tests(session, plugin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "cmd2-ext-test",
     "gnureadline; platform_system == 'Darwin'",
     "pyperclip",
     "pyreadline3; platform_system == 'Windows'",
@@ -333,3 +334,6 @@ dev-dependencies = [
     "ruff",
     "twine",
 ]
+
+[tool.uv.sources]
+cmd2-ext-test = { path = "plugins/ext_test", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "cmd2-ext-test",
     "gnureadline; platform_system == 'Darwin'",
     "pyperclip",
     "pyreadline3; platform_system == 'Windows'",
@@ -321,6 +320,7 @@ packages = ["cmd2"]
 
 [tool.uv]
 dev-dependencies = [
+    "cmd2-ext-test",
     "codecov",
     "doc8",
     "invoke",


### PR DESCRIPTION
Make Sphinx documentation build not dependent on nox.

Also, fix `uv run inv pytest` so that it also properly runs the isolated tests which depend on both `cmd2` and the `cmd2-ext-test` extension.

In the future, those tests should be moved under the extension package if they depend on that and should not be considered tests for the parent `cmd2` package.