### PR TITLE
No longer overwriting sys.stderr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
       `Cmd._build_parser()`. This code had previously been restored to support backward
       compatibility in `cmd2` 2.0 family.
 
+    - In an effort be consistent with the purpose of `self.stdout` and our own documentation, the
+      following changes were made.
+        - No longer redirecting `sys.stdout`.
+        - No longer capturing pyscript output written to `sys.stdout`.
+            - To assist with this change, calling `print()` within a pyscript now writes to
+              `self.stdout`. Calling `self.poutput()` within a pyscript is still preferred, but that
+              may not always be possible.
+
 - Enhancements
 
     - Simplified the process to set a custom parser for `cmd2's` built-in commands. See

--- a/cmd2/py_bridge.py
+++ b/cmd2/py_bridge.py
@@ -4,10 +4,7 @@ Maintains a reasonable degree of isolation between the two.
 """
 
 import sys
-from contextlib import (
-    redirect_stderr,
-    redirect_stdout,
-)
+from contextlib import redirect_stderr
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -19,9 +16,7 @@ from typing import (
     cast,
 )
 
-from .utils import (  # namedtuple_with_defaults,
-    StdSim,
-)
+from .utils import StdSim
 
 if TYPE_CHECKING:  # pragma: no cover
     import cmd2
@@ -113,7 +108,7 @@ class PyBridge:
         if echo is None:
             echo = self.cmd_echo
 
-        # This will be used to capture _cmd2_app.stdout and sys.stdout
+        # This will be used to capture _cmd2_app.stdout
         copy_cmd_stdout = StdSim(cast(Union[TextIO, StdSim], self._cmd2_app.stdout), echo=echo)
 
         # Pause the storing of stdout until onecmd_plus_hooks enables it
@@ -127,7 +122,7 @@ class PyBridge:
         stop = False
         try:
             self._cmd2_app.stdout = cast(TextIO, copy_cmd_stdout)
-            with redirect_stdout(cast(IO[str], copy_cmd_stdout)), redirect_stderr(cast(IO[str], copy_stderr)):
+            with redirect_stderr(cast(IO[str], copy_stderr)):
                 stop = self._cmd2_app.onecmd_plus_hooks(
                     command,
                     add_to_history=self._add_to_history,

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -13,10 +13,22 @@ import subprocess
 import sys
 import threading
 import unicodedata
-from collections.abc import Callable, Iterable
+from collections.abc import (
+    Callable,
+    Iterable,
+)
 from difflib import SequenceMatcher
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, TextIO, TypeVar, Union, cast, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    TextIO,
+    TypeVar,
+    Union,
+    cast,
+    get_type_hints,
+)
 
 from . import constants
 from .argparse_custom import ChoicesProviderFunc, CompleterFunc
@@ -683,23 +695,20 @@ class RedirectionSavedState:
     def __init__(
         self,
         self_stdout: Union[StdSim, TextIO],
-        sys_stdout: Union[StdSim, TextIO],
         pipe_proc_reader: Optional[ProcReader],
         saved_redirecting: bool,
     ) -> None:
         """RedirectionSavedState initializer.
 
         :param self_stdout: saved value of Cmd.stdout
-        :param sys_stdout: saved value of sys.stdout
         :param pipe_proc_reader: saved value of Cmd._cur_pipe_proc_reader
         :param saved_redirecting: saved value of Cmd._redirecting.
         """
         # Tells if command is redirecting
         self.redirecting = False
 
-        # Used to restore values after redirection ends
+        # Used to restore self.stdout after redirection ends
         self.saved_self_stdout = self_stdout
-        self.saved_sys_stdout = sys_stdout
 
         # Used to restore values after command ends regardless of whether the command redirected
         self.saved_pipe_proc_reader = pipe_proc_reader

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -61,7 +61,7 @@ be run by the [edit](./builtin_commands.md#edit) command.
 
 ### feedback_to_output
 
-Controls whether feedback generated with the `cmd2.Cmd.pfeedback` method is sent to `sys.stdout` or
+Controls whether feedback generated with the `cmd2.Cmd.pfeedback` method is sent to `self.stdout` or
 `sys.stderr`. If `False` the output will be sent to `sys.stderr`
 
 If `True` the output is sent to `stdout` (which is often the screen but may be


### PR DESCRIPTION
- In an effort be consistent with the purpose of `self.stdout` and our own documentation, the following changes were made.
    - No longer redirecting `sys.stdout`.
    - No longer capturing pyscript output written to `sys.stdout`.
        - To assist with this change, calling `print()` within a pyscript now writes to `self.stdout`. Calling `self.poutput()` within a pyscript is still preferred, but that may not always be possible.