### PR TITLE
No longer setting parser's prog value in with_argparser().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Breaking Changes
 
     - Removed macros
+    - No longer setting parser's `prog` value in `with_argparser()` since it gets set in
+      `Cmd._build_parser()`. This code had previously been restored to support backward
+      compatibility in `cmd2` 2.0 family.
 
 - Enhancements
     - Simplified the process to set a custom parser for `cmd2's` built-in commands. See

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -393,14 +393,6 @@ def with_argparser(
 
         command_name = func.__name__[len(constants.COMMAND_FUNC_PREFIX) :]
 
-        if isinstance(parser, argparse.ArgumentParser):
-            # Set parser's prog value for backward compatibility within the cmd2 2.0 family.
-            # This will be removed in cmd2 3.0 since we never reference this parser object's prog value.
-            # Since it's possible for the same parser object to be passed into multiple with_argparser()
-            # calls, we only set prog on the deep copies of this parser based on the specific do_xxxx
-            # instance method they are associated with.
-            _set_parser_prog(parser, command_name)
-
         # Set some custom attributes for this command
         setattr(cmd_wrapper, constants.CMD_ATTR_ARGPARSER, parser)
         setattr(cmd_wrapper, constants.CMD_ATTR_PRESERVE_QUOTES, preserve_quotes)


### PR DESCRIPTION
No longer setting parser's prog value in with_argparser() since it gets set in Cmd._build_parser().

This code had previously been restored to support backward compatibility in cmd2 2.0 family.
Now that we are moving to cmd2 3.0, it can be removed.
