### PR TITLE
Enable ruff ARG ruleset to warn about unused arguments

### DIFF
--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -280,7 +280,7 @@ class CompletionItem(str):  # noqa: SLOT000
     See header of this file for more information
     """
 
-    def __new__(cls, value: object, *args: Any, **kwargs: Any) -> 'CompletionItem':
+    def __new__(cls, value: object, *_args: Any, **_kwargs: Any) -> 'CompletionItem':
         return super().__new__(cls, value)
 
     def __init__(self, value: object, description: str = '', *args: Any) -> None:
@@ -914,7 +914,7 @@ setattr(argparse.ArgumentParser, 'set_ap_completer_type', _ArgumentParser_set_ap
 ############################################################################################################
 # Patch ArgumentParser._check_value to support CompletionItems as choices
 ############################################################################################################
-def _ArgumentParser_check_value(self: argparse.ArgumentParser, action: argparse.Action, value: Any) -> None:  # noqa: N802
+def _ArgumentParser_check_value(_self: argparse.ArgumentParser, action: argparse.Action, value: Any) -> None:  # noqa: N802
     """Custom override of ArgumentParser._check_value that supports CompletionItems as choices.
     When evaluating choices, input is compared to CompletionItem.orig_value instead of the
     CompletionItem instance.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1111,7 +1111,7 @@ class Cmd(cmd.Cmd):
     def build_settables(self) -> None:
         """Create the dictionary of user-settable parameters."""
 
-        def get_allow_style_choices(cli_self: Cmd) -> list[str]:
+        def get_allow_style_choices(_cli_self: Cmd) -> list[str]:
             """Used to tab complete allow_style values."""
             return [val.name.lower() for val in ansi.AllowStyle]
 
@@ -1419,9 +1419,9 @@ class Cmd(cmd.Cmd):
     def basic_complete(
         self,
         text: str,
-        line: str,
-        begidx: int,
-        endidx: int,
+        line: str,  # noqa: ARG002
+        begidx: int,  # noqa: ARG002
+        endidx: int,  # noqa: ARG002
         match_against: Iterable[str],
     ) -> list[str]:
         """Basic tab completion function that matches against a list of strings without considering line contents
@@ -1602,7 +1602,13 @@ class Cmd(cmd.Cmd):
         return matches
 
     def path_complete(
-        self, text: str, line: str, begidx: int, endidx: int, *, path_filter: Optional[Callable[[str], bool]] = None
+        self,
+        text: str,
+        line: str,
+        begidx: int,  # noqa: ARG002
+        endidx: int,
+        *,
+        path_filter: Optional[Callable[[str], bool]] = None,
     ) -> list[str]:
         """Performs completion of local file system paths.
 
@@ -2346,7 +2352,7 @@ class Cmd(cmd.Cmd):
         # Filter out hidden and disabled commands
         return [topic for topic in all_topics if topic not in self.hidden_commands and topic not in self.disabled_commands]
 
-    def sigint_handler(self, signum: int, _: Optional[FrameType]) -> None:
+    def sigint_handler(self, signum: int, _: Optional[FrameType]) -> None:  # noqa: ARG002
         """Signal handler for SIGINTs which typically come from Ctrl-C events.
 
         If you need custom SIGINT behavior, then override this method.
@@ -2402,7 +2408,7 @@ class Cmd(cmd.Cmd):
         """
         return Statement(statement) if not isinstance(statement, Statement) else statement
 
-    def postcmd(self, stop: bool, statement: Union[Statement, str]) -> bool:
+    def postcmd(self, stop: bool, statement: Union[Statement, str]) -> bool:  # noqa: ARG002
         """Hook method executed just after a command is executed by
         [cmd2.Cmd.onecmd][].
 
@@ -3087,7 +3093,7 @@ class Cmd(cmd.Cmd):
                 # Disable completion
                 if completion_mode == utils.CompletionMode.NONE:
 
-                    def complete_none(text: str, state: int) -> Optional[str]:  # pragma: no cover
+                    def complete_none(text: str, state: int) -> Optional[str]:  # pragma: no cover  # noqa: ARG001
                         return None
 
                     complete_func = complete_none
@@ -3773,7 +3779,7 @@ class Cmd(cmd.Cmd):
                 self.perror(err_msg, apply_style=False)
                 self.last_result = False
 
-    def print_topics(self, header: str, cmds: Optional[list[str]], cmdlen: int, maxcol: int) -> None:
+    def print_topics(self, header: str, cmds: Optional[list[str]], cmdlen: int, maxcol: int) -> None:  # noqa: ARG002
         """Print groups of commands and topics in columns and an optional header
         Override of cmd's print_topics() to handle headers with newlines, ANSI style sequences, and wide characters.
 
