### PR TITLE
Optimize performance of running command finalization hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ time reading the [rich documentation](https://rich.readthedocs.io/).
         - [argparse_example.py](https://github.com/python-cmd2/cmd2/blob/main/examples/argparse_example.py)
         - [command_sets.py](https://github.com/python-cmd2/cmd2/blob/main/examples/command_sets.py)
         - [getting_started.py](https://github.com/python-cmd2/cmd2/blob/main/examples/getting_started.py)
+    - Optimized performance of terminal fixup during command finalization by replacing `stty sane`
+      with `termios.tcsetattr`
 
 - Bug Fixes
     - Fixed a redirection bug where `cmd2` could unintentionally overwrite an application's

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -508,6 +508,18 @@ class Cmd(cmd.Cmd):
         # Commands that will run at the beginning of the command loop
         self._startup_commands: list[str] = []
 
+        # Store initial termios settings to restore after each command.
+        # This is a faster way of accomplishing what "stty sane" does.
+        self._initial_termios_settings = None
+        if not sys.platform.startswith('win') and self.stdin.isatty():
+            try:
+                import termios
+
+                self._initial_termios_settings = termios.tcgetattr(self.stdin.fileno())
+            except (ImportError, termios.error):
+                # This can happen if termios isn't available or stdin is a pseudo-TTY
+                pass
+
         # If a startup script is provided and exists, then execute it in the startup commands
         if startup_script:
             startup_script = os.path.abspath(os.path.expanduser(startup_script))

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1068,16 +1068,14 @@ def test_cmdloop_without_rawinput() -> None:
     assert out == expected
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason="stty sane only run on Linux/Mac")
-def test_stty_sane(base_app, monkeypatch) -> None:
-    """Make sure stty sane is run on Linux/Mac after each command if stdin is a terminal"""
+def test_cmdfinalizations_runs(base_app, monkeypatch) -> None:
+    """Make sure _run_cmdfinalization_hooks is run on after each command."""
     with mock.patch('sys.stdin.isatty', mock.MagicMock(name='isatty', return_value=True)):
-        # Mock out the subprocess.Popen call so we don't actually run stty sane
-        m = mock.MagicMock(name='Popen')
-        monkeypatch.setattr("subprocess.Popen", m)
+        m = mock.MagicMock(name='cmdfinalization')
+        monkeypatch.setattr("cmd2.Cmd._run_cmdfinalization_hooks", m)
 
         base_app.onecmd_plus_hooks('help')
-        m.assert_called_once_with(['stty', 'sane'])
+        m.assert_called_once()
 
 
 def test_sigint_handler(base_app) -> None:


### PR DESCRIPTION
Optimize performance of the `_run_cmdfinalization_hooks` method by replacing a subprocess call to `stty sane` with a call to `termios.tcsetattr()`. For optimial performance, the initial termios settings are cached when instantiating the `cmd2.Cmd` class and are restored in the `_run_cmdfinalization_hooks` method.

The motivation behind this was a user report of slowness in Discussion #1503. 

I also temporarily tweaked where we we report our elapsed timing when the `timiing` settable is True to include the full command lifecycle timing and did measurements before and after.

I did some testing on a system with the following setup:

- Latest `cmd2` from main branch on GitHub
- Python 3.14.0rc2
- macOS Sequoia 15.6.1 on an older Intel core i9 Macbook pro
- term2 3.5.14

in this testing I modified cmd's built-in timing measurement to capture the full command lifecycle timing. With the code as-is on the `main` branch, the full lifecycle for an empty command on this older computer was about 0.007 seconds (7 thousands of a second). This is not something I would even remotely call "slow" given typical human reaction times.

I then re-ran the same tests using the code in this PR. This did substantially speed things up to the point where an empty command ran with an elapsed time of about 0.00011 seconds (about 64 times faster).

I think we should do some manual evaluation with the code here to verify it is fixing the same things that `stty sane` was fixing. Even though the performance difference should be below what would normally be perceptible for the system I tested on, user reports of slowness in some circumstances suggest this may be a beneficial and noticeable change overall.

TODO:

- [x] Manual testing to verify new code has same beneficial effects as running `stty sane`
- [x] Improve test coverage