### PR TITLE
Upgrade GitHub Action for setup-python from v5 to v6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true


### PR DESCRIPTION
Upgrade GitHub Action for setup-python from v5 to v6

I learned about this from Dependabot via PR #1505 , but tests failed there due to inability to upload code coverage data to codecov