### PR TITLE
Add example for setting a theme

### DIFF
--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -29,6 +29,7 @@ class ThemedApp(cmd2.Cmd):
             Cmd2Style.HELP_HEADER: Style(color=Color.CYAN, bgcolor="#44475a"),
             Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),  # use RGB hex colors
             Cmd2Style.TABLE_BORDER: Style(color="turquoise2"),  # use a rich standard color
+            "traceback.exc_type": Style(color=Color.RED, bgcolor=Color.LIGHT_YELLOW3),
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
         }

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -27,7 +27,7 @@ class ThemedApp(cmd2.Cmd):
             Cmd2Style.WARNING: Style(color=Color.ORANGE1),
             Cmd2Style.ERROR: Style(color=Color.PINK1),
             Cmd2Style.HELP_HEADER: Style(color=Color.CYAN, bgcolor="#44475a"),
-            Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),  # use RGX hex colors
+            Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),  # use RGB hex colors
             Cmd2Style.TABLE_BORDER: Style(color="turquoise2"),  # use a rich standard color
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""A simple example of setting a custom theme for a cmd2 application."""
+
+from rich.style import Style
+
+import cmd2
+import cmd2.rich_utils as ru
+from cmd2 import Cmd2Style, Color
+
+
+class ThemedApp(cmd2.Cmd):
+    """A simple cmd2 application with a custom theme."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the application."""
+        super().__init__(*args, **kwargs)
+        self.intro = "This is a themed application. Try the 'theme_show' command."
+
+        # Create a custom theme
+        custom_theme = {
+            Cmd2Style.SUCCESS: Style(color=Color.CYAN),
+            Cmd2Style.WARNING: Style(color=Color.MAGENTA),
+            Cmd2Style.ERROR: Style(color=Color.BRIGHT_RED),
+            "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
+            "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
+        }
+        ru.set_theme(custom_theme)
+
+    @cmd2.with_category("Theme Commands")
+    def do_theme_show(self, _: cmd2.Statement):
+        """Showcases the custom theme by printing messages with different styles."""
+        self.poutput("This is a basic output message.")
+        self.psuccess("This is a success message.")
+        self.warning("This is a warning message.")
+        self.error("This is an error message.")
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = ThemedApp()
+    sys.exit(app.cmdloop())

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -16,14 +16,17 @@ class ThemedApp(cmd2.Cmd):
         super().__init__(*args, **kwargs)
         self.intro = "This is a themed application. Try the 'theme_show' command."
 
+        # Set text which prints right before all of the help tables are listed.
+        self.doc_leader = "Welcome to this glorious help ..."
+
         # Create a custom theme
         custom_theme = {
             Cmd2Style.SUCCESS: Style(color=Color.CYAN),
             Cmd2Style.WARNING: Style(color=Color.MAGENTA),
             Cmd2Style.ERROR: Style(color=Color.BRIGHT_RED),
             Cmd2Style.HELP_HEADER: Style(color=Color.YELLOW),
-            Cmd2Style.HELP_LEADER: Style(color=Color.PURPLE),
-            Cmd2Style.TABLE_BORDER: Style(color=Color.BLUE),
+            Cmd2Style.HELP_LEADER: Style(color=Color.VIOLET),
+            Cmd2Style.TABLE_BORDER: Style(color=Color.LIGHT_SKY_BLUE1),
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
         }

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -21,6 +21,9 @@ class ThemedApp(cmd2.Cmd):
             Cmd2Style.SUCCESS: Style(color=Color.CYAN),
             Cmd2Style.WARNING: Style(color=Color.MAGENTA),
             Cmd2Style.ERROR: Style(color=Color.BRIGHT_RED),
+            Cmd2Style.HELP_HEADER: Style(color=Color.YELLOW),
+            Cmd2Style.HELP_LEADER: Style(color=Color.PURPLE),
+            Cmd2Style.TABLE_BORDER: Style(color=Color.BLUE),
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
         }

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -20,13 +20,15 @@ class ThemedApp(cmd2.Cmd):
         self.doc_leader = "Welcome to this glorious help ..."
 
         # Create a custom theme
