### PR TITLE
Add mypy type checking for Python 3.14 and fix deprecation warning

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     defaults:
       run:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -183,14 +183,12 @@ def is_text_file(file_path: str) -> bool:
     :return: True if the file is a non-empty text file, otherwise False
     :raises OSError: if file can't be read
     """
-    import codecs
-
     expanded_path = os.path.abspath(os.path.expanduser(file_path.strip()))
     valid_text_file = False
 
     # Only need to check for utf-8 compliance since that covers ASCII, too
     try:
-        with codecs.open(expanded_path, encoding='utf-8', errors='strict') as f:
+        with open(expanded_path, encoding='utf-8', errors='strict') as f:
             # Make sure the file has only utf-8 text and is not empty
             if sum(1 for _ in f) > 0:
                 valid_text_file = True


### PR DESCRIPTION
Add `mypy` type checking for Python 3.14 and use `open()` instead of `codecs.open()` due to deprecation in 3.14.

The first [release candidate](https://www.python.org/downloads/release/python-3140rc1/) for Python 3.14 was released on 2025-07-22 and I did some local testing.

The first thing I realized is that `mypy` now works well with 3.14 and so we should add type checking on that platform to our GitLab Actions.

The second thing I noticed is that when we ran tests with pytests, we were getting a bunch of warnings due to [codecs.open()](https://docs.python.org/3.14/library/codecs.html#codecs.open) being deprecated.  Since at least Python 3.6 there has been no need for that as `open()` does everything it can do plus more.