### PR TITLE
Minior improvements to some of the GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,18 +20,14 @@ jobs:
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --dev
+
+      - name: Install the project
+        run: make install
 
       - name: Run tests
-        run: uv run inv pytest --junit --no-pty --base
-
-      - name: Run isolated tests
-        run: uv run inv pytest --junit --no-pty --isolated
+        run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install the project
         run: uv sync --dev
 
-      - name: Install the project
-        run: make install
-
       - name: Run tests
-        run: make test
+        run: uv run inv pytest --junit --no-pty --base
+
+      - name: Run isolated tests
+        run: uv run inv pytest --junit --no-pty --isolated

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,15 @@ jobs:
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install the project
-        run: uv sync --dev
+        run: uv sync --all-extras --dev
 
       - name: Run tests
         run: uv run inv pytest --junit --no-pty --base

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,11 +21,11 @@ jobs:
           # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
           # Set fetch-depth: 0 to fetch all history for all branches and tags.
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
-      - name: Set up Python
-        uses: actions/setup-python@v5 # https://github.com/actions/setup-python
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install python prerequisites
-        run: pip install -U --user pip setuptools setuptools-scm griffe_typingdoc mkdocs-include-markdown-plugin mkdocs-macros-plugin mkdocs-material mkdocstrings[python] . plugins/ext_test
+      - name: Install the project
+        run: uv sync --docs
       - name: MkDocs documentation build
-        run: mkdocs build
+        run: uv run mkdocs build -s

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install the project
-        run: uv sync --docs
+        run: uv sync --group docs
       - name: MkDocs documentation build
         run: uv run mkdocs build -s

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,5 +16,5 @@ jobs:
           # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
           # Set fetch-depth: 0 to fetch all history for all branches and tags.
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
-      - run: pip install --user ruff
+      - uses: astral-sh/ruff-action@v3
       - run: ruff format --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
           # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
           # Set fetch-depth: 0 to fetch all history for all branches and tags.
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
-      - run: pip install --user ruff
+      - uses: astral-sh/ruff-action@v3
       - run: ruff check --output-format=github .

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,12 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # https://github.com/actions/checkout
-      - uses: actions/setup-python@v5 # https://github.com/actions/setup-python
         with:
-          python-version: 3.13
-          allow-prereleases: true
           # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
           # Set fetch-depth: 0 to fetch all history for all branches and tags.
           fetch-depth: 0 # Needed for setuptools_scm to work correctly
-      - run: pip install -U --user pip mypy
-      - run: mypy .
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: 3.13
+      - name: Install the project
+        run: uv sync --validate
+      - name: Run mypy static type checker
+        run: uv run mypy .

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           python-version: 3.13
       - name: Install the project
-        run: uv sync --validate
+        run: uv sync --group validate
       - name: Run mypy static type checker
         run: uv run mypy .


### PR DESCRIPTION
- Bump doc build Python version to 3.13
- Use `uv` and `ruff` GH Actions provided by **Astral** where possible