### PR TITLE
Suppress mypy warning

### DIFF
--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1361,7 +1361,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         # determine help from format above
         return formatter.format_help() + '\n'
 
-    def _print_message(self, message: str, file: Optional[IO[str]] = None) -> None:
+    def _print_message(self, message: str, file: Optional[IO[str]] = None) -> None:  # type: ignore[override]
         # Override _print_message to use style_aware_write() since we use ANSI escape characters to support color
         if message:
             if file is None:


### PR DESCRIPTION
Supress new `mypy` warning that first appeared with a new version of `mypy`.

Warning is:
```
cmd2/argparse_custom.py: note: In member "_print_message" of class "Cmd2ArgumentParser":
cmd2/argparse_custom.py:1364:44: error: Argument 2 of "_print_message" is incompatible with supertype "ArgumentParser"; supertype defines the argument type as "SupportsWrite[str] | None"  [override]
cmd2/argparse_custom.py:1364:44: note: This violates the Liskov substitution principle
cmd2/argparse_custom.py:1364:44: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```

I tried replacing `typing.IO[str]` with `SupportsWrite[str]` as suggested, but then that broke things down the road because we need this thing to support an `isatty` method. So for now we can just suppress this warning.