### PR TITLE
Remove support for Python 3.8 and make 3.9 minimum required

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The tables below list all prerequisites along with the minimum required version 
 
 | Prerequisite                                             | Minimum Version | Purpose                                |
 |----------------------------------------------------------|-----------------|----------------------------------------|
-| [python](https://www.python.org/downloads/)              | `3.8`           | Python programming language            |
+| [python](https://www.python.org/downloads/)              | `3.9`           | Python programming language            |
 | [pyperclip](https://github.com/asweigart/pyperclip)      | `1.8.2`         | Cross-platform clipboard functions     |
 | [rich-argparse](https://pypi.org/project/rich-argparse/) | `1.6.0`         | Rich help formatters for argparse      |
 | [wcwidth](https://pypi.python.org/pypi/wcwidth)          | `0.2.12`        | Measure the displayed width of unicode |
@@ -96,7 +96,7 @@ on all platforms (Windows, Mac, and Linux).  You can install `uv` using instruct
 
 You can then install multiple versions of Python using `uv` like so:
 ```sh
-uv python install 3.10 3.11 3.12 3.13
+uv python install 3.9 3.10 3.11 3.12 3.13
 ```
 
 ### Forking the project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,15 @@
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: "build"
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4 # https://github.com/actions/checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.0 (TBD)
 * Breaking Changes
+  * `cmd2` 3.x supports Python 3.9+ (removed support for Python 3.8)
   * Removed macros
 * Enhancements
   * Simplified the process to set a custom parser for `cmd2's` built-in commands.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On all operating systems, the latest stable version of `cmd2` can be installed u
 pip install -U cmd2
 ```
 
-cmd2 works with Python 3.8+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
+cmd2 works with Python 3.9+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party dependencies.
 
 For information on other installation options, see
 [Installation Instructions](https://cmd2.readthedocs.io/en/latest/overview/installation.html) in the cmd2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,6 +190,7 @@ nitpick_ignore = [
     ('py:class', 'CommandParent'),
     ('py:class', 'frame'),
     ('py:class', 'RawCommandFuncOptionalBoolReturn'),
+    ('py:class', 'r.Console'),
     ('py:class', 'rich.console.Console'),
     ('py:class', 'rich.console.ConsoleRenderable'),
     ('py:class', 'rich.console.RichCast'),

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -1,4 +1,3 @@
-
 Installation Instructions
 =========================
 
@@ -7,7 +6,7 @@ Installation Instructions
 .. _setuptools: https://pypi.org/project/setuptools
 .. _PyPI: https://pypi.org
 
-``cmd2`` works on Linux, macOS, and Windows. It requires Python 3.8 or
+``cmd2`` works on Linux, macOS, and Windows. It requires Python 3.9 or
 higher, pip_, and setuptools_. If you've got all that, then you can just:
 
 .. code-block:: shell
@@ -30,7 +29,7 @@ higher, pip_, and setuptools_. If you've got all that, then you can just:
 Prerequisites
 -------------
 
-If you have Python 3 >=3.8 installed from `python.org
+If you have Python 3 >=3.9 installed from `python.org
 <https://www.python.org>`_, you will already have pip_ and setuptools_, but may
 need to upgrade to the latest versions:
 

--- a/plugins/ext_test/build-pyenvs.sh
+++ b/plugins/ext_test/build-pyenvs.sh
@@ -8,7 +8,7 @@
 # version numbers are: major.minor.patch
 #
 # this script will delete and recreate existing virtualenvs named
-# cmd2-3.8, etc. It will also create a .python-version
+# cmd2-3.9, etc. It will also create a .python-version
 #
 # Prerequisites:
 #   - *nix-ish environment like macOS or Linux
@@ -23,7 +23,7 @@
 # virtualenvs will be added to '.python-version'. Feel free to modify
 # this list, but note that this script intentionally won't install
 # dev, rc, or beta python releases
-declare -a pythons=("3.8" "3.9", "3.10", "3.11", "3.12")
+declare -a pythons=("3.9", "3.10", "3.11", "3.12", "3.13")
 
 # function to find the latest patch of a minor version of python
 function find_latest_version {

--- a/plugins/ext_test/noxfile.py
+++ b/plugins/ext_test/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=['3.8', '3.9', '3.10', '3.11', '3.12'])
+@nox.session(python=['3.9', '3.10', '3.11', '3.12', '3.13'])
 def tests(session):
     session.install('invoke', './[test]')
     session.run('invoke', 'pytest', '--junit', '--no-pty')

--- a/plugins/ext_test/setup.py
+++ b/plugins/ext_test/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     license='MIT',
     package_data=PACKAGE_DATA,
     packages=['cmd2_ext_test'],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=['cmd2 >= 2, <3'],
     setup_requires=['setuptools >= 42', 'setuptools_scm >= 3.4'],
     classifiers=[
@@ -43,11 +43,11 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     # dependencies for development and testing
     # $ pip install -e .[dev]

--- a/plugins/template/README.md
+++ b/plugins/template/README.md
@@ -231,15 +231,15 @@ automates the creation of these environments.
 If you prefer to create these virtualenvs by hand, do the following:
 ```
 $ cd cmd2_abbrev
-$ pyenv install 3.8.5
-$ pyenv virtualenv -p python3.8 3.8.5 cmd2-3.8
-$ pyenv install 3.9.0
-$ pyenv virtualenv -p python3.9 3.9.0 cmd2-3.9
+$ pyenv install 3.12
+$ pyenv virtualenv -p python3.12 3.12 cmd2-3.12
+$ pyenv install 3.13
+$ pyenv virtualenv -p python3.13 3.13 cmd2-3.13
 ```
 
 Now set pyenv to make both of those available at the same time:
 ```
-$ pyenv local cmd2-3.8 cmd2-3.9
+$ pyenv local cmd2-3.13 cmd2-3.13
 ```
 
 Whether you ran the script, or did it by hand, you now have isolated virtualenvs
@@ -247,12 +247,12 @@ for each of the major python versions. This table shows various python commands,
 the version of python which will be executed, and the virtualenv it will
 utilize.
 
-| Command     | python | virtualenv |
-| ----------- | ------ | ---------- |
-| `python3.8` | 3.8.5  | cmd2-3.8   |
-| `python3.9` | 3.9.0  | cmd2-3.9   |
-| `pip3.8`    | 3.8.5  | cmd2-3.8   |
-| `pip3.9`    | 3.9.0  | cmd2-3.9   |
+| Command      | python | virtualenv |
+|--------------|--------|------------|
+| `python3.12` | 3.12   | cmd2-3.12  |
+| `python3.13` | 3.13   | cmd2-3.13  |
+| `pip3.12`    | 3.12   | cmd2-3.12  |
+| `pip3.13`    | 3.13   | cmd2-3.13  |
 
 ## Install Dependencies
 
@@ -264,11 +264,11 @@ $ pip install -e .[dev]
 This command also installs `cmd2-myplugin` "in-place", so the package points to
 the source code instead of copying files to the python `site-packages` folder.
 
-All the dependencies now have been installed in the `cmd2-3.8`
+All the dependencies now have been installed in the `cmd2-3.13`
 virtualenv. If you want to work in other virtualenvs, you'll need to manually
 select it, and install again::
 
-   $ pyenv shell cmd2-3.4
+   $ pyenv shell cmd2-3.13
    $ pip install -e .[dev]
 
 Now that you have your python environments created, you need to install the
@@ -286,8 +286,8 @@ unit tests found in the `tests` directory.
 
 ### Use nox to run unit tests in multiple versions of python
 
-The included `noxfile.py` is setup to run the unit tests in python 3.8, 3.9
-3.10, 3.11, and 3.12 You can run your unit tests in all of these versions
+The included `noxfile.py` is setup to run the unit tests in python 3.9
+3.10, 3.11, 3.12, and 3.13 You can run your unit tests in all of these versions
 of python by:
 ```
 $ nox

--- a/plugins/template/build-pyenvs.sh
+++ b/plugins/template/build-pyenvs.sh
@@ -8,7 +8,7 @@
 # version numbers are: major.minor.patch
 #
 # this script will delete and recreate existing virtualenvs named
-# cmd2-3.8, etc. It will also create a .python-version
+# cmd2-3.9, etc. It will also create a .python-version
 #
 # Prerequisites:
 #   - *nix-ish environment like macOS or Linux
@@ -23,7 +23,7 @@
 # virtualenvs will be added to '.python-version'. Feel free to modify
 # this list, but note that this script intentionally won't install
 # dev, rc, or beta python releases
-declare -a pythons=("3.8" "3.9" "3.10" "3.11", "3.12")
+declare -a pythons=("3.9", "3.10", "3.11", "3.12", "3.13")
 
 # function to find the latest patch of a minor version of python
 function find_latest_version {

--- a/plugins/template/noxfile.py
+++ b/plugins/template/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=['3.8', '3.9', '3.10', '3.11', '3.12'])
+@nox.session(python=['3.9', '3.10', '3.11', '3.12', '3.13'])
 def tests(session):
     session.install('invoke', './[test]')
     session.run('invoke', 'pytest', '--junit', '--no-pty')

--- a/plugins/template/setup.py
+++ b/plugins/template/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     url='https://github.com/python-cmd2/cmd2-plugin-template',
     license='MIT',
     packages=['cmd2_myplugin'],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=['cmd2 >= 2, <3'],
     setup_requires=['setuptools_scm'],
     classifiers=[
@@ -34,11 +34,11 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     # dependencies for development and testing
     # $ pip install -e .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python"
 authors = [{ name = "cmd2 Contributors" }]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "CLI",
     "cmd",
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Remove support for Python 3.8 and make 3.9 minimum required.

This PR simply updates the boilerplate files. It doesn't yet start to take advantage of things like built-in types such as `list`, `dict`, etc. supporting generics for type hints directly.