### PR TITLE
Monkey patched two Rich functions.

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1205,8 +1205,8 @@ class Cmd(cmd.Cmd):
 
         :param file: file stream being written to
         :param objects: objects to print
-        :param sep: string to write between print data. Defaults to " ".
-        :param end: string to write at end of print data. Defaults to a newline.
+        :param sep: string to write between printed text. Defaults to " ".
+        :param end: string to write at end of printed text. Defaults to a newline.
         :param style: optional style to apply to output
         :param soft_wrap: Enable soft wrap mode. If True, lines of text will not be word-wrapped or cropped to
                           fit the terminal width. Defaults to True.

--- a/cmd2/string_utils.py
+++ b/cmd2/string_utils.py
@@ -7,6 +7,7 @@ full-width characters (like those used in CJK languages).
 
 from rich.align import AlignMethod
 from rich.style import StyleType
+from rich.text import Text
 
 from . import rich_utils as ru
 
@@ -30,7 +31,7 @@ def align(
     if width is None:
         width = ru.console_width()
 
-    text = ru.string_to_rich_text(val)
+    text = Text.from_ansi(val)
     text.align(align, width=width, character=character)
     return ru.rich_text_to_string(text)
 
@@ -88,7 +89,7 @@ def stylize(val: str, style: StyleType) -> str:
     :return: the stylized string
     """
     # Convert to a Rich Text object to parse and preserve existing ANSI styles.
-    text = ru.string_to_rich_text(val)
+    text = Text.from_ansi(val)
     text.stylize(style)
     return ru.rich_text_to_string(text)
 
@@ -111,7 +112,7 @@ def str_width(val: str) -> int:
     :param val: the string being measured
     :return: width of the string when printed to the terminal
     """
-    text = ru.string_to_rich_text(val)
+    text = Text.from_ansi(val)
     return text.cell_len
 
 

--- a/examples/rich_theme.py
+++ b/examples/rich_theme.py
@@ -23,7 +23,7 @@ class ThemedApp(cmd2.Cmd):
         # Colors can come from the cmd2.color.Color StrEnum class, be RGB hex values, or
         # be any of the rich standard colors: https://rich.readthedocs.io/en/stable/appendix/colors.html
         custom_theme = {
-            Cmd2Style.SUCCESS: Style(color=Color.GREEN),  # Use color from cmd2 Color class
+            Cmd2Style.SUCCESS: Style(color=Color.GREEN1, bgcolor=Color.GRAY30),  # Use color from cmd2 Color class
             Cmd2Style.WARNING: Style(color=Color.ORANGE1),
             Cmd2Style.ERROR: Style(color=Color.PINK1),
             Cmd2Style.HELP_HEADER: Style(color=Color.CYAN, bgcolor="#44475a"),
@@ -37,11 +37,10 @@ class ThemedApp(cmd2.Cmd):
     @cmd2.with_category("Theme Commands")
     def do_theme_show(self, _: cmd2.Statement):
         """Showcases the custom theme by printing messages with different styles."""
-        # NOTE: Using soft_wrap=False will ensure display looks correct when background colors are part of the style
         self.poutput("This is a basic output message.")
-        self.psuccess("This is a success message.", soft_wrap=False)
-        self.pwarning("This is a warning message.", soft_wrap=False)
-        self.perror("This is an error message.", soft_wrap=False)
+        self.psuccess("This is a success message.")
+        self.pwarning("This is a warning message.")
+        self.perror("This is an error message.")
         self.pexcept(ValueError("This is a dummy ValueError exception."))
 
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -224,11 +224,9 @@ def test_set_no_settables(base_app) -> None:
         ('invalid', False, ru.AllowStyle.TERMINAL),
     ],
 )
+@with_ansi_style(ru.AllowStyle.TERMINAL)
 def test_set_allow_style(base_app, new_val, is_valid, expected) -> None:
-    # Initialize allow_style for this test
-    ru.ALLOW_STYLE = ru.AllowStyle.TERMINAL
-
-    # Use the set command to alter it
+    # Use the set command to alter allow_style
     out, err = run_cmd(base_app, f'set allow_style {new_val}')
     assert base_app.last_result is is_valid
 
@@ -237,9 +235,6 @@ def test_set_allow_style(base_app, new_val, is_valid, expected) -> None:
     if is_valid:
         assert not err
         assert out
-
-    # Reset allow_style to its default since it's an application-wide setting that can affect other unit tests
-    ru.ALLOW_STYLE = ru.AllowStyle.TERMINAL
 
 
 def test_set_with_choices(base_app) -> None:
@@ -2673,7 +2668,7 @@ def test_perror_style(base_app, capsys) -> None:
     msg = 'testing...'
     base_app.perror(msg)
     out, err = capsys.readouterr()
-    assert err == "\x1b[91mtesting...\x1b[0m\x1b[91m\n\x1b[0m"
+    assert err == "\x1b[91mtesting...\x1b[0m\n"
 
 
 @with_ansi_style(ru.AllowStyle.ALWAYS)


### PR DESCRIPTION
Removed `rich_utils.string_to_rich_text()` in favor of monkey patching Rich's `Text.from_ansi()`. Now a dev isn't required to call a cmd2-specific function to get the bug fix.
    
Monkey patched `Rich's Segment.apply_style()` to fix an issue where background colors incorrectly carry over onto the following line when printing with soft_wrap enabled.