### PR TITLE
Ruggedize cmd2's runtime type annotation validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.1 (TBD)
+
+- Enhancements
+    - Ruggedize runtime validation of type annotations when registering hook methods
+
 ## 2.6.0 (May 31, 2025)
 
 - Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.6.1 (TBD)
 
-- Enhancements
-    - Ruggedize runtime validation of type annotations when registering hook methods
+- Bug Fixes
+    - Fix bug that prevented `cmd2` from working with `from __future__ import annotations`
 
 ## 2.6.0 (May 31, 2025)
 

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -16,7 +16,6 @@ import unicodedata
 from collections.abc import Callable, Iterable
 from difflib import SequenceMatcher
 from enum import Enum
-from types import NoneType
 from typing import TYPE_CHECKING, Any, Optional, TextIO, TypeVar, Union, cast, get_type_hints
 
 from . import constants
@@ -1263,6 +1262,6 @@ def get_types(func_or_method: Callable[..., Any]) -> tuple[dict[str, Any], Any]:
     ret_ann = type_hints.pop('return', None)  # Pop off the return annotation if it exists
     if inspect.ismethod(func_or_method):
         type_hints.pop('self', None)  # Pop off `self` hint for methods
-    if ret_ann is NoneType:
+    if ret_ann is type(None):
         ret_ann = None  # Simplify logic to just return None instead of NoneType
     return type_hints, ret_ann

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -1258,7 +1258,10 @@ def get_types(func_or_method: Callable[..., Any]) -> tuple[dict[str, Any], Any]:
     :return tuple with first element being dictionary mapping param names to type hints
             and second element being return type hint, unspecified, returns None
     """
-    type_hints = get_type_hints(func_or_method)  # Get dictionary of type hints
+    try:
+        type_hints = get_type_hints(func_or_method)  # Get dictionary of type hints
+    except TypeError as exc:
+        raise ValueError("Argument passed to get_types should be a function or method") from exc
     ret_ann = type_hints.pop('return', None)  # Pop off the return annotation if it exists
     if inspect.ismethod(func_or_method):
         type_hints.pop('self', None)  # Pop off `self` hint for methods

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import cmd2
+
+from .conftest import normalize, run_cmd
+
+
+def test_hooks_work_with_future_annotations() -> None:
+    class HookApp(cmd2.Cmd):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.register_cmdfinalization_hook(self.hook)
+
+        def hook(self: cmd2.Cmd, data: cmd2.plugin.CommandFinalizationData) -> cmd2.plugin.CommandFinalizationData:
+            if self.in_script():
+                self.poutput("WE ARE IN SCRIPT")
+            return data
+
+    hook_app = HookApp()
+    out, err = run_cmd(hook_app, '')
+    expected = normalize('')
+    assert out == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -892,3 +892,44 @@ def test_similarity_overwrite_function() -> None:
 
     suggested_command = cu.suggest_similar("test", ["test"], similarity_function_to_use=custom_similarity_function)
     assert suggested_command is None
+
+
+def test_get_types_invalid_input() -> None:
+    x = 1
+    with pytest.raises(ValueError, match="Argument passed to get_types should be a function or method"):
+        cu.get_types(x)
+
+
+def test_get_types_empty() -> None:
+    def a(b):
+        print(b)
+
+    param_ann, ret_ann = cu.get_types(a)
+    assert ret_ann is None
+    assert param_ann == {}
+
+
+def test_get_types_non_empty() -> None:
+    def foo(x: int) -> str:
+        return f"{x * x}"
+
+    param_ann, ret_ann = cu.get_types(foo)
+    assert ret_ann is str
+    param_name, param_value = next(iter(param_ann.items()))
+    assert param_name == 'x'
+    assert param_value is int
+
+
+def test_get_types_method() -> None:
+    class Foo:
+        def bar(self, x: bool) -> None:
+            print(x)
+
+    f = Foo()
+
+    param_ann, ret_ann = cu.get_types(f.bar)
+    assert ret_ann is None
+    assert len(param_ann) == 1
+    param_name, param_value = next(iter(param_ann.items()))
+    assert param_name == 'x'
+    assert param_value is bool


### PR DESCRIPTION
Change cmd2's runtime type annotation validation for hook callback function registration to be based on `typing.get_type_hints`

Previously it was based on `inspect.signature`. The problem is that prior to Python 3.10, the `inspect` module doesn't have a safe way of evaluating type annotations that works equivalently both in the presence or absence of `from __future__ import annotations`. Hence, any attempt at using that in an app would break `cmd2`. Even in Python 3.10+, it requires an extra argument to be provided.

This change adds a `get_types()` helper function to the `cmd2.utils` module which uses `typing.get_type_hints()` to do the introspection in a safer way.

Down the road when `cmd2` drops support for Python 3.9, we can evaluate to switching the underlying implementation to use `inspect.get_annotations()` if we wish.

Closes #1443 