@@ -5379,7 +5385,7 @@ class Cmd(cmd.Cmd):
         setattr(self, help_func_name, new_func)
 
         # Set the completer to a function that returns a blank list
-        setattr(self, completer_func_name, lambda *args, **kwargs: [])
+        setattr(self, completer_func_name, lambda *_args, **_kwargs: [])
 
     def disable_category(self, category: str, message_to_print: str) -> None:
         """Disable an entire category of commands.

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -145,7 +145,7 @@ class Statement(str):  # type: ignore[override]  # noqa: SLOT000
     # Used in JSON dictionaries
     _args_field = 'args'
 
-    def __new__(cls, value: object, *pos_args: Any, **kw_args: Any) -> 'Statement':
+    def __new__(cls, value: object, *_pos_args: Any, **_kw_args: Any) -> 'Statement':
         """Create a new instance of Statement.
 
         We must override __new__ because we are subclassing `str` which is

--- a/examples/basic_completion.py
+++ b/examples/basic_completion.py
@@ -82,7 +82,7 @@ class BasicCompletion(cmd2.Cmd):
         """Demonstrates effect of raising CompletionError."""
         self.poutput(f"Args: {statement.args}")
 
-    def complete_raise_error(self, text, line, begidx, endidx) -> list[str]:
+    def complete_raise_error(self, _text, _line, _begidx, _endidx) -> list[str]:
         """CompletionErrors can be raised if an error occurs while tab completing.
 
         Example use cases

--- a/examples/default_categories.py
+++ b/examples/default_categories.py
@@ -67,7 +67,7 @@ class ExampleApp(cmd2.Cmd):
     def __init__(self) -> None:
         super().__init__()
 
-    def do_something(self, arg) -> None:
+    def do_something(self, _arg) -> None:
         self.poutput('this is the something command')
 
 

--- a/examples/dynamic_commands.py
+++ b/examples/dynamic_commands.py
@@ -34,7 +34,7 @@ class CommandsInLoop(cmd2.Cmd):
 
         super().__init__(include_ipy=True)
 
-    def send_text(self, args: cmd2.Statement, *, text: str) -> None:
+    def send_text(self, _args: cmd2.Statement, *, text: str) -> None:
         """Simulate sending text to a server and printing the response."""
         self.poutput(text.capitalize())
 

--- a/examples/environment.py
+++ b/examples/environment.py
@@ -16,7 +16,7 @@ class EnvironmentApp(cmd2.Cmd):
         )
         self.add_settable(cmd2.Settable('sunny', bool, 'Is it sunny outside?', self))
 
-    def do_sunbathe(self, arg) -> None:
+    def do_sunbathe(self, _arg) -> None:
         """Attempt to sunbathe."""
         if self.degrees_c < 20:
             result = f"It's {self.degrees_c} C - are you a penguin?"
@@ -26,7 +26,7 @@ class EnvironmentApp(cmd2.Cmd):
             result = 'UV is bad for your skin.'
         self.poutput(result)
 
-    def _onchange_degrees_c(self, param_name, old, new) -> None:
+    def _onchange_degrees_c(self, _param_name, _old, new) -> None:
         # if it's over 40C, it's gotta be sunny, right?
         if new > 40:
             self.sunny = True

--- a/examples/migrating.py
+++ b/examples/migrating.py
@@ -13,7 +13,7 @@ class CmdLineApp(cmd.Cmd):
     MUMBLE_FIRST = ('so', 'like', 'well')
     MUMBLE_LAST = ('right?',)
 
-    def do_exit(self, line) -> bool:
+    def do_exit(self, _line) -> bool:
         """Exit the application."""
         return True
 

--- a/examples/modular_commands/commandset_basic.py
+++ b/examples/modular_commands/commandset_basic.py
@@ -73,7 +73,7 @@ class BasicCompletionCommandSet(CommandSet):
         """Demonstrates effect of raising CompletionError."""
         self._cmd.poutput(f"Args: {statement.args}")
 
-    def complete_raise_error(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
+    def complete_raise_error(self, _text: str, _line: str, _begidx: int, _endidx: int) -> list[str]:
         """CompletionErrors can be raised if an error occurs while tab completing.
 
         Example use cases
@@ -83,5 +83,5 @@ class BasicCompletionCommandSet(CommandSet):
         raise CompletionError("This is how a CompletionError behaves")
 
     @with_category('Not Basic Completion')
-    def do_custom_category(self, statement: Statement) -> None:
+    def do_custom_category(self, _statement: Statement) -> None:
         self._cmd.poutput('Demonstrates a command that bypasses the default category')

--- a/examples/modular_commands/commandset_complex.py
+++ b/examples/modular_commands/commandset_complex.py
@@ -7,10 +7,10 @@ import cmd2
 
 @cmd2.with_default_category('Fruits')
 class CommandSetA(cmd2.CommandSet):
-    def do_apple(self, statement: cmd2.Statement) -> None:
+    def do_apple(self, _statement: cmd2.Statement) -> None:
         self._cmd.poutput('Apple!')
 
-    def do_banana(self, statement: cmd2.Statement) -> None:
+    def do_banana(self, _statement: cmd2.Statement) -> None:
         """Banana Command."""
         self._cmd.poutput('Banana!!')
 

--- a/examples/modular_commands/commandset_custominit.py
+++ b/examples/modular_commands/commandset_custominit.py
@@ -16,8 +16,8 @@ class CustomInitCommandSet(CommandSet):
         self._arg1 = arg1
         self._arg2 = arg2
 
-    def do_show_arg1(self, cmd: Cmd, _: Statement) -> None:
+    def do_show_arg1(self, _cmd: Cmd, _: Statement) -> None:
         self._cmd.poutput('Arg1: ' + self._arg1)
 
-    def do_show_arg2(self, cmd: Cmd, _: Statement) -> None:
+    def do_show_arg2(self, _cmd: Cmd, _: Statement) -> None:
         self._cmd.poutput('Arg2: ' + self._arg2)

--- a/examples/modular_commands_basic.py
+++ b/examples/modular_commands_basic.py
@@ -26,7 +26,7 @@ class ExampleApp(cmd2.Cmd):
     def __init__(self) -> None:
         super().__init__()
 
-    def do_something(self, arg) -> None:
+    def do_something(self, _arg) -> None:
         self.poutput('this is the something command')
 
 

--- a/examples/pirate.py
+++ b/examples/pirate.py
@@ -41,7 +41,7 @@ class Pirate(cmd2.Cmd):
         self.initial_gold = self.gold
         return line
 
-    def postcmd(self, stop, line):
+    def postcmd(self, stop, _line):
         """Runs right before a command is about to return."""
         if self.gold != self.initial_gold:
             self.poutput(f'Now we gots {self.gold} doubloons')
@@ -51,7 +51,7 @@ class Pirate(cmd2.Cmd):
             stop = True
         return stop
 
-    def do_loot(self, arg) -> None:
+    def do_loot(self, _arg) -> None:
         """Seize booty from a passing ship."""
         self.gold += 1
 
@@ -67,7 +67,7 @@ class Pirate(cmd2.Cmd):
                 self.poutput(f'''What's "{arg}"?  I'll take rrrum.''')
             self.gold -= 1
 
-    def do_quit(self, arg) -> bool:
+    def do_quit(self, _arg) -> bool:
         """Quit the application gracefully."""
         self.poutput("Quiterrr!")
         return True

--- a/examples/python_scripting.py
+++ b/examples/python_scripting.py
@@ -40,7 +40,7 @@ class CmdLineApp(cmd2.Cmd):
         self.cwd = os.getcwd()
         self.prompt = ansi.style(f'{self.cwd} $ ', fg=ansi.Fg.CYAN)
 
-    def postcmd(self, stop: bool, line: str) -> bool:
+    def postcmd(self, stop: bool, _line: str) -> bool:
         """Hook method executed just after a command dispatch is finished.
 
         :param stop: if True, the command has indicated the application should exit
@@ -96,7 +96,7 @@ class CmdLineApp(cmd2.Cmd):
     dir_parser.add_argument('-l', '--long', action='store_true', help="display in long format with one item per line")
 
     @cmd2.with_argparser(dir_parser, with_unknown_args=True)
-    def do_dir(self, args, unknown) -> None:
+    def do_dir(self, _args, unknown) -> None:
         """List contents of current directory."""
         # No arguments for this command
         if unknown:

--- a/plugins/ext_test/examples/example.py
+++ b/plugins/ext_test/examples/example.py
@@ -11,7 +11,7 @@ class Example(cmd2.Cmd):
         # gotta have this or neither the plugin or cmd2 will initialize
         super().__init__(*args, **kwargs)
 
-    def do_something(self, arg):
+    def do_something(self, _arg):
         self.last_result = 5
         self.poutput('this is the something command')
 

--- a/plugins/template/examples/example.py
+++ b/plugins/template/examples/example.py
@@ -11,7 +11,7 @@ class Example(cmd2_myplugin.MyPlugin, cmd2.Cmd):
         super().__init__(*args, **kwargs)
 
     @cmd2_myplugin.empty_decorator
-    def do_something(self, arg) -> None:
+    def do_something(self, _arg) -> None:
         self.poutput('this is the something command')
 
 

--- a/plugins/template/tasks.py
+++ b/plugins/template/tasks.py
@@ -96,7 +96,7 @@ DISTDIR = 'dist'
 
 
 @invoke.task
-def build_clean(context) -> None:
+def build_clean(_context) -> None:
     """Remove the build directory."""
     # pylint: disable=unused-argument
     rmrf(BUILDDIR)
@@ -106,7 +106,7 @@ namespace_clean.add_task(build_clean, 'build')
 
 
 @invoke.task
-def dist_clean(context) -> None:
+def dist_clean(_context) -> None:
     """Remove the dist directory."""
     # pylint: disable=unused-argument
     rmrf(DISTDIR)
@@ -116,7 +116,7 @@ namespace_clean.add_task(dist_clean, 'dist')
 
 
 @invoke.task
-def eggs_clean(context) -> None:
+def eggs_clean(_context) -> None:
     """Remove egg directories."""
     # pylint: disable=unused-argument
     dirs = set()
@@ -133,7 +133,7 @@ namespace_clean.add_task(eggs_clean, 'eggs')
 
 
 @invoke.task
-def bytecode_clean(context) -> None:
+def bytecode_clean(_context) -> None:
     """Remove __pycache__ directories and *.pyc files."""
     # pylint: disable=unused-argument
     dirs = set()

--- a/plugins/template/tests/test_myplugin.py
+++ b/plugins/template/tests/test_myplugin.py
@@ -18,7 +18,7 @@ class MyApp(cmd2_myplugin.MyPluginMixin, cmd2.Cmd):
         super().__init__(*args, **kwargs)
 
     @cmd2_myplugin.empty_decorator
-    def do_empty(self, args) -> None:
+    def do_empty(self, _args) -> None:
         self.poutput("running the empty command")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,8 @@ select = [
     # https://docs.astral.sh/ruff/rules
     "A", # flake8-builtins (variables or arguments shadowing built-ins)
     # "AIR", # Airflow specific warnings
-    "ANN", # flake8-annotations (missing type annotations for arguments or return types)
-    # "ARG", # flake8-unused-arguments (functions or methods with arguments that are never used)
+    "ANN",   # flake8-annotations (missing type annotations for arguments or return types)
+    "ARG",   # flake8-unused-arguments (functions or methods with arguments that are never used)
     "ASYNC", # flake8-async (async await bugs)
     # "B", # flake8-bugbear (various likely bugs and design issues)
     "BLE", # flake8-blind-except (force more specific exception types than just Exception)
@@ -279,6 +279,7 @@ per-file-ignores."plugins/*.py" = [
 
 per-file-ignores."tests/*.py" = [
     "ANN",  # Ignore all type annotation rules in test folders
+    "ARG",  # Ignore all unused argument warnings in test folders
     "D",    # Ignore all pydocstyle rules in test folders
     "E501", # Line too long
     "S",    # Ignore all Security rules in test folders
@@ -292,6 +293,7 @@ per-file-ignores."tests/pyscript/*.py" = [
 
 per-file-ignores."tests_isolated/*.py" = [
     "ANN", # Ignore all type annotation rules in test folders
+    "ARG", # Ignore all unused argument warnings in test folders
     "D",   # Ignore all pydocstyle rules in test folders
     "S",   # Ignore all Security rules in test folders
     "SLF", # Ignore all warnings about private or protected member access in test folders

--- a/tasks.py
+++ b/tasks.py
@@ -125,7 +125,7 @@ MKDOCS_OPTS = '-nvWT'  # Be nitpicky, verbose, and treat warnings as errors
 
 
 @invoke.task()
-def docs(context: Context, builder: str = 'html') -> None:
+def docs(context: Context) -> None:
     """Build documentation using MkDocs."""
     with context.cd(TASK_ROOT_STR):
         context.run('mkdocs build', pty=True)


### PR DESCRIPTION
Enable ruff ARG ruleset to warn about unused arguments.

However, disabled it in all of the test folders for convenience.