+        # Colors can come from the cmd2.color.Color StrEnum class, be RGB hex values, or
+        # be any of the rich standard colors: https://rich.readthedocs.io/en/stable/appendix/colors.html
         custom_theme = {
-            Cmd2Style.SUCCESS: Style(color=Color.GREEN),
+            Cmd2Style.SUCCESS: Style(color=Color.GREEN),  # Use color from cmd2 Color class
             Cmd2Style.WARNING: Style(color=Color.ORANGE1),
             Cmd2Style.ERROR: Style(color=Color.PINK1),
             Cmd2Style.HELP_HEADER: Style(color=Color.CYAN, bgcolor="#44475a"),
-            Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),
-            Cmd2Style.TABLE_BORDER: Style(color=Color.LIGHT_SKY_BLUE1),
+            Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),  # use RGX hex colors
+            Cmd2Style.TABLE_BORDER: Style(color="turquoise2"),  # use a rich standard color
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
         }

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -21,11 +21,11 @@ class ThemedApp(cmd2.Cmd):
 
         # Create a custom theme
         custom_theme = {
-            Cmd2Style.SUCCESS: Style(color=Color.CYAN),
-            Cmd2Style.WARNING: Style(color=Color.MAGENTA),
-            Cmd2Style.ERROR: Style(color=Color.BRIGHT_RED),
-            Cmd2Style.HELP_HEADER: Style(color=Color.YELLOW),
-            Cmd2Style.HELP_LEADER: Style(color=Color.DARK_VIOLET, bgcolor=Color.BRIGHT_WHITE),
+            Cmd2Style.SUCCESS: Style(color=Color.GREEN),
+            Cmd2Style.WARNING: Style(color=Color.ORANGE1),
+            Cmd2Style.ERROR: Style(color=Color.PINK1),
+            Cmd2Style.HELP_HEADER: Style(color=Color.CYAN, bgcolor="#44475a"),
+            Cmd2Style.HELP_LEADER: Style(color="#f8f8f2", bgcolor="#282a36"),
             Cmd2Style.TABLE_BORDER: Style(color=Color.LIGHT_SKY_BLUE1),
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),
@@ -35,10 +35,12 @@ class ThemedApp(cmd2.Cmd):
     @cmd2.with_category("Theme Commands")
     def do_theme_show(self, _: cmd2.Statement):
         """Showcases the custom theme by printing messages with different styles."""
+        # NOTE: Using soft_wrap=False will ensure display looks correct when background colors are part of the style
         self.poutput("This is a basic output message.")
-        self.psuccess("This is a success message.")
-        self.pwarning("This is a warning message.")
-        self.perror("This is an error message.")
+        self.psuccess("This is a success message.", soft_wrap=False)
+        self.pwarning("This is a warning message.", soft_wrap=False)
+        self.perror("This is an error message.", soft_wrap=False)
+        self.pexcept(ValueError("This is a dummy ValueError exception."))
 
 
 if __name__ == "__main__":

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -31,8 +31,8 @@ class ThemedApp(cmd2.Cmd):
         """Showcases the custom theme by printing messages with different styles."""
         self.poutput("This is a basic output message.")
         self.psuccess("This is a success message.")
-        self.warning("This is a warning message.")
-        self.error("This is an error message.")
+        self.pwarning("This is a warning message.")
+        self.perror("This is an error message.")
 
 
 if __name__ == "__main__":

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -25,7 +25,7 @@ class ThemedApp(cmd2.Cmd):
             Cmd2Style.WARNING: Style(color=Color.MAGENTA),
             Cmd2Style.ERROR: Style(color=Color.BRIGHT_RED),
             Cmd2Style.HELP_HEADER: Style(color=Color.YELLOW),
-            Cmd2Style.HELP_LEADER: Style(color=Color.VIOLET),
+            Cmd2Style.HELP_LEADER: Style(color=Color.DARK_VIOLET, bgcolor=Color.BRIGHT_WHITE),
             Cmd2Style.TABLE_BORDER: Style(color=Color.LIGHT_SKY_BLUE1),
             "argparse.args": Style(color=Color.AQUAMARINE3, underline=True),
             "inspect.attr": Style(color=Color.DARK_GOLDENROD, bold=True),


### PR DESCRIPTION
This is an attempt to add an example demonstrating how to create a custom theme for a cmd2 application.

It currently overrides a few elements of the theme. We should override more elements to make things more discoverable for users.