### PR TITLE
Test as well on the free-threaded version of Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 2.6.2 (June TBD, 2025)
+## 2.6.2 (TBD, 2025)
 
-- Bug Fixes
-    - TBD
+- Enhancements
+    - Added explicit support for free-threaded versions of Python, starting with version 3.14
 
 ## 2.6.1 (June 8, 2025)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pip install -U cmd2
 ```
 
 cmd2 works with Python 3.9+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party
-dependencies.
+dependencies. It works with both conventional CPython and free-threaded variants.
 
 For information on other installation options, see
 [Installation Instructions](https://cmd2.readthedocs.io/en/latest/overview/installation.html) in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [


### PR DESCRIPTION
Python 3.14 will officially support free-threading, removing the "experimental" tag from the free-threaded build. This means it's no longer experimental, but it won't be the default build. The transition to free-threading in Python involves multiple phases, and 3.14 marks the beginning of phase II, where free-threading is officially supported but remains optional. 

This PR simply adds `3.14t`, the free-threaded version of Python 3.14 as an additional test target Python version.

It also updates various files to note that we explicitly support free-threaded versions of Python.