### PR TITLE
Enable ruff TRY ruleset for warnings related to try/except issues

### DIFF
--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -392,14 +392,14 @@ class ChoicesCallable:
     def completer(self) -> CompleterFunc:
         if not isinstance(self.to_call, (CompleterFuncBase, CompleterFuncWithTokens)):  # pragma: no cover
             # this should've been caught in the constructor, just a backup check
-            raise ValueError('Function is not a CompleterFunc')
+            raise TypeError('Function is not a CompleterFunc')
         return self.to_call
 
     @property
     def choices_provider(self) -> ChoicesProviderFunc:
         if not isinstance(self.to_call, (ChoicesProviderFuncBase, ChoicesProviderFuncWithTokens)):  # pragma: no cover
             # this should've been caught in the constructor, just a backup check
-            raise ValueError('Function is not a ChoicesProviderFunc')
+            raise TypeError('Function is not a ChoicesProviderFunc')
         return self.to_call
 
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2497,7 +2497,7 @@ class Cmd(cmd.Cmd):
             if stop:
                 # we should not run the command, but
                 # we need to run the finalization hooks
-                raise EmptyStatement
+                raise EmptyStatement  # noqa: TRY301
 
             redir_saved_state: Optional[utils.RedirectionSavedState] = None
 
@@ -4047,7 +4047,7 @@ class Cmd(cmd.Cmd):
             try:
                 choice = int(response)
                 if choice < 1:
-                    raise IndexError
+                    raise IndexError  # noqa: TRY301
                 return fulloptions[choice - 1][0]
             except (ValueError, IndexError):
                 self.poutput(f"'{response}' isn't a valid choice. Pick a number between 1 and {len(fulloptions)}:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ select = [
     "TC",  # flake8-type-checking (type checking warnings)
     "TD",  # flake8-todos (force all TODOs to include an author and issue link)
     "TID", # flake8-tidy-imports (extra import rules to check)
-    # "TRY", # tryceratops (warnings related to exceptions and try/except)
+    "TRY", # tryceratops (warnings related to exceptions and try/except)
     "UP",  # pyupgrade (A tool (and pre-commit hook) to automatically upgrade syntax for newer versions of the language)
     "W",   # pycodestyle warnings (warn about minor stylistic issues)
     "YTT", # flake8-2020 (checks for misuse of sys.version or sys.version_info)
@@ -236,6 +236,7 @@ ignore = [
     "Q002",   # Conflicts with ruff format
     "Q003",   # Conflicts with ruff format
     "TC006",  # Add quotes to type expression in typing.cast() (not needed except for forward references)
+    "TRY003", # Avoid specifying long messages outside the exception class (force custom exceptions for everything)
     "UP007",  # Use X | Y for type annotations (requires Python 3.10+)
     "UP017",  # Use datetime.UTC alias (requires Python 3.11+)
     "UP036",  # Version block is outdated for minimum Python version (requires ruff target_version set to minimum supported)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -643,8 +643,6 @@ def test_output_redirection(base_app) -> None:
             appended_content = f.read()
         assert appended_content.startswith(content)
         assert len(appended_content) > len(content)
-    except Exception:
-        raise
     finally:
         os.remove(filename)
 
@@ -686,8 +684,6 @@ def test_feedback_to_output_true(base_app) -> None:
         with open(filename) as f:
             content = f.readlines()
         assert content[-1].startswith('Elapsed: ')
-    except:
-        raise
     finally:
         os.remove(filename)
 
@@ -705,8 +701,6 @@ def test_feedback_to_output_false(base_app) -> None:
             content = f.readlines()
         assert not content[-1].startswith('Elapsed: ')
         assert err[0].startswith('Elapsed')
-    except:
-        raise
     finally:
         os.remove(filename)
 


### PR DESCRIPTION
Enable ruff TRY ruleset for warnings related to try/except issues.

Globally disabled specific TRY003 rule because it wants you to avoid long messages when raising an exception and basically put the logic in a custom exception class for everything. This is too much of a hassle IMO.