### PR TITLE
Styled string conversion

### DIFF
--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -44,6 +44,7 @@ from .exceptions import (
 )
 from .parsing import Statement
 from .py_bridge import CommandResult
+from .rich_utils import RichPrintKwargs
 from .string_utils import stylize
 from .styles import Cmd2Style
 from .utils import (
@@ -86,6 +87,8 @@ __all__: list[str] = [  # noqa: RUF022
     'plugin',
     'rich_utils',
     'string_utils',
+    # Rich Utils
+    'RichPrintKwargs',
     # String Utils
     'stylize',
     # Styles,

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -194,7 +194,7 @@ This means a long string which exceeds the width of its column will be
 truncated with an ellipsis at the end. You can override this and other settings
 when you create the ``Column``.
 
-``descriptive_data`` items can include Rich objects, including styled text.
+``descriptive_data`` items can include Rich objects, including styled Text and Tables.
 
 To avoid printing a excessive information to the screen at once when a user
 presses tab, there is a maximum threshold for the number of CompletionItems
@@ -388,13 +388,18 @@ class CompletionItem(str):  # noqa: SLOT000
         """CompletionItem Initializer.
 
         :param value: the value being tab completed
-        :param descriptive_data: descriptive data to display
+        :param descriptive_data: a list of descriptive data to display in the columns that follow
+                                 the completion value. The number of items in this list must equal
+                                 the number of descriptive headers defined for the argument.
         :param args: args for str __init__
         """
         super().__init__(*args)
 
         # Make sure all objects are renderable by a Rich table.
-        self.descriptive_data = [obj if is_renderable(obj) else str(obj) for obj in descriptive_data]
+        renderable_data = [obj if is_renderable(obj) else str(obj) for obj in descriptive_data]
+
+        # Convert objects with ANSI styles to Rich Text for correct display width.
+        self.descriptive_data = ru.prepare_objects_for_rich_rendering(*renderable_data)
 
         # Save the original value to support CompletionItems as argparse choices.
         # cmd2 has patched argparse so input is compared to this value instead of the CompletionItem instance.

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -399,7 +399,7 @@ class CompletionItem(str):  # noqa: SLOT000
         renderable_data = [obj if is_renderable(obj) else str(obj) for obj in descriptive_data]
 
         # Convert objects with ANSI styles to Rich Text for correct display width.
-        self.descriptive_data = ru.prepare_objects_for_rich_rendering(*renderable_data)
+        self.descriptive_data = ru.prepare_objects_for_rendering(*renderable_data)
 
         # Save the original value to support CompletionItems as argparse choices.
         # cmd2 has patched argparse so input is compared to this value instead of the CompletionItem instance.

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1225,7 +1225,7 @@ class Cmd(cmd.Cmd):
                        method and still call `super()` without encountering unexpected keyword argument errors.
                        These arguments are not passed to Rich's Console.print().
         """
-        prepared_objects = ru.prepare_objects_for_rich_print(*objects)
+        prepared_objects = ru.prepare_objects_for_rich_rendering(*objects)
 
         try:
             Cmd2GeneralConsole(file).print(
@@ -1469,7 +1469,7 @@ class Cmd(cmd.Cmd):
 
         # Check if we are outputting to a pager.
         if functional_terminal and can_block:
-            prepared_objects = ru.prepare_objects_for_rich_print(*objects)
+            prepared_objects = ru.prepare_objects_for_rich_rendering(*objects)
 
             # Chopping overrides soft_wrap
             if chop:
@@ -2508,7 +2508,11 @@ class Cmd(cmd.Cmd):
         results: list[CompletionItem] = []
 
         for cur_key in self.settables:
-            descriptive_data = [self.settables[cur_key].get_value(), self.settables[cur_key].description]
+            settable = self.settables[cur_key]
+            descriptive_data = [
+                str(settable.get_value()),
+                settable.description,
+            ]
             results.append(CompletionItem(cur_key, descriptive_data))
 
         return results
@@ -4157,8 +4161,8 @@ class Cmd(cmd.Cmd):
             Column("Name", no_wrap=True),
             Column("Description", overflow="fold"),
             box=rich.box.SIMPLE_HEAD,
-            border_style=Cmd2Style.TABLE_BORDER,
             show_edge=False,
+            border_style=Cmd2Style.TABLE_BORDER,
         )
 
         # Try to get the documentation string for each command
@@ -4478,8 +4482,8 @@ class Cmd(cmd.Cmd):
             Column("Value", overflow="fold"),
             Column("Description", overflow="fold"),
             box=rich.box.SIMPLE_HEAD,
-            border_style=Cmd2Style.TABLE_BORDER,
             show_edge=False,
+            border_style=Cmd2Style.TABLE_BORDER,
         )
 
         # Build the table and populate self.last_result
@@ -4487,7 +4491,11 @@ class Cmd(cmd.Cmd):
 
         for param in sorted(to_show, key=self.default_sort_key):
             settable = self.settables[param]
-            settable_table.add_row(param, str(settable.get_value()), settable.description)
+            settable_table.add_row(
+                param,
+                str(settable.get_value()),
+                settable.description,
+            )
             self.last_result[param] = settable.get_value()
 
         self.poutput()

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1225,7 +1225,7 @@ class Cmd(cmd.Cmd):
                        method and still call `super()` without encountering unexpected keyword argument errors.
                        These arguments are not passed to Rich's Console.print().
         """
-        prepared_objects = ru.prepare_objects_for_rich_rendering(*objects)
+        prepared_objects = ru.prepare_objects_for_rendering(*objects)
 
         try:
             Cmd2GeneralConsole(file).print(
@@ -1469,7 +1469,7 @@ class Cmd(cmd.Cmd):
 
         # Check if we are outputting to a pager.
         if functional_terminal and can_block:
-            prepared_objects = ru.prepare_objects_for_rich_rendering(*objects)
+            prepared_objects = ru.prepare_objects_for_rendering(*objects)
 
             # Chopping overrides soft_wrap
             if chop:

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -14,9 +14,9 @@ from rich.console import (
     JustifyMethod,
     OverflowMethod,
     RenderableType,
-    RichCast,
 )
 from rich.padding import Padding
+from rich.protocol import rich_cast
 from rich.style import StyleType
 from rich.table import (
     Column,
@@ -39,10 +39,6 @@ class AllowStyle(Enum):
     def __str__(self) -> str:
         """Return value instead of enum name for printing in cmd2's set command."""
         return str(self.value)
-
-    def __repr__(self) -> str:
-        """Return quoted value instead of enum description for printing in cmd2's set command."""
-        return repr(self.value)
 
 
 # Controls when ANSI style sequences are allowed in output
@@ -303,7 +299,7 @@ def indent(renderable: RenderableType, level: int) -> Padding:
     return Padding.indent(renderable, level)
 
 
-def prepare_objects_for_rich_print(*objects: Any) -> tuple[RenderableType, ...]:
+def prepare_objects_for_rich_rendering(*objects: Any) -> tuple[Any, ...]:
     """Prepare a tuple of objects for printing by Rich's Console.print().
 
     This function converts any non-Rich object whose string representation contains
@@ -316,17 +312,22 @@ def prepare_objects_for_rich_print(*objects: Any) -> tuple[RenderableType, ...]:
     :return: a tuple containing the processed objects.
     """
     object_list = list(objects)
+
     for i, obj in enumerate(object_list):
-        # If the object is a recognized renderable, we don't need to do anything. Rich will handle it.
-        if isinstance(obj, (ConsoleRenderable, RichCast)):
+        # Resolve the object's final renderable form, including those
+        # with a __rich__ method that might return a string.
+        renderable = rich_cast(obj)
+
+        # This object implements the Rich console protocol, so no preprocessing is needed.
+        if isinstance(renderable, ConsoleRenderable):
             continue
 
         # Check if the object's string representation contains ANSI styles, and if so,
         # replace it with a Rich Text object for correct width calculation.
-        obj_str = str(obj)
-        obj_text = string_to_rich_text(obj_str)
+        renderable_as_str = str(renderable)
+        renderable_as_text = string_to_rich_text(renderable_as_str)
 
-        if obj_text.plain != obj_str:
-            object_list[i] = obj_text
+        if renderable_as_text.plain != renderable_as_str:
+            object_list[i] = renderable_as_text
 
     return tuple(object_list)

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -299,7 +299,7 @@ def indent(renderable: RenderableType, level: int) -> Padding:
     return Padding.indent(renderable, level)
 
 
-def prepare_objects_for_rich_rendering(*objects: Any) -> tuple[Any, ...]:
+def prepare_objects_for_rendering(*objects: Any) -> tuple[Any, ...]:
     """Prepare a tuple of objects for printing by Rich's Console.print().
 
     This function converts any non-Rich object whose string representation contains

--- a/examples/argparse_completion.py
+++ b/examples/argparse_completion.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-from rich.box import SIMPLE_HEAD
+import rich.box
 from rich.style import Style
 from rich.table import Table
 from rich.text import Text
@@ -49,7 +49,12 @@ class ArgparseCompletion(Cmd):
             Text("styled text!!", style=Style(color=Color.BRIGHT_YELLOW, underline=True)),
         )
 
-        table_item = Table("Left Column", "Right Column", box=SIMPLE_HEAD, border_style=Cmd2Style.TABLE_BORDER)
+        table_item = Table(
+            "Left Column",
+            "Right Column",
+            box=rich.box.ROUNDED,
+            border_style=Cmd2Style.TABLE_BORDER,
+        )
         table_item.add_row("Yes, it's true.", "CompletionItems can")
         table_item.add_row("even display description", "data in tables!")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,9 @@ from unittest import (
 import pytest
 
 import cmd2
-from cmd2.rl_utils import (
-    readline,
-)
-from cmd2.utils import (
-    StdSim,
-)
+from cmd2 import rich_utils as ru
+from cmd2.rl_utils import readline
+from cmd2.utils import StdSim
 
 
 def verify_help_text(cmd2_app: cmd2.Cmd, help_output: str | list[str], verbose_strings: list[str] | None = None) -> None:
@@ -86,6 +83,25 @@ def run_cmd(app, cmd):
 @pytest.fixture
 def base_app():
     return cmd2.Cmd(include_py=True, include_ipy=True)
+
+
+def with_ansi_style(style):
+    def arg_decorator(func):
+        import functools
+
+        @functools.wraps(func)
+        def cmd_wrapper(*args, **kwargs):
+            old = ru.ALLOW_STYLE
+            ru.ALLOW_STYLE = style
+            try:
+                retval = func(*args, **kwargs)
+            finally:
+                ru.ALLOW_STYLE = old
+            return retval
+
+        return cmd_wrapper
+
+    return arg_decorator
 
 
 # These are odd file names for testing quoting of them

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -425,7 +425,7 @@ def test_subcmd_decorator(subcommand_app) -> None:
 
     # Test subcommand that has no help option
     out, err = run_cmd(subcommand_app, 'test_subcmd_decorator helpless_subcmd')
-    assert "'subcommand': 'helpless_subcmd'" in out[0]
+    assert "'subcommand': 'helpless_subcmd'" in out[1]
 
     out, err = run_cmd(subcommand_app, 'help test_subcmd_decorator helpless_subcmd')
     assert out[0] == 'Usage: test_subcmd_decorator helpless_subcmd'

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -41,26 +41,8 @@ from .conftest import (
     odd_file_names,
     run_cmd,
     verify_help_text,
+    with_ansi_style,
 )
-
-
-def with_ansi_style(style):
-    def arg_decorator(func):
-        import functools
-
-        @functools.wraps(func)
-        def cmd_wrapper(*args, **kwargs):
-            old = ru.ALLOW_STYLE
-            ru.ALLOW_STYLE = style
-            try:
-                retval = func(*args, **kwargs)
-            finally:
-                ru.ALLOW_STYLE = old
-            return retval
-
-        return cmd_wrapper
-
-    return arg_decorator
 
 
 def create_outsim_app():

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -2092,21 +2092,32 @@ def test_poutput_none(outsim_app) -> None:
 
 
 @with_ansi_style(ru.AllowStyle.ALWAYS)
-def test_poutput_ansi_always(outsim_app) -> None:
-    msg = 'Hello World'
-    colored_msg = Text(msg, style="cyan")
-    outsim_app.poutput(colored_msg)
+@pytest.mark.parametrize(
+    # Test a Rich Text and a string.
+    ('styled_msg', 'expected'),
+    [
+        (Text("A Text object", style="cyan"), "\x1b[36mA Text object\x1b[0m\n"),
+        (su.stylize("A str object", style="blue"), "\x1b[34mA str object\x1b[0m\n"),
+    ],
+)
+def test_poutput_ansi_always(styled_msg, expected, outsim_app) -> None:
+    outsim_app.poutput(styled_msg)
     out = outsim_app.stdout.getvalue()
-    assert out == "\x1b[36mHello World\x1b[0m\n"
+    assert out == expected
 
 
 @with_ansi_style(ru.AllowStyle.NEVER)
-def test_poutput_ansi_never(outsim_app) -> None:
-    msg = 'Hello World'
-    colored_msg = Text(msg, style="cyan")
-    outsim_app.poutput(colored_msg)
+@pytest.mark.parametrize(
+    # Test a Rich Text and a string.
+    ('styled_msg', 'expected'),
+    [
+        (Text("A Text object", style="cyan"), "A Text object\n"),
+        (su.stylize("A str object", style="blue"), "A str object\n"),
+    ],
+)
+def test_poutput_ansi_never(styled_msg, expected, outsim_app) -> None:
+    outsim_app.poutput(styled_msg)
     out = outsim_app.stdout.getvalue()
-    expected = msg + '\n'
     assert out == expected
 
 


### PR DESCRIPTION
Fixed a few issues related to converting strings to Text before rendering.
Previously we converted all non-Rich objects to a Text object. Now we only convert strings which contain ANSI styles.

Rich only looks for markup, emojis, and highlighting in strings. Therefore we were losing this capability since they had been converted to Text objects. Additionally, we lost pretty printing on objects like dictionaries because they also had been converted to Text by our code.

Finally, I fixed an issue with incorrect display widths of styled_strings in CompletionItems descriptions.