### PR TITLE
Fix Codecov code coverage analysis from test data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,26 +36,23 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: uv run inv pytest --junit --no-pty --base
+        run: uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml tests
 
       - name: Run isolated tests
-        run: uv run inv pytest --junit --no-pty --isolated
+        run: uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml tests_isolated
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
-          files: ./junit.xml,!./cache
           flags: python${{ matrix.python-version }}
           name: codecov-umbrella-test-results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          directory: ./coverage/reports/
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage1.xml,./coverage2.xml,!./cache
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,22 @@ jobs:
       - name: Run isolated tests
         run: uv run inv pytest --junit --no-pty --isolated
 
-      - name: Upload coverage reports to Codecov with GitHub Action on Python 3.13 for each OS
-        uses: codecov/codecov-action@v3
-        if: ${{ matrix.python-version == '3.13' }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./junit.xml,!./cache
+          flags: python${{ matrix.python-version }}
+          name: codecov-umbrella-test-results
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./coverage/reports/
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage1.xml,./coverage2.xml,!./cache
+          flags: unittests
+          name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true


### PR DESCRIPTION
This PR does a few things in pursuit of fixing our integrated code coverage analysis provided by [Codecov](https://app.codecov.io/gh/python-cmd2/cmd2):

1. It removes the last usage of `invoke` from our GitHub Actions CI scripts. Now we rely purely on `uv` for everything.
2. Uploading of data to `Codecov` is now done using a private token which is stored in GitHub secrets for this repo.
3. Both test data and code coverage are now uploaded.
