### PR TITLE
Created Cmd2RichArgparseConsole to prevent rich-argparse help from being truncated.

### DIFF
--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -19,7 +19,7 @@ from typing import (
 from .constants import (
     INFINITY,
 )
-from .rich_utils import Cmd2Console
+from .rich_utils import Cmd2GeneralConsole
 
 if TYPE_CHECKING:  # pragma: no cover
     from .cmd2 import (
@@ -590,7 +590,7 @@ class ArgparseCompleter:
                 hint_table.add_row(item, *item.descriptive_data)
 
             # Generate the hint table string
-            console = Cmd2Console()
+            console = Cmd2GeneralConsole()
             with console.capture() as capture:
                 console.print(hint_table, end="")
             self._cmd2_app.formatted_completions = capture.get()

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -295,7 +295,7 @@ from rich_argparse import (
 )
 
 from . import constants
-from .rich_utils import Cmd2Console
+from .rich_utils import Cmd2RichArgparseConsole
 from .styles import Cmd2Style
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -1113,12 +1113,12 @@ class Cmd2HelpFormatter(RichHelpFormatter):
         max_help_position: int = 24,
         width: int | None = None,
         *,
-        console: Cmd2Console | None = None,
+        console: Cmd2RichArgparseConsole | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Cmd2HelpFormatter."""
         if console is None:
-            console = Cmd2Console()
+            console = Cmd2RichArgparseConsole()
 
         super().__init__(prog, indent_increment, max_help_position, width, console=console, **kwargs)
 
@@ -1481,7 +1481,7 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         # Add error style to message
         console = self._get_formatter().console
         with console.capture() as capture:
-            console.print(formatted_message, style=Cmd2Style.ERROR)
+            console.print(formatted_message, style=Cmd2Style.ERROR, crop=False)
         formatted_message = f"{capture.get()}"
 
         self.exit(2, f'{formatted_message}\n')

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -130,7 +130,7 @@ from .parsing import (
     shlex_split,
 )
 from .rich_utils import (
-    Cmd2Console,
+    Cmd2GeneralConsole,
     RichPrintKwargs,
 )
 from .styles import Cmd2Style
@@ -161,7 +161,7 @@ from .utils import (
 
 # Set up readline
 if rl_type == RlType.NONE:  # pragma: no cover
-    Cmd2Console(sys.stderr).print(rl_warning, style=Cmd2Style.WARNING)
+    Cmd2GeneralConsole(sys.stderr).print(rl_warning, style=Cmd2Style.WARNING)
 else:
     from .rl_utils import (
         readline,
@@ -1221,7 +1221,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1230,7 +1230,7 @@ class Cmd(cmd.Cmd):
         prepared_objects = ru.prepare_objects_for_rich_print(*objects)
 
         try:
-            Cmd2Console(file).print(
+            Cmd2GeneralConsole(file).print(
                 *prepared_objects,
                 sep=sep,
                 end=end,
@@ -1245,7 +1245,7 @@ class Cmd(cmd.Cmd):
             # warning message, then set the broken_pipe_warning attribute
             # to the message you want printed.
             if self.broken_pipe_warning and file != sys.stderr:
-                Cmd2Console(sys.stderr).print(self.broken_pipe_warning)
+                Cmd2GeneralConsole(sys.stderr).print(self.broken_pipe_warning)
 
     def poutput(
         self,
@@ -1267,7 +1267,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1303,7 +1303,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1337,7 +1337,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1370,7 +1370,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1404,7 +1404,7 @@ class Cmd(cmd.Cmd):
         final_msg = Text()
 
         if self.debug and sys.exc_info() != (None, None, None):
-            console = Cmd2Console(sys.stderr)
+            console = Cmd2GeneralConsole(sys.stderr)
             console.print_exception(word_wrap=True)
         else:
             final_msg += f"EXCEPTION of type '{type(exception).__name__}' occurred with message: {exception}"
@@ -1442,7 +1442,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
@@ -1498,7 +1498,7 @@ class Cmd(cmd.Cmd):
                           terminal width; instead, any text that doesn't fit will run onto the following line(s),
                           similar to the built-in print() function. Set to False to enable automatic word-wrapping.
                           If None (the default for this parameter), the output will default to no word-wrapping, as
-                          configured by the Cmd2Console.
+                          configured by the Cmd2GeneralConsole.
                           Note: If chop is True and a pager is used, soft_wrap is automatically set to True.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
@@ -1525,7 +1525,7 @@ class Cmd(cmd.Cmd):
                 soft_wrap = True
 
             # Generate the bytes to send to the pager
-            console = Cmd2Console(self.stdout)
+            console = Cmd2GeneralConsole(self.stdout)
             with console.capture() as capture:
                 console.print(
                     *prepared_objects,

--- a/tests/test_rich_utils.py
+++ b/tests/test_rich_utils.py
@@ -12,6 +12,21 @@ from cmd2 import rich_utils as ru
 from cmd2 import string_utils as su
 
 
+def test_cmd2_base_console() -> None:
+    # Test the keyword arguments which are not allowed.
+    with pytest.raises(TypeError) as excinfo:
+        ru.Cmd2BaseConsole(force_terminal=True)
+    assert 'force_terminal' in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        ru.Cmd2BaseConsole(force_interactive=True)
+    assert 'force_interactive' in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        ru.Cmd2BaseConsole(theme=None)
+    assert 'theme' in str(excinfo.value)
+
+
 def test_string_to_rich_text() -> None:
     # Line breaks recognized by str.splitlines().
     # Source: https://docs.python.org/3/library/stdtypes.html#str.splitlines
@@ -56,7 +71,7 @@ def test_rich_text_to_string(rich_text: Text, string: str) -> None:
     assert ru.rich_text_to_string(rich_text) == string
 
 
-def test_set_style() -> None:
+def test_set_theme() -> None:
     # Save a cmd2, rich-argparse, and rich-specific style.
     cmd2_style_key = Cmd2Style.ERROR
     argparse_style_key = "argparse.args"


### PR DESCRIPTION
The class doesn't enable soft wrapping, which restores Rich's default behavior and ensures long lines wrap correctly.