### PR TITLE
Add an initial codecov.yml file to tell it to ignore test and examples

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+# Components allow you to isolate and categorize coverage data from your project with virtual filters
+component_management:
+  individual_components:
+    - component_id: cmd2 # this is an identifier that should not be changed
+      name: cmd2 # this is a display name, and can be changed freely
+      paths:
+        - cmd2/**
+    - component_id: plugins
+      name: plugins
+      paths:
+        - plugins/**
+
+# Ignore certain paths, all files under these paths will be skipped during processing
+ignore:
+  - "examples" # ignore example code folder
+  - "tests" # ignore unit test code folder
+  - "tests_isolated" # ignore integration test code folder


### PR DESCRIPTION
Add an initial `codecov.yml` file to tell Codecov to ignore test and examples code.

Also tell it to split the plugin directory into a separate component.

Closes #1436 