### PR TITLE
Fixed issue where argument parsers for overridden commands were not being created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.7 (TBD)
+* Bug Fixes
+   * Fixed issue where argument parsers for overridden commands were not being created.
+
 ## 2.5.6 (November 14, 2024)
 * Bug Fixes
    * Fixed type hint for `with_default_category` decorator which caused type checkers to mistype

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.5.7 (TBD)
 * Bug Fixes
    * Fixed issue where argument parsers for overridden commands were not being created.
-   * Fixed terminal check in `Cmd.ppaged()` to use correct output stream.
+   * Fixed issue where `Cmd.ppaged()` was not writing to the passed in destination.
 
 ## 2.5.6 (November 14, 2024)
 * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.7 (TBD)
 * Bug Fixes
    * Fixed issue where argument parsers for overridden commands were not being created.
+   * Fixed terminal check in `Cmd.ppaged()` to use correct output stream.
 
 ## 2.5.6 (November 14, 2024)
 * Bug Fixes

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1436,7 +1436,7 @@ class Cmd(cmd.Cmd):
                 # Prevent KeyboardInterrupts while in the pager. The pager application will
                 # still receive the SIGINT since it is in the same process group as us.
                 with self.sigint_protection:
-                    pipe_proc = subprocess.Popen(pager, shell=True, stdin=subprocess.PIPE)
+                    pipe_proc = subprocess.Popen(pager, shell=True, stdin=subprocess.PIPE, stdout=dest)
                     pipe_proc.communicate(msg_str.encode('utf-8', 'replace'))
             else:
                 ansi.style_aware_write(dest, f'{msg_str}{end}')

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1419,7 +1419,7 @@ class Cmd(cmd.Cmd):
             # Don't try to use the pager when being run by a continuous integration system like Jenkins + pexpect.
             functional_terminal = False
 
-            if self.stdin.isatty() and self.stdout.isatty():
+            if self.stdin.isatty() and dest.isatty():
                 if sys.platform.startswith('win') or os.environ.get('TERM') is not None:
                     functional_terminal = True
 

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -346,7 +346,9 @@ def with_argparser(
             statement, parsed_arglist = cmd2_app.statement_parser.get_command_arg_list(
                 command_name, statement_arg, preserve_quotes
             )
-            arg_parser = cmd2_app._command_parsers.get(command_name, None)
+
+            # Pass cmd_wrapper instead of func, since it contains the parser info.
+            arg_parser = cmd2_app._command_parsers.get(cmd_wrapper)
             if arg_parser is None:
                 # This shouldn't be possible to reach
                 raise ValueError(f'No argument parser found for {command_name}')  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,6 +328,7 @@ dev-dependencies = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
+    "ruff",
     "sphinx",
     "sphinx-autobuild",
     "sphinx-rtd-theme",

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -14,7 +14,6 @@ import pytest
 import cmd2
 
 from .conftest import (
-    find_subcommand,
     run_cmd,
 )
 
@@ -402,8 +401,7 @@ def test_add_another_subcommand(subcommand_app):
     This tests makes sure _set_parser_prog() sets _prog_prefix on every _SubParsersAction so that all future calls
     to add_parser() write the correct prog value to the parser being added.
     """
-    base_parser = subcommand_app._command_parsers.get('base')
-    find_subcommand(subcommand_app._command_parsers.get('base'), [])
+    base_parser = subcommand_app._command_parsers.get(subcommand_app.do_base)
     for sub_action in base_parser._actions:
         if isinstance(sub_action, argparse._SubParsersAction):
             new_parser = sub_action.add_parser('new_sub', help='stuff')

--- a/tests/transcripts/from_cmdloop.txt
+++ b/tests/transcripts/from_cmdloop.txt
@@ -2,7 +2,7 @@
 # so you can see where they are.
 
 (Cmd) help say
-Usage: say [-h] [-p] [-s] [-r REPEAT]/ */
+Usage: speak [-h] [-p] [-s] [-r REPEAT]/ */
 
 Repeats what you tell me to./ */
 

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -164,8 +164,10 @@ def test_command_synonyms():
         # Create a synonym to a command inside of this CommandSet
         do_builtin_synonym = do_builtin
 
-        # Create a synonym to a command outside of this CommandSet
-        do_help_synonym = cmd2.Cmd.do_help
+        # Create a synonym to a command outside of this CommandSet with subcommands.
+        # This will best test the synonym check in cmd2.Cmd._check_uninstallable() when
+        # we unresgister this CommandSet.
+        do_alias_synonym = cmd2.Cmd.do_alias
 
     cs = SynonymCommandSet("foo")
     app = WithCommandSets(command_sets=[cs])
@@ -176,21 +178,21 @@ def test_command_synonyms():
     assert builtin_parser is not None
     assert builtin_parser is builtin_synonym_parser
 
-    help_parser = app._command_parsers.get(cmd2.Cmd.do_help)
-    help_synonym_parser = app._command_parsers.get(app.do_help_synonym)
-    assert help_parser is not None
-    assert help_parser is help_synonym_parser
+    alias_parser = app._command_parsers.get(cmd2.Cmd.do_alias)
+    alias_synonym_parser = app._command_parsers.get(app.do_alias_synonym)
+    assert alias_parser is not None
+    assert alias_parser is alias_synonym_parser
 
     # Unregister the CommandSet and make sure built-in command and synonyms are gone
     app.unregister_command_set(cs)
     assert not hasattr(app, "do_builtin")
     assert not hasattr(app, "do_builtin_synonym")
-    assert not hasattr(app, "do_help_synonym")
+    assert not hasattr(app, "do_alias_synonym")
 
-    # Make sure the help command still exists, has the same parser, and works.
-    assert help_parser is app._command_parsers.get(cmd2.Cmd.do_help)
-    out, err = run_cmd(app, 'help')
-    assert app.doc_header in out
+    # Make sure the alias command still exists, has the same parser, and works.
+    assert alias_parser is app._command_parsers.get(cmd2.Cmd.do_alias)
+    out, err = run_cmd(app, 'alias --help')
+    assert normalize(alias_parser.format_help())[0] in out
 
 
 def test_custom_construct_commandsets():


### PR DESCRIPTION
Fixes #1383 

Also fixed issue where `Cmd.ppaged()` was not writing to the passed in destination.