### PR TITLE
Enable ruff ANN ruleset to warn about missing type annotations

### DIFF
--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -150,7 +150,7 @@ class Settable:
         """
         if val_type is bool:
 
-            def get_bool_choices(_) -> list[str]:  # type: ignore[no-untyped-def]
+            def get_bool_choices(_: str) -> list[str]:
                 """Used to tab complete lowercase boolean values."""
                 return ['true', 'false']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ select = [
     # https://docs.astral.sh/ruff/rules
     "A", # flake8-builtins (variables or arguments shadowing built-ins)
     # "AIR", # Airflow specific warnings
-    # "ANN", # flake8-annotations (missing type annotations for arguments or return types)
+    "ANN", # flake8-annotations (missing type annotations for arguments or return types)
     # "ARG", # flake8-unused-arguments (functions or methods with arguments that are never used)
     "ASYNC", # flake8-async (async await bugs)
     # "B", # flake8-bugbear (various likely bugs and design issues)
@@ -222,6 +222,7 @@ select = [
 ]
 ignore = [
     # `uv run ruff rule E501` for a description of that rule
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed (would be good to enable this later)
     "COM812", # Conflicts with ruff format (see https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)
     "COM819", # Conflicts with ruff format
     "D206",   # Conflicts with ruff format


### PR DESCRIPTION
Enable ruff ANN ruleset to warn about missing type annotations for arguments and return values.

However, globally disabled rule ANN401 which disallows use of `typing.Any` because that is just too strict for now.