### PR TITLE
Undo backwards-incompatible change in naming of cmd2.ansi.Cursor method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ uv.lock
 # Node/npm used for installing Prettier locally to override the outdated version that is bundled with the VSCode extension
 node_modules/
 package-lock.json
-package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Breaking Change
     - `cmd2` 2.6 supports Python 3.9+ (removed support for Python 3.8)
-    - Renamed methods in `cmd2.ansi.Cursor` to make it clear they are intended for internal use only as was documented
 - Enhancements
     - Add support for Python 3.14
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Simple Makefile for use with a uv-based development environment
 .PHONY: install
-install: ## Install the virtual environment
-	@echo "🚀 Creating virtual environment"
+install: ## Install the virtual environment with dependencies
+	@echo "🚀 Creating uv Python virtual environment"
 	@uv sync
+	@echo "🚀 Installing Prettier using npm"
+	@npm install
 
 .PHONY: check
 check: ## Run code quality tools.

--- a/cmd2/ansi.py
+++ b/cmd2/ansi.py
@@ -219,27 +219,27 @@ class Cursor:
     """Create ANSI sequences to alter the cursor position."""
 
     @staticmethod
-    def _up(count: int = 1) -> str:
+    def UP(count: int = 1) -> str:  # noqa: N802
         """Move the cursor up a specified amount of lines (Defaults to 1)."""
         return f"{CSI}{count}A"
 
     @staticmethod
-    def _down(count: int = 1) -> str:
+    def DOWN(count: int = 1) -> str:  # noqa: N802
         """Move the cursor down a specified amount of lines (Defaults to 1)."""
         return f"{CSI}{count}B"
 
     @staticmethod
-    def _forward(count: int = 1) -> str:
+    def FORWARD(count: int = 1) -> str:  # noqa: N802
         """Move the cursor forward a specified amount of lines (Defaults to 1)."""
         return f"{CSI}{count}C"
 
     @staticmethod
-    def _back(count: int = 1) -> str:
+    def BACK(count: int = 1) -> str:  # noqa: N802
         """Move the cursor back a specified amount of lines (Defaults to 1)."""
         return f"{CSI}{count}D"
 
     @staticmethod
-    def _set_pos(x: int, y: int) -> str:
+    def SET_POS(x: int, y: int) -> str:  # noqa: N802
         """Set the cursor position to coordinates which are 1-based."""
         return f"{CSI}{y};{x}H"
 
@@ -1079,11 +1079,11 @@ def async_alert_str(*, terminal_columns: int, prompt: str, line: str, cursor_off
 
     # Move the cursor down to the last input line
     if cursor_input_line != num_input_terminal_lines:
-        terminal_str += Cursor._down(num_input_terminal_lines - cursor_input_line)
+        terminal_str += Cursor.DOWN(num_input_terminal_lines - cursor_input_line)
 
     # Clear each line from the bottom up so that the cursor ends up on the first prompt line
     total_lines = num_prompt_terminal_lines + num_input_terminal_lines
-    terminal_str += (clear_line() + Cursor._up(1)) * (total_lines - 1)
+    terminal_str += (clear_line() + Cursor.UP(1)) * (total_lines - 1)
 
     # Clear the first prompt line
     terminal_str += clear_line()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "prettier": "^3.5.3",
+    "prettier-plugin-toml": "^2.0.5"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ per-file-ignores."cmd2/argparse_custom.py" = [
     "B010", # Do not call setattr with a constant attribute value
 ]
 
-
 per-file-ignores."examples/*.py" = [
     "ANN",     # Ignore all type annotation rules in examples folder
     "D",       # Ignore all pydocstyle rules in examples folder
@@ -308,7 +307,6 @@ per-file-ignores."tests_isolated/*.py" = [
     "S",   # Ignore all Security rules in test folders
     "SLF", # Ignore all warnings about private or protected member access in test folders
 ]
-
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -202,14 +202,14 @@ def test_clear_line() -> None:
 
 def test_cursor() -> None:
     count = 1
-    assert ansi.Cursor._up(count) == f"{ansi.CSI}{count}A"
-    assert ansi.Cursor._down(count) == f"{ansi.CSI}{count}B"
-    assert ansi.Cursor._forward(count) == f"{ansi.CSI}{count}C"
-    assert ansi.Cursor._back(count) == f"{ansi.CSI}{count}D"
+    assert ansi.Cursor.UP(count) == f"{ansi.CSI}{count}A"
+    assert ansi.Cursor.DOWN(count) == f"{ansi.CSI}{count}B"
+    assert ansi.Cursor.FORWARD(count) == f"{ansi.CSI}{count}C"
+    assert ansi.Cursor.BACK(count) == f"{ansi.CSI}{count}D"
 
     x = 4
     y = 5
-    assert ansi.Cursor._set_pos(x, y) == f"{ansi.CSI}{y};{x}H"
+    assert ansi.Cursor.SET_POS(x, y) == f"{ansi.CSI}{y};{x}H"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Undo backwards-incompatible change in naming of cmd2.ansi.Cursor method.

It just wasn't worth making a backwards-incompatible change which might impact people, especially since we are likely to replace the ansi module with one based on rich in the near future.

Also updated the Makefile to also install prettier using npm and added the package.json file to Git to support this.