### PR TITLE
Upgrade from ruff 0.12.9 to ruff 0.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.9"
+    rev: "v0.13.0"
     hooks:
       - id: ruff-format
         args: [--config=pyproject.toml]

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -6024,7 +6024,7 @@ class Cmd(cmd.Cmd):
         type_hints, ret_ann = get_types(func)
         if not type_hints:
             raise TypeError(f"{func.__name__} parameter is missing a type hint, expected: {data_type}")
-        param_name, par_ann = next(iter(type_hints.items()))
+        _param_name, par_ann = next(iter(type_hints.items()))
         # validate the parameter has the right annotation
         if par_ann != data_type:
             raise TypeError(f'argument 1 of {func.__name__} has incompatible type {par_ann}, expected {data_type}')

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -126,17 +126,17 @@ def argparse_app():
 
 
 def test_invalid_syntax(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'speak "')
+    _out, err = run_cmd(argparse_app, 'speak "')
     assert err[0] == "Invalid syntax: No closing quotation"
 
 
 def test_argparse_basic_command(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'say hello')
+    out, _err = run_cmd(argparse_app, 'say hello')
     assert out == ['hello']
 
 
 def test_argparse_remove_quotes(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'say "hello there"')
+    out, _err = run_cmd(argparse_app, 'say "hello there"')
     assert out == ['hello there']
 
 
@@ -150,64 +150,64 @@ def test_argparse_with_no_args(argparse_app) -> None:
 def test_argparser_kwargs(argparse_app, capsys) -> None:
     """Test with_argparser wrapper passes through kwargs to command function"""
     argparse_app.do_say('word', keyword_arg="foo")
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == "foo\n"
 
 
 def test_argparse_preserve_quotes(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'tag mytag "hello"')
+    out, _err = run_cmd(argparse_app, 'tag mytag "hello"')
     assert out[0] == '<mytag>"hello"</mytag>'
 
 
 def test_argparse_custom_namespace(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'test_argparse_ns')
+    out, _err = run_cmd(argparse_app, 'test_argparse_ns')
     assert out[0] == 'custom'
 
 
 def test_argparse_with_list(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'speak -s hello world!')
+    out, _err = run_cmd(argparse_app, 'speak -s hello world!')
     assert out == ['HELLO WORLD!']
 
 
 def test_argparse_with_list_remove_quotes(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'speak -s hello "world!"')
+    out, _err = run_cmd(argparse_app, 'speak -s hello "world!"')
     assert out == ['HELLO WORLD!']
 
 
 def test_argparse_with_list_preserve_quotes(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'test_argparse_with_list_quotes "hello" person')
+    out, _err = run_cmd(argparse_app, 'test_argparse_with_list_quotes "hello" person')
     assert out[0] == '"hello" person'
 
 
 def test_argparse_with_list_custom_namespace(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'test_argparse_with_list_ns')
+    out, _err = run_cmd(argparse_app, 'test_argparse_with_list_ns')
     assert out[0] == 'custom'
 
 
 def test_argparse_with_list_and_empty_doc(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'speak -s hello world!')
+    out, _err = run_cmd(argparse_app, 'speak -s hello world!')
     assert out == ['HELLO WORLD!']
 
 
 def test_argparser_correct_args_with_quotes_and_midline_options(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, "speak 'This  is a' -s test of the emergency broadcast system!")
+    out, _err = run_cmd(argparse_app, "speak 'This  is a' -s test of the emergency broadcast system!")
     assert out == ['THIS  IS A TEST OF THE EMERGENCY BROADCAST SYSTEM!']
 
 
 def test_argparser_and_unknown_args_kwargs(argparse_app, capsys) -> None:
     """Test with_argparser wrapper passing through kwargs to command function"""
     argparse_app.do_speak('', keyword_arg="foo")
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == "foo\n"
 
 
 def test_argparse_quoted_arguments_multiple(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'say "hello  there" "rick & morty"')
+    out, _err = run_cmd(argparse_app, 'say "hello  there" "rick & morty"')
     assert out == ['hello  there rick & morty']
 
 
 def test_argparse_help_docstring(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'help say')
+    out, _err = run_cmd(argparse_app, 'help say')
     assert out[0].startswith('Usage: say')
     assert out[1] == ''
     assert out[2] == 'Repeat what you tell me to.'
@@ -216,32 +216,32 @@ def test_argparse_help_docstring(argparse_app) -> None:
 
 
 def test_argparse_help_description(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'help tag')
+    out, _err = run_cmd(argparse_app, 'help tag')
     assert out[0].startswith('Usage: tag')
     assert out[1] == ''
     assert out[2] == 'create a html tag'
 
 
 def test_argparse_prog(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'help tag')
+    out, _err = run_cmd(argparse_app, 'help tag')
     progname = out[0].split(' ')[1]
     assert progname == 'tag'
 
 
 def test_arglist(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'arglist "we  should" get these')
+    out, _err = run_cmd(argparse_app, 'arglist "we  should" get these')
     assert out[0] == 'True'
 
 
 def test_arglist_kwargs(argparse_app, capsys) -> None:
     """Test with_argument_list wrapper passes through kwargs to command function"""
     argparse_app.do_arglist('arg', keyword_arg="foo")
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == "foo\n"
 
 
 def test_preservelist(argparse_app) -> None:
-    out, err = run_cmd(argparse_app, 'preservelist foo "bar baz"')
+    out, _err = run_cmd(argparse_app, 'preservelist foo "bar baz"')
     assert out[0] == "['foo', '\"bar baz\"']"
 
 
@@ -332,23 +332,23 @@ def subcommand_app():
 
 
 def test_subcommand_foo(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base foo -x2 5.0')
+    out, _err = run_cmd(subcommand_app, 'base foo -x2 5.0')
     assert out == ['10.0']
 
 
 def test_subcommand_bar(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base bar baz')
+    out, _err = run_cmd(subcommand_app, 'base bar baz')
     assert out == ['((baz))']
 
 
 def test_subcommand_invalid(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base baz')
+    _out, err = run_cmd(subcommand_app, 'base baz')
     assert err[0].startswith('Usage: base')
     assert err[1].startswith("Error: argument SUBCOMMAND: invalid choice: 'baz'")
 
 
 def test_subcommand_base_help(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'help base')
+    out, _err = run_cmd(subcommand_app, 'help base')
     assert out[0].startswith('Usage: base')
     assert out[1] == ''
     assert out[2] == 'Base command help'
@@ -356,46 +356,46 @@ def test_subcommand_base_help(subcommand_app) -> None:
 
 def test_subcommand_help(subcommand_app) -> None:
     # foo has no aliases
-    out, err = run_cmd(subcommand_app, 'help base foo')
+    out, _err = run_cmd(subcommand_app, 'help base foo')
     assert out[0].startswith('Usage: base foo')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
     # bar has aliases (usage should never show alias name)
-    out, err = run_cmd(subcommand_app, 'help base bar')
+    out, _err = run_cmd(subcommand_app, 'help base bar')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base bar_1')
+    out, _err = run_cmd(subcommand_app, 'help base bar_1')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base bar_2')
+    out, _err = run_cmd(subcommand_app, 'help base bar_2')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
     # helpless has aliases and no help text (usage should never show alias name)
-    out, err = run_cmd(subcommand_app, 'help base helpless')
+    out, _err = run_cmd(subcommand_app, 'help base helpless')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base helpless_1')
+    out, _err = run_cmd(subcommand_app, 'help base helpless_1')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base helpless_2')
+    out, _err = run_cmd(subcommand_app, 'help base helpless_2')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
 
 def test_subcommand_invalid_help(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'help base baz')
+    out, _err = run_cmd(subcommand_app, 'help base baz')
     assert out[0].startswith('Usage: base')
 
 

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -348,16 +348,16 @@ def ac_app():
 
 @pytest.mark.parametrize('command', ['music', 'music create', 'music create rock', 'music create jazz'])
 def test_help(ac_app, command) -> None:
-    out1, err1 = run_cmd(ac_app, f'{command} -h')
-    out2, err2 = run_cmd(ac_app, f'help {command}')
+    out1, _err1 = run_cmd(ac_app, f'{command} -h')
+    out2, _err2 = run_cmd(ac_app, f'help {command}')
     assert out1 == out2
 
 
 def test_bad_subcommand_help(ac_app) -> None:
     # These should give the same output because the second one isn't using a
     # real subcommand, so help will be called on the music command instead.
-    out1, err1 = run_cmd(ac_app, 'help music')
-    out2, err2 = run_cmd(ac_app, 'help music fake')
+    out1, _err1 = run_cmd(ac_app, 'help music')
+    out2, _err2 = run_cmd(ac_app, 'help music fake')
     assert out1 == out2
 
 
@@ -907,7 +907,7 @@ def test_unfinished_flag_error(ac_app, command_and_args, text, is_error, capsys)
 
     complete_tester(text, line, begidx, endidx, ac_app)
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert is_error == all(x in out for x in ["Error: argument", "expected"])
 
 
@@ -1016,7 +1016,7 @@ def test_autocomp_hint(ac_app, command_and_args, text, has_hint, capsys) -> None
     begidx = endidx - len(text)
 
     complete_tester(text, line, begidx, endidx, ac_app)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     if has_hint:
         assert "Hint:\n" in out
     else:
@@ -1030,7 +1030,7 @@ def test_autocomp_hint_no_help_text(ac_app, capsys) -> None:
     begidx = endidx - len(text)
 
     first_match = complete_tester(text, line, begidx, endidx, ac_app)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert first_match is None
     assert out != '''\nHint:\n  NO_HELP_POS\n\n'''
@@ -1051,7 +1051,7 @@ def test_completion_error(ac_app, capsys, args, text) -> None:
     begidx = endidx - len(text)
 
     first_match = complete_tester(text, line, begidx, endidx, ac_app)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert first_match is None
     assert f"{text} broke something" in out
@@ -1113,7 +1113,7 @@ def test_complete_mutex_group(ac_app, command_and_args, text, output_contains, f
 
     assert first_match == complete_tester(text, line, begidx, endidx, ac_app)
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert output_contains in out
 
 

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -87,30 +87,30 @@ def test_apcustom_usage() -> None:
 
 
 def test_apcustom_nargs_help_format(cust_app) -> None:
-    out, err = run_cmd(cust_app, 'help range')
+    out, _err = run_cmd(cust_app, 'help range')
     assert 'Usage: range [-h] [--arg0 ARG0] [--arg1 ARG1{2}] [--arg2 ARG2{3+}]' in out[0]
     assert '             [--arg3 ARG3{2..3}] [--arg4 [ARG4 [...]]] [--arg5 ARG5 [...]]' in out[1]
 
 
 def test_apcustom_nargs_range_validation(cust_app) -> None:
     # nargs = (3,)  # noqa: ERA001
-    out, err = run_cmd(cust_app, 'range --arg2 one two')
+    _out, err = run_cmd(cust_app, 'range --arg2 one two')
     assert 'Error: argument --arg2: expected at least 3 arguments' in err[2]
 
-    out, err = run_cmd(cust_app, 'range --arg2 one two three')
+    _out, err = run_cmd(cust_app, 'range --arg2 one two three')
     assert not err
 
-    out, err = run_cmd(cust_app, 'range --arg2 one two three four')
+    _out, err = run_cmd(cust_app, 'range --arg2 one two three four')
     assert not err
 
     # nargs = (2,3)  # noqa: ERA001
-    out, err = run_cmd(cust_app, 'range --arg3 one')
+    _out, err = run_cmd(cust_app, 'range --arg3 one')
     assert 'Error: argument --arg3: expected 2 to 3 arguments' in err[2]
 
-    out, err = run_cmd(cust_app, 'range --arg3 one two')
+    _out, err = run_cmd(cust_app, 'range --arg3 one two')
     assert not err
 
-    out, err = run_cmd(cust_app, 'range --arg2 one two three')
+    _out, err = run_cmd(cust_app, 'range --arg2 one two three')
     assert not err
 
 
@@ -284,7 +284,7 @@ def test_completion_items_as_choices(capsys) -> None:
         args = parser.parse_args(['3'])
 
     # Confirm error text contains correct value type of str
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert "invalid choice: '3' (choose from '1', '2')" in err
 
     ##############################################################
@@ -306,5 +306,5 @@ def test_completion_items_as_choices(capsys) -> None:
         args = parser.parse_args(['3'])
 
     # Confirm error text contains correct value type of int
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'invalid choice: 3 (choose from 1, 2)' in err

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -77,19 +77,19 @@ def test_not_in_main_thread(base_app, capsys) -> None:
 
 
 def test_empty_statement(base_app) -> None:
-    out, err = run_cmd(base_app, '')
+    out, _err = run_cmd(base_app, '')
     expected = normalize('')
     assert out == expected
 
 
 def test_base_help(base_app) -> None:
-    out, err = run_cmd(base_app, 'help')
+    out, _err = run_cmd(base_app, 'help')
     assert base_app.last_result is True
     verify_help_text(base_app, out)
 
 
 def test_base_help_verbose(base_app) -> None:
-    out, err = run_cmd(base_app, 'help -v')
+    out, _err = run_cmd(base_app, 'help -v')
     assert base_app.last_result is True
     verify_help_text(base_app, out)
 
@@ -98,7 +98,7 @@ def test_base_help_verbose(base_app) -> None:
     help_doc += "\n:param fake param"
     base_app.do_help.__func__.__doc__ = help_doc
 
-    out, err = run_cmd(base_app, 'help --verbose')
+    out, _err = run_cmd(base_app, 'help --verbose')
     assert base_app.last_result is True
     verify_help_text(base_app, out)
     assert ':param' not in ''.join(out)
@@ -106,8 +106,8 @@ def test_base_help_verbose(base_app) -> None:
 
 def test_base_argparse_help(base_app) -> None:
     # Verify that "set -h" gives the same output as "help set" and that it starts in a way that makes sense
-    out1, err1 = run_cmd(base_app, 'set -h')
-    out2, err2 = run_cmd(base_app, 'help set')
+    out1, _err1 = run_cmd(base_app, 'set -h')
+    out2, _err2 = run_cmd(base_app, 'help set')
 
     assert out1 == out2
     assert out1[0].startswith('Usage: set')
@@ -116,13 +116,13 @@ def test_base_argparse_help(base_app) -> None:
 
 
 def test_base_invalid_option(base_app) -> None:
-    out, err = run_cmd(base_app, 'set -z')
+    _out, err = run_cmd(base_app, 'set -z')
     assert err[0] == 'Usage: set [-h] [param] [value]'
     assert 'Error: unrecognized arguments: -z' in err[1]
 
 
 def test_base_shortcuts(base_app) -> None:
-    out, err = run_cmd(base_app, 'shortcuts')
+    out, _err = run_cmd(base_app, 'shortcuts')
     expected = normalize(SHORTCUTS_TXT)
     assert out == expected
     assert base_app.last_result is True
@@ -136,7 +136,7 @@ def test_command_starts_with_shortcut() -> None:
 
 def test_base_set(base_app) -> None:
     # Make sure all settables appear in output.
-    out, err = run_cmd(base_app, 'set')
+    out, _err = run_cmd(base_app, 'set')
     settables = sorted(base_app.settables.keys())
 
     # The settables will appear in order in the table.
@@ -157,7 +157,7 @@ def test_base_set(base_app) -> None:
 
 
 def test_set(base_app) -> None:
-    out, err = run_cmd(base_app, 'set quiet True')
+    out, _err = run_cmd(base_app, 'set quiet True')
     expected = normalize(
         """
 quiet - was: False
@@ -168,7 +168,7 @@ now: True
     assert base_app.last_result is True
 
     line_found = False
-    out, err = run_cmd(base_app, 'set quiet')
+    out, _err = run_cmd(base_app, 'set quiet')
     for line in out:
         if "quiet" in line and "True" in line and "False" not in line:
             line_found = True
@@ -181,20 +181,20 @@ now: True
 
 def test_set_val_empty(base_app) -> None:
     base_app.editor = "fake"
-    out, err = run_cmd(base_app, 'set editor ""')
+    _out, _err = run_cmd(base_app, 'set editor ""')
     assert base_app.editor == ''
     assert base_app.last_result is True
 
 
 def test_set_val_is_flag(base_app) -> None:
     base_app.editor = "fake"
-    out, err = run_cmd(base_app, 'set editor "-h"')
+    _out, _err = run_cmd(base_app, 'set editor "-h"')
     assert base_app.editor == '-h'
     assert base_app.last_result is True
 
 
 def test_set_not_supported(base_app) -> None:
-    out, err = run_cmd(base_app, 'set qqq True')
+    _out, err = run_cmd(base_app, 'set qqq True')
     expected = normalize(
         """
 Parameter 'qqq' not supported (type 'set' for list of parameters).
@@ -206,7 +206,7 @@ Parameter 'qqq' not supported (type 'set' for list of parameters).
 
 def test_set_no_settables(base_app) -> None:
     base_app._settables.clear()
-    out, err = run_cmd(base_app, 'set quiet True')
+    _out, err = run_cmd(base_app, 'set quiet True')
     expected = normalize("There are no settable parameters")
     assert err == expected
     assert base_app.last_result is False
@@ -246,12 +246,12 @@ def test_set_with_choices(base_app) -> None:
     base_app.add_settable(fake_settable)
 
     # Try a valid choice
-    out, err = run_cmd(base_app, f'set fake {fake_choices[1]}')
+    _out, err = run_cmd(base_app, f'set fake {fake_choices[1]}')
     assert base_app.last_result is True
     assert not err
 
     # Try an invalid choice
-    out, err = run_cmd(base_app, 'set fake bad_value')
+    _out, err = run_cmd(base_app, 'set fake bad_value')
     assert base_app.last_result is False
     assert err[0].startswith("Error setting fake: invalid choice")
 
@@ -272,7 +272,7 @@ def onchange_app():
 
 
 def test_set_onchange_hook(onchange_app) -> None:
-    out, err = run_cmd(onchange_app, 'set quiet True')
+    out, _err = run_cmd(onchange_app, 'set quiet True')
     expected = normalize(
         """
 You changed quiet
@@ -287,7 +287,7 @@ now: True
 def test_base_shell(base_app, monkeypatch) -> None:
     m = mock.Mock()
     monkeypatch.setattr("{}.Popen".format('subprocess'), m)
-    out, err = run_cmd(base_app, 'shell echo a')
+    out, _err = run_cmd(base_app, 'shell echo a')
     assert out == []
     assert m.called
 
@@ -311,7 +311,7 @@ def test_shell_manual_call(base_app) -> None:
 
 
 def test_base_error(base_app) -> None:
-    out, err = run_cmd(base_app, 'meow')
+    _out, err = run_cmd(base_app, 'meow')
     assert "is not a recognized command" in err[0]
 
 
@@ -319,7 +319,7 @@ def test_base_error_suggest_command(base_app) -> None:
     try:
         old_suggest_similar_command = base_app.suggest_similar_command
         base_app.suggest_similar_command = True
-        out, err = run_cmd(base_app, 'historic')
+        _out, err = run_cmd(base_app, 'historic')
         assert "history" in err[1]
     finally:
         base_app.suggest_similar_command = old_suggest_similar_command
@@ -355,20 +355,20 @@ def test_run_script(base_app, request) -> None:
 
 
 def test_run_script_with_empty_args(base_app) -> None:
-    out, err = run_cmd(base_app, 'run_script')
+    _out, err = run_cmd(base_app, 'run_script')
     assert "the following arguments are required" in err[1]
     assert base_app.last_result is None
 
 
 def test_run_script_with_invalid_file(base_app, request) -> None:
     # Path does not exist
-    out, err = run_cmd(base_app, 'run_script does_not_exist.txt')
+    _out, err = run_cmd(base_app, 'run_script does_not_exist.txt')
     assert "Problem accessing script from " in err[0]
     assert base_app.last_result is False
 
     # Path is a directory
     test_dir = os.path.dirname(request.module.__file__)
-    out, err = run_cmd(base_app, f'run_script {test_dir}')
+    _out, err = run_cmd(base_app, f'run_script {test_dir}')
     assert "Problem accessing script from " in err[0]
     assert base_app.last_result is False
 
@@ -385,7 +385,7 @@ def test_run_script_with_empty_file(base_app, request) -> None:
 def test_run_script_with_binary_file(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'scripts', 'binary.bin')
-    out, err = run_cmd(base_app, f'run_script {filename}')
+    _out, err = run_cmd(base_app, f'run_script {filename}')
     assert "is not an ASCII or UTF-8 encoded text file" in err[0]
     assert base_app.last_result is False
 
@@ -396,7 +396,7 @@ def test_run_script_with_python_file(base_app, request) -> None:
 
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'pyscript', 'stop.py')
-    out, err = run_cmd(base_app, f'run_script {filename}')
+    _out, err = run_cmd(base_app, f'run_script {filename}')
     assert "appears to be a Python file" in err[0]
     assert base_app.last_result is False
 
@@ -471,7 +471,7 @@ help
 shortcuts
 _relative_run_script postcmds.txt
 set allow_style Never"""
-    out, err = run_cmd(base_app, 'history -s')
+    out, _err = run_cmd(base_app, 'history -s')
     assert out == normalize(expected)
 
 
@@ -489,7 +489,7 @@ shortcuts
 run_script {postfilepath}
 set allow_style Never"""
 
-    out, err = run_cmd(base_app, 'history -s')
+    out, _err = run_cmd(base_app, 'history -s')
     assert out == normalize(expected)
 
 
@@ -505,14 +505,14 @@ def test_runcmds_plus_hooks_ctrl_c(base_app, capsys) -> None:
     # Default behavior is to not stop runcmds_plus_hooks() on Ctrl-C
     base_app.history.clear()
     base_app.runcmds_plus_hooks(['help', 'keyboard_interrupt', 'shortcuts'])
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert not err
     assert len(base_app.history) == 3
 
     # Ctrl-C should stop runcmds_plus_hooks() in this case
     base_app.history.clear()
     base_app.runcmds_plus_hooks(['help', 'keyboard_interrupt', 'shortcuts'], stop_on_keyboard_interrupt=True)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert err.startswith("Interrupting this command")
     assert len(base_app.history) == 2
 
@@ -558,7 +558,7 @@ def test_relative_run_script_with_odd_file_names(base_app, file_name, monkeypatc
 
 
 def test_relative_run_script_requires_an_argument(base_app) -> None:
-    out, err = run_cmd(base_app, '_relative_run_script')
+    _out, err = run_cmd(base_app, '_relative_run_script')
     assert 'Error: the following arguments' in err[1]
     assert base_app.last_result is None
 
@@ -577,7 +577,7 @@ def test_in_script(request) -> None:
     hook_app = HookApp()
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'script.txt')
-    out, err = run_cmd(hook_app, f'run_script {filename}')
+    out, _err = run_cmd(hook_app, f'run_script {filename}')
 
     assert "WE ARE IN SCRIPT" in out[-1]
 
@@ -685,10 +685,10 @@ def test_output_redirection_custom_stdout(redirection_app) -> None:
 def test_output_redirection_to_nonexistent_directory(redirection_app) -> None:
     filename = '~/fakedir/this_does_not_exist.txt'
 
-    out, err = run_cmd(redirection_app, f'print_output > {filename}')
+    _out, err = run_cmd(redirection_app, f'print_output > {filename}')
     assert 'Failed to redirect' in err[0]
 
-    out, err = run_cmd(redirection_app, f'print_output >> {filename}')
+    _out, err = run_cmd(redirection_app, f'print_output >> {filename}')
     assert 'Failed to redirect' in err[0]
 
 
@@ -701,10 +701,10 @@ def test_output_redirection_to_too_long_filename(redirection_app) -> None:
         'whfieuwfhieufhiuewhfeiuwfhiuefhueiwhfw'
     )
 
-    out, err = run_cmd(redirection_app, f'print_output > {filename}')
+    _out, err = run_cmd(redirection_app, f'print_output > {filename}')
     assert 'Failed to redirect' in err[0]
 
-    out, err = run_cmd(redirection_app, f'print_output >> {filename}')
+    _out, err = run_cmd(redirection_app, f'print_output >> {filename}')
     assert 'Failed to redirect' in err[0]
 
 
@@ -728,7 +728,7 @@ def test_feedback_to_output_false(redirection_app) -> None:
     os.close(f)
 
     try:
-        out, err = run_cmd(redirection_app, f'print_feedback > {filename}')
+        _out, err = run_cmd(redirection_app, f'print_feedback > {filename}')
 
         with open(filename) as f:
             content = f.read().splitlines()
@@ -745,7 +745,7 @@ def test_disallow_redirection(redirection_app) -> None:
     filename = 'test_allow_redirect.txt'
 
     # Verify output wasn't redirected
-    out, err = run_cmd(redirection_app, f'print_output > {filename}')
+    out, _err = run_cmd(redirection_app, f'print_output > {filename}')
     assert "print" in out
     assert "poutput" in out
 
@@ -915,7 +915,7 @@ def test_debug_not_settable(base_app) -> None:
 
     # Cause an exception by setting editor to None and running edit
     base_app.editor = None
-    out, err = run_cmd(base_app, 'edit')
+    _out, err = run_cmd(base_app, 'edit')
 
     # Since debug is unsettable, the user will not be given the option to enable a full traceback
     assert err == ["ValueError: Please use 'set editor' to specify your text editing program of", 'choice.']
@@ -923,7 +923,7 @@ def test_debug_not_settable(base_app) -> None:
 
 def test_blank_exception(mocker, base_app):
     mocker.patch("cmd2.Cmd.do_help", side_effect=Exception)
-    out, err = run_cmd(base_app, 'help')
+    _out, err = run_cmd(base_app, 'help')
 
     # When an exception has no message, the first error line is just its type.
     assert err[0] == "Exception"
@@ -1231,7 +1231,7 @@ def test_default_to_shell(base_app, monkeypatch) -> None:
     base_app.default_to_shell = True
     m = mock.Mock()
     monkeypatch.setattr("{}.Popen".format('subprocess'), m)
-    out, err = run_cmd(base_app, line)
+    out, _err = run_cmd(base_app, line)
     assert out == []
     assert m.called
 
@@ -1314,7 +1314,7 @@ def help_app():
 def test_help_headers(capsys) -> None:
     help_app = HelpApp()
     help_app.onecmd_plus_hooks('help')
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert help_app.doc_leader in out
     assert help_app.doc_header in out
@@ -1324,47 +1324,47 @@ def test_help_headers(capsys) -> None:
 
 
 def test_custom_command_help(help_app) -> None:
-    out, err = run_cmd(help_app, 'help squat')
+    out, _err = run_cmd(help_app, 'help squat')
     expected = normalize('This command does diddly squat...')
     assert out == expected
     assert help_app.last_result is True
 
 
 def test_custom_help_menu(help_app) -> None:
-    out, err = run_cmd(help_app, 'help')
+    out, _err = run_cmd(help_app, 'help')
     verify_help_text(help_app, out)
     assert help_app.last_result is True
 
 
 def test_help_undocumented(help_app) -> None:
-    out, err = run_cmd(help_app, 'help undoc')
+    _out, err = run_cmd(help_app, 'help undoc')
     assert err[0].startswith("No help on undoc")
     assert help_app.last_result is False
 
 
 def test_help_overridden_method(help_app) -> None:
-    out, err = run_cmd(help_app, 'help edit')
+    out, _err = run_cmd(help_app, 'help edit')
     expected = normalize('This overrides the edit command and does nothing.')
     assert out == expected
     assert help_app.last_result is True
 
 
 def test_help_multiline_docstring(help_app) -> None:
-    out, err = run_cmd(help_app, 'help multiline_docstr')
+    out, _err = run_cmd(help_app, 'help multiline_docstr')
     expected = normalize('This documentation\nis multiple lines\nand there are no\ntabs')
     assert out == expected
     assert help_app.last_result is True
 
 
 def test_miscellaneous_help_topic(help_app) -> None:
-    out, err = run_cmd(help_app, 'help physics')
+    out, _err = run_cmd(help_app, 'help physics')
     expected = normalize("Here is some help on physics.")
     assert out == expected
     assert help_app.last_result is True
 
 
 def test_help_verbose_uses_parser_description(help_app: HelpApp) -> None:
-    out, err = run_cmd(help_app, 'help --verbose')
+    out, _err = run_cmd(help_app, 'help --verbose')
     expected_verbose = utils.strip_doc_annotations(help_app.do_parser_cmd.__doc__)
     verify_help_text(help_app, out, verbose_strings=[expected_verbose])
 
@@ -1375,7 +1375,7 @@ def test_help_verbose_with_fake_command(capsys) -> None:
 
     cmds = ["alias", "fake_command"]
     help_app._print_documented_command_topics(help_app.doc_header, cmds, verbose=True)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert cmds[0] in out
     assert cmds[1] not in out
 
@@ -1404,7 +1404,7 @@ def test_columnize(capsys: pytest.CaptureFixture[str]) -> None:
     help_app = HelpApp()
     items = ["one", "two"]
     help_app.columnize(items)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     # poutput() adds a newline at the end.
     expected = "one  two\n"
@@ -1452,7 +1452,7 @@ def helpcat_app():
 
 
 def test_help_cat_base(helpcat_app) -> None:
-    out, err = run_cmd(helpcat_app, 'help')
+    out, _err = run_cmd(helpcat_app, 'help')
     assert helpcat_app.last_result is True
     verify_help_text(helpcat_app, out)
 
@@ -1463,7 +1463,7 @@ def test_help_cat_base(helpcat_app) -> None:
 
 
 def test_help_cat_verbose(helpcat_app) -> None:
-    out, err = run_cmd(helpcat_app, 'help --verbose')
+    out, _err = run_cmd(helpcat_app, 'help --verbose')
     assert helpcat_app.last_result is True
     verify_help_text(helpcat_app, out)
 
@@ -1523,7 +1523,7 @@ def test_select_options(select_app, monkeypatch) -> None:
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
     food = 'bacon'
-    out, err = run_cmd(select_app, f"eat {food}")
+    out, _err = run_cmd(select_app, f"eat {food}")
     expected = normalize(
         f"""
    1. sweet
@@ -1548,7 +1548,7 @@ def test_select_invalid_option_too_big(select_app, monkeypatch) -> None:
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
     food = 'fish'
-    out, err = run_cmd(select_app, f"eat {food}")
+    out, _err = run_cmd(select_app, f"eat {food}")
     expected = normalize(
         f"""
    1. sweet
@@ -1577,7 +1577,7 @@ def test_select_invalid_option_too_small(select_app, monkeypatch) -> None:
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
     food = 'fish'
-    out, err = run_cmd(select_app, f"eat {food}")
+    out, _err = run_cmd(select_app, f"eat {food}")
     expected = normalize(
         f"""
    1. sweet
@@ -1602,7 +1602,7 @@ def test_select_list_of_strings(select_app, monkeypatch) -> None:
     read_input_mock = mock.MagicMock(name='read_input', return_value='2')
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
-    out, err = run_cmd(select_app, "study")
+    out, _err = run_cmd(select_app, "study")
     expected = normalize(
         """
    1. math
@@ -1623,7 +1623,7 @@ def test_select_list_of_tuples(select_app, monkeypatch) -> None:
     read_input_mock = mock.MagicMock(name='read_input', return_value='2')
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
-    out, err = run_cmd(select_app, "procrastinate")
+    out, _err = run_cmd(select_app, "procrastinate")
     expected = normalize(
         """
    1. Netflix
@@ -1644,7 +1644,7 @@ def test_select_uneven_list_of_tuples(select_app, monkeypatch) -> None:
     read_input_mock = mock.MagicMock(name='read_input', return_value='2')
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
-    out, err = run_cmd(select_app, "play")
+    out, _err = run_cmd(select_app, "play")
     expected = normalize(
         """
    1. Electric Guitar
@@ -1673,7 +1673,7 @@ def test_select_return_type(select_app, monkeypatch, selection, type_str) -> Non
     read_input_mock = mock.MagicMock(name='read_input', return_value=selection)
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
-    out, err = run_cmd(select_app, "return_type")
+    out, _err = run_cmd(select_app, "return_type")
     expected = normalize(
         f"""
    1. Integer
@@ -1696,7 +1696,7 @@ def test_select_eof(select_app, monkeypatch) -> None:
     monkeypatch.setattr("cmd2.Cmd.read_input", read_input_mock)
 
     food = 'fish'
-    out, err = run_cmd(select_app, f"eat {food}")
+    _out, _err = run_cmd(select_app, f"eat {food}")
 
     # Make sure our mock was called exactly twice with the expected arguments
     arg = 'Sauce? '
@@ -1984,7 +1984,7 @@ def test_echo(capsys) -> None:
 
     app.runcmds_plus_hooks(commands)
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out.startswith(f'{app.prompt}{commands[0]}\nUsage: history')
 
 
@@ -2041,14 +2041,14 @@ def test_read_input_rawinput_true(capsys, monkeypatch) -> None:
         # echo True
         app.echo = True
         line = app.read_input(prompt_str)
-        out, err = capsys.readouterr()
+        out, _err = capsys.readouterr()
         assert line == input_str
         assert out == f"{prompt_str}{input_str}\n"
 
         # echo False
         app.echo = False
         line = app.read_input(prompt_str)
-        out, err = capsys.readouterr()
+        out, _err = capsys.readouterr()
         assert line == input_str
         assert not out
 
@@ -2071,14 +2071,14 @@ def test_read_input_rawinput_false(capsys, monkeypatch) -> None:
     # isatty True
     app = make_app(isatty=True)
     line = app.read_input(prompt_str)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert line == input_str
     assert out == prompt_str
 
     # isatty True, empty input
     app = make_app(isatty=True, empty_input=True)
     line = app.read_input(prompt_str)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert line == 'eof'
     assert out == prompt_str
 
@@ -2086,7 +2086,7 @@ def test_read_input_rawinput_false(capsys, monkeypatch) -> None:
     app = make_app(isatty=False)
     app.echo = True
     line = app.read_input(prompt_str)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert line == input_str
     assert out == f"{prompt_str}{input_str}\n"
 
@@ -2094,14 +2094,14 @@ def test_read_input_rawinput_false(capsys, monkeypatch) -> None:
     app = make_app(isatty=False)
     app.echo = False
     line = app.read_input(prompt_str)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert line == input_str
     assert not out
 
     # isatty is False, empty input
     app = make_app(isatty=False, empty_input=True)
     line = app.read_input(prompt_str)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert line == 'eof'
     assert not out
 
@@ -2341,7 +2341,7 @@ def test_get_settable_completion_items(base_app) -> None:
 
 
 def test_alias_no_subcommand(base_app) -> None:
-    out, err = run_cmd(base_app, 'alias')
+    _out, err = run_cmd(base_app, 'alias')
     assert "Usage: alias [-h]" in err[0]
     assert "Error: the following arguments are required: SUBCOMMAND" in err[1]
 
@@ -2387,11 +2387,11 @@ def test_alias_create_with_quoted_tokens(base_app) -> None:
     create_command = f"alias create {alias_name} {alias_command}"
 
     # Create the alias
-    out, err = run_cmd(base_app, create_command)
+    out, _err = run_cmd(base_app, create_command)
     assert out == normalize("Alias 'fake' created")
 
     # Look up the new alias and verify all quotes are preserved
-    out, err = run_cmd(base_app, 'alias list fake')
+    out, _err = run_cmd(base_app, 'alias list fake')
     assert out == normalize(create_command)
     assert len(base_app.last_result) == 1
     assert base_app.last_result[alias_name] == alias_command
@@ -2399,13 +2399,13 @@ def test_alias_create_with_quoted_tokens(base_app) -> None:
 
 @pytest.mark.parametrize('alias_name', invalid_command_name)
 def test_alias_create_invalid_name(base_app, alias_name, capsys) -> None:
-    out, err = run_cmd(base_app, f'alias create {alias_name} help')
+    _out, err = run_cmd(base_app, f'alias create {alias_name} help')
     assert "Invalid alias name" in err[0]
     assert base_app.last_result is False
 
 
 def test_alias_create_with_command_name(base_app) -> None:
-    out, err = run_cmd(base_app, 'alias create help stuff')
+    _out, err = run_cmd(base_app, 'alias create help stuff')
     assert "Alias cannot have the same name as a command" in err[0]
     assert base_app.last_result is False
 
@@ -2413,7 +2413,7 @@ def test_alias_create_with_command_name(base_app) -> None:
 def test_alias_create_with_macro_name(base_app) -> None:
     macro = "my_macro"
     run_cmd(base_app, f'macro create {macro} help')
-    out, err = run_cmd(base_app, f'alias create {macro} help')
+    _out, err = run_cmd(base_app, f'alias create {macro} help')
     assert "Alias cannot have the same name as a macro" in err[0]
     assert base_app.last_result is False
 
@@ -2431,7 +2431,7 @@ def test_alias_that_resolves_into_comment(base_app) -> None:
 
 def test_alias_list_invalid_alias(base_app) -> None:
     # Look up invalid alias
-    out, err = run_cmd(base_app, 'alias list invalid')
+    _out, err = run_cmd(base_app, 'alias list invalid')
     assert "Alias 'invalid' not found" in err[0]
     assert base_app.last_result == {}
 
@@ -2441,25 +2441,25 @@ def test_alias_delete(base_app) -> None:
     run_cmd(base_app, 'alias create fake run_pyscript')
 
     # Delete the alias
-    out, err = run_cmd(base_app, 'alias delete fake')
+    out, _err = run_cmd(base_app, 'alias delete fake')
     assert out == normalize("Alias 'fake' deleted")
     assert base_app.last_result is True
 
 
 def test_alias_delete_all(base_app) -> None:
-    out, err = run_cmd(base_app, 'alias delete --all')
+    out, _err = run_cmd(base_app, 'alias delete --all')
     assert out == normalize("All aliases deleted")
     assert base_app.last_result is True
 
 
 def test_alias_delete_non_existing(base_app) -> None:
-    out, err = run_cmd(base_app, 'alias delete fake')
+    _out, err = run_cmd(base_app, 'alias delete fake')
     assert "Alias 'fake' does not exist" in err[0]
     assert base_app.last_result is True
 
 
 def test_alias_delete_no_name(base_app) -> None:
-    out, err = run_cmd(base_app, 'alias delete')
+    _out, err = run_cmd(base_app, 'alias delete')
     assert "Either --all or alias name(s)" in err[0]
     assert base_app.last_result is False
 
@@ -2469,15 +2469,15 @@ def test_multiple_aliases(base_app) -> None:
     alias2 = 'h2'
     run_cmd(base_app, f'alias create {alias1} help')
     run_cmd(base_app, f'alias create {alias2} help -v')
-    out, err = run_cmd(base_app, alias1)
+    out, _err = run_cmd(base_app, alias1)
     verify_help_text(base_app, out)
 
-    out, err = run_cmd(base_app, alias2)
+    out, _err = run_cmd(base_app, alias2)
     verify_help_text(base_app, out)
 
 
 def test_macro_no_subcommand(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro')
+    _out, err = run_cmd(base_app, 'macro')
     assert "Usage: macro [-h]" in err[0]
     assert "Error: the following arguments are required: SUBCOMMAND" in err[1]
 
@@ -2523,11 +2523,11 @@ def test_macro_create_with_quoted_tokens(base_app) -> None:
     create_command = f"macro create {macro_name} {macro_command}"
 
     # Create the macro
-    out, err = run_cmd(base_app, create_command)
+    out, _err = run_cmd(base_app, create_command)
     assert out == normalize("Macro 'fake' created")
 
     # Look up the new macro and verify all quotes are preserved
-    out, err = run_cmd(base_app, 'macro list fake')
+    out, _err = run_cmd(base_app, 'macro list fake')
     assert out == normalize(create_command)
     assert len(base_app.last_result) == 1
     assert base_app.last_result[macro_name] == macro_command
@@ -2535,13 +2535,13 @@ def test_macro_create_with_quoted_tokens(base_app) -> None:
 
 @pytest.mark.parametrize('macro_name', invalid_command_name)
 def test_macro_create_invalid_name(base_app, macro_name) -> None:
-    out, err = run_cmd(base_app, f'macro create {macro_name} help')
+    _out, err = run_cmd(base_app, f'macro create {macro_name} help')
     assert "Invalid macro name" in err[0]
     assert base_app.last_result is False
 
 
 def test_macro_create_with_command_name(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro create help stuff')
+    _out, err = run_cmd(base_app, 'macro create help stuff')
     assert "Macro cannot have the same name as a command" in err[0]
     assert base_app.last_result is False
 
@@ -2549,18 +2549,18 @@ def test_macro_create_with_command_name(base_app) -> None:
 def test_macro_create_with_alias_name(base_app) -> None:
     macro = "my_macro"
     run_cmd(base_app, f'alias create {macro} help')
-    out, err = run_cmd(base_app, f'macro create {macro} help')
+    _out, err = run_cmd(base_app, f'macro create {macro} help')
     assert "Macro cannot have the same name as an alias" in err[0]
     assert base_app.last_result is False
 
 
 def test_macro_create_with_args(base_app) -> None:
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake {1} {2}')
+    out, _err = run_cmd(base_app, 'macro create fake {1} {2}')
     assert out == normalize("Macro 'fake' created")
 
     # Run the macro
-    out, err = run_cmd(base_app, 'fake help -v')
+    out, _err = run_cmd(base_app, 'fake help -v')
     verify_help_text(base_app, out)
 
 
@@ -2586,24 +2586,24 @@ def test_macro_usage_with_missing_args(base_app) -> None:
 
 def test_macro_usage_with_exta_args(base_app) -> None:
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake help {1}')
+    out, _err = run_cmd(base_app, 'macro create fake help {1}')
     assert out == normalize("Macro 'fake' created")
 
     # Run the macro
-    out, err = run_cmd(base_app, 'fake alias create')
+    out, _err = run_cmd(base_app, 'fake alias create')
     assert "Usage: alias create" in out[0]
 
 
 def test_macro_create_with_missing_arg_nums(base_app) -> None:
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake help {1} {3}')
+    _out, err = run_cmd(base_app, 'macro create fake help {1} {3}')
     assert "Not all numbers between 1 and 3" in err[0]
     assert base_app.last_result is False
 
 
 def test_macro_create_with_invalid_arg_num(base_app) -> None:
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake help {1} {-1} {0}')
+    _out, err = run_cmd(base_app, 'macro create fake help {1} {-1} {0}')
     assert "Argument numbers must be greater than 0" in err[0]
     assert base_app.last_result is False
 
@@ -2619,7 +2619,7 @@ def test_macro_create_with_unicode_numbered_arg(base_app) -> None:
 
 
 def test_macro_create_with_missing_unicode_arg_nums(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro create fake help {1} {\N{ARABIC-INDIC DIGIT THREE}}')
+    _out, err = run_cmd(base_app, 'macro create fake help {1} {\N{ARABIC-INDIC DIGIT THREE}}')
     assert "Not all numbers between 1 and 3" in err[0]
     assert base_app.last_result is False
 
@@ -2637,7 +2637,7 @@ def test_macro_that_resolves_into_comment(base_app) -> None:
 
 def test_macro_list_invalid_macro(base_app) -> None:
     # Look up invalid macro
-    out, err = run_cmd(base_app, 'macro list invalid')
+    _out, err = run_cmd(base_app, 'macro list invalid')
     assert "Macro 'invalid' not found" in err[0]
     assert base_app.last_result == {}
 
@@ -2647,25 +2647,25 @@ def test_macro_delete(base_app) -> None:
     run_cmd(base_app, 'macro create fake run_pyscript')
 
     # Delete the macro
-    out, err = run_cmd(base_app, 'macro delete fake')
+    out, _err = run_cmd(base_app, 'macro delete fake')
     assert out == normalize("Macro 'fake' deleted")
     assert base_app.last_result is True
 
 
 def test_macro_delete_all(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro delete --all')
+    out, _err = run_cmd(base_app, 'macro delete --all')
     assert out == normalize("All macros deleted")
     assert base_app.last_result is True
 
 
 def test_macro_delete_non_existing(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro delete fake')
+    _out, err = run_cmd(base_app, 'macro delete fake')
     assert "Macro 'fake' does not exist" in err[0]
     assert base_app.last_result is True
 
 
 def test_macro_delete_no_name(base_app) -> None:
-    out, err = run_cmd(base_app, 'macro delete')
+    _out, err = run_cmd(base_app, 'macro delete')
     assert "Either --all or macro name(s)" in err[0]
     assert base_app.last_result is False
 
@@ -2675,10 +2675,10 @@ def test_multiple_macros(base_app) -> None:
     macro2 = 'h2'
     run_cmd(base_app, f'macro create {macro1} help')
     run_cmd(base_app, f'macro create {macro2} help -v')
-    out, err = run_cmd(base_app, macro1)
+    out, _err = run_cmd(base_app, macro1)
     verify_help_text(base_app, out)
 
-    out2, err2 = run_cmd(base_app, macro2)
+    out2, _err2 = run_cmd(base_app, macro2)
     verify_help_text(base_app, out2)
     assert len(out2) > len(out)
 
@@ -2702,7 +2702,7 @@ def test_nonexistent_macro(base_app) -> None:
 def test_perror_style(base_app, capsys) -> None:
     msg = 'testing...'
     base_app.perror(msg)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert err == "\x1b[91mtesting...\x1b[0m\n"
 
 
@@ -2711,7 +2711,7 @@ def test_perror_no_style(base_app, capsys) -> None:
     msg = 'testing...'
     end = '\n'
     base_app.perror(msg, style=None)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert err == msg + end
 
 
@@ -2720,7 +2720,7 @@ def test_pexcept_style(base_app, capsys) -> None:
     msg = Exception('testing...')
 
     base_app.pexcept(msg)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     expected = su.stylize("Exception: ", style="traceback.exc_type")
     assert err.startswith(expected)
 
@@ -2730,7 +2730,7 @@ def test_pexcept_no_style(base_app, capsys) -> None:
     msg = Exception('testing...')
 
     base_app.pexcept(msg)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert err.startswith("Exception: testing...")
 
 
@@ -3232,7 +3232,7 @@ def test_disabled_message_command_name(disable_commands_app) -> None:
     message_to_print = f'{COMMAND_NAME} is currently disabled'
     disable_commands_app.disable_command('has_helper_funcs', message_to_print)
 
-    out, err = run_cmd(disable_commands_app, 'has_helper_funcs')
+    _out, err = run_cmd(disable_commands_app, 'has_helper_funcs')
     assert err[0].startswith('has_helper_funcs is currently disabled')
 
 
@@ -3245,13 +3245,13 @@ def test_startup_script(request, capsys, silence_startup_script) -> None:
     app._startup_commands.append('quit')
     app.cmdloop()
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     if silence_startup_script:
         assert not out
     else:
         assert out
 
-    out, err = run_cmd(app, 'alias list')
+    out, _err = run_cmd(app, 'alias list')
     assert len(out) > 1
     assert 'alias create ls' in out[0]
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -270,7 +270,7 @@ def test_complete_exception(cmd2_app, capsys) -> None:
     begidx = endidx - len(text)
 
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
 
     assert first_match is None
     assert "IndexError" in err
@@ -278,7 +278,7 @@ def test_complete_exception(cmd2_app, capsys) -> None:
 
 def test_complete_macro(base_app, request) -> None:
     # Create the macro
-    out, err = run_cmd(base_app, 'macro create fake run_pyscript {1}')
+    out, _err = run_cmd(base_app, 'macro create fake run_pyscript {1}')
     assert out == normalize("Macro 'fake' created")
 
     # Macros do path completion
@@ -1178,7 +1178,7 @@ def test_complete_set_value_invalid_settable(cmd2_app, capsys) -> None:
     first_match = complete_tester(text, line, begidx, endidx, cmd2_app)
     assert first_match is None
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert "fake is not a settable parameter" in out
 
 

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -17,6 +17,6 @@ def test_hooks_work_with_future_annotations() -> None:
             return data
 
     hook_app = HookApp()
-    out, err = run_cmd(hook_app, '')
+    out, _err = run_cmd(hook_app, '')
     expected = normalize('')
     assert out == expected

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -497,7 +497,7 @@ def test_history_item_properties(histitem) -> None:
 def test_base_history(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
-    out, err = run_cmd(base_app, 'history')
+    out, _err = run_cmd(base_app, 'history')
     expected = normalize(
         """
     1  help
@@ -506,7 +506,7 @@ def test_base_history(base_app) -> None:
     )
     assert out == expected
 
-    out, err = run_cmd(base_app, 'history he')
+    out, _err = run_cmd(base_app, 'history he')
     expected = normalize(
         """
     1  help
@@ -515,7 +515,7 @@ def test_base_history(base_app) -> None:
     assert out == expected
     verify_hi_last_result(base_app, 1)
 
-    out, err = run_cmd(base_app, 'history sh')
+    out, _err = run_cmd(base_app, 'history sh')
     expected = normalize(
         """
     2  shortcuts
@@ -528,7 +528,7 @@ def test_base_history(base_app) -> None:
 def test_history_script_format(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
-    out, err = run_cmd(base_app, 'history -s')
+    out, _err = run_cmd(base_app, 'history -s')
     expected = normalize(
         """
 help
@@ -543,7 +543,7 @@ def test_history_with_string_argument(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
     run_cmd(base_app, 'help history')
-    out, err = run_cmd(base_app, 'history help')
+    out, _err = run_cmd(base_app, 'history help')
     expected = normalize(
         """
     1  help
@@ -559,7 +559,7 @@ def test_history_expanded_with_string_argument(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'help history')
     run_cmd(base_app, 'sc')
-    out, err = run_cmd(base_app, 'history -v shortcuts')
+    out, _err = run_cmd(base_app, 'history -v shortcuts')
     expected = normalize(
         """
     1  alias create sc shortcuts
@@ -576,7 +576,7 @@ def test_history_expanded_with_regex_argument(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'help history')
     run_cmd(base_app, 'sc')
-    out, err = run_cmd(base_app, 'history -v /sh.*cuts/')
+    out, _err = run_cmd(base_app, 'history -v /sh.*cuts/')
     expected = normalize(
         """
     1  alias create sc shortcuts
@@ -591,7 +591,7 @@ def test_history_expanded_with_regex_argument(base_app) -> None:
 def test_history_with_integer_argument(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
-    out, err = run_cmd(base_app, 'history 1')
+    out, _err = run_cmd(base_app, 'history 1')
     expected = normalize(
         """
     1  help
@@ -605,7 +605,7 @@ def test_history_with_integer_span(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
     run_cmd(base_app, 'help history')
-    out, err = run_cmd(base_app, 'history 1..2')
+    out, _err = run_cmd(base_app, 'history 1..2')
     expected = normalize(
         """
     1  help
@@ -620,7 +620,7 @@ def test_history_with_span_start(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
     run_cmd(base_app, 'help history')
-    out, err = run_cmd(base_app, 'history 2:')
+    out, _err = run_cmd(base_app, 'history 2:')
     expected = normalize(
         """
     2  shortcuts
@@ -635,7 +635,7 @@ def test_history_with_span_end(base_app) -> None:
     run_cmd(base_app, 'help')
     run_cmd(base_app, 'shortcuts')
     run_cmd(base_app, 'help history')
-    out, err = run_cmd(base_app, 'history :2')
+    out, _err = run_cmd(base_app, 'history :2')
     expected = normalize(
         """
     1  help
@@ -723,8 +723,8 @@ def test_history_run_all_commands(base_app) -> None:
 
 
 def test_history_run_one_command(base_app) -> None:
-    out1, err1 = run_cmd(base_app, 'help')
-    out2, err2 = run_cmd(base_app, 'history -r 1')
+    out1, _err1 = run_cmd(base_app, 'help')
+    out2, _err2 = run_cmd(base_app, 'history -r 1')
     assert out1 == out2
     assert base_app.last_result is True
 
@@ -768,7 +768,7 @@ def test_history_verbose_with_other_options(base_app) -> None:
     # make sure -v shows a usage error if any other options are present
     options_to_test = ['-r', '-e', '-o file', '-t file', '-c', '-x']
     for opt in options_to_test:
-        out, err = run_cmd(base_app, 'history -v ' + opt)
+        out, _err = run_cmd(base_app, 'history -v ' + opt)
         assert '-v cannot be used with any other options' in out
         assert base_app.last_result is False
 
@@ -777,7 +777,7 @@ def test_history_verbose(base_app) -> None:
     # validate function of -v option
     run_cmd(base_app, 'alias create s shortcuts')
     run_cmd(base_app, 's')
-    out, err = run_cmd(base_app, 'history -v')
+    out, _err = run_cmd(base_app, 'history -v')
 
     expected = normalize(
         """
@@ -794,7 +794,7 @@ def test_history_script_with_invalid_options(base_app) -> None:
     # make sure -s shows a usage error if -c, -r, -e, -o, or -t are present
     options_to_test = ['-r', '-e', '-o file', '-t file', '-c']
     for opt in options_to_test:
-        out, err = run_cmd(base_app, 'history -s ' + opt)
+        out, _err = run_cmd(base_app, 'history -s ' + opt)
         assert '-s and -x cannot be used with -c, -r, -e, -o, or -t' in out
         assert base_app.last_result is False
 
@@ -803,7 +803,7 @@ def test_history_script(base_app) -> None:
     cmds = ['alias create s shortcuts', 's']
     for cmd in cmds:
         run_cmd(base_app, cmd)
-    out, err = run_cmd(base_app, 'history -s')
+    out, _err = run_cmd(base_app, 'history -s')
     assert out == cmds
     verify_hi_last_result(base_app, 2)
 
@@ -812,7 +812,7 @@ def test_history_expanded_with_invalid_options(base_app) -> None:
     # make sure -x shows a usage error if -c, -r, -e, -o, or -t are present
     options_to_test = ['-r', '-e', '-o file', '-t file', '-c']
     for opt in options_to_test:
-        out, err = run_cmd(base_app, 'history -x ' + opt)
+        out, _err = run_cmd(base_app, 'history -x ' + opt)
         assert '-s and -x cannot be used with -c, -r, -e, -o, or -t' in out
         assert base_app.last_result is False
 
@@ -822,7 +822,7 @@ def test_history_expanded(base_app) -> None:
     cmds = ['alias create s shortcuts', 's']
     for cmd in cmds:
         run_cmd(base_app, cmd)
-    out, err = run_cmd(base_app, 'history -x')
+    out, _err = run_cmd(base_app, 'history -x')
     expected = ['    1  alias create s shortcuts', '    2  shortcuts']
     assert out == expected
     verify_hi_last_result(base_app, 2)
@@ -833,7 +833,7 @@ def test_history_script_expanded(base_app) -> None:
     cmds = ['alias create s shortcuts', 's']
     for cmd in cmds:
         run_cmd(base_app, cmd)
-    out, err = run_cmd(base_app, 'history -sx')
+    out, _err = run_cmd(base_app, 'history -sx')
     expected = ['alias create s shortcuts', 'shortcuts']
     assert out == expected
     verify_hi_last_result(base_app, 2)
@@ -845,7 +845,7 @@ def test_exclude_from_history(base_app) -> None:
     verify_hi_last_result(base_app, 0)
 
     # Verify that the history is empty
-    out, err = run_cmd(base_app, 'history')
+    out, _err = run_cmd(base_app, 'history')
     assert out == []
     verify_hi_last_result(base_app, 0)
 
@@ -853,7 +853,7 @@ def test_exclude_from_history(base_app) -> None:
     run_cmd(base_app, 'help')
 
     # And verify we have a history now ...
-    out, err = run_cmd(base_app, 'history')
+    out, _err = run_cmd(base_app, 'history')
     expected = normalize("""    1  help""")
     assert out == expected
     verify_hi_last_result(base_app, 1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -961,7 +961,7 @@ def test_skip_postcmd_hooks(capsys) -> None:
 
     # Cause a SkipPostcommandHooks exception and verify no postcmd stuff runs but cmdfinalization_hook still does
     app.onecmd_plus_hooks('skip_postcmd_hooks')
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert "In do_skip_postcmd_hooks" in out
     assert app.called_postcmd == 0
     assert app.called_cmdfinalization == 1

--- a/tests/test_run_pyscript.py
+++ b/tests/test_run_pyscript.py
@@ -21,7 +21,7 @@ def test_run_pyscript(base_app, request) -> None:
     python_script = os.path.join(test_dir, 'script.py')
     expected = 'This is a python script running ...'
 
-    out, err = run_cmd(base_app, f"run_pyscript {python_script}")
+    out, _err = run_cmd(base_app, f"run_pyscript {python_script}")
     assert expected in out
     assert base_app.last_result is True
 
@@ -31,14 +31,14 @@ def test_run_pyscript_recursive_not_allowed(base_app, request) -> None:
     python_script = os.path.join(test_dir, 'pyscript', 'recursive.py')
     expected = 'Recursively entering interactive Python shells is not allowed'
 
-    out, err = run_cmd(base_app, f"run_pyscript {python_script}")
+    _out, err = run_cmd(base_app, f"run_pyscript {python_script}")
     assert err[0] == expected
     assert base_app.last_result is False
 
 
 def test_run_pyscript_with_nonexist_file(base_app) -> None:
     python_script = 'does_not_exist.py'
-    out, err = run_cmd(base_app, f"run_pyscript {python_script}")
+    _out, err = run_cmd(base_app, f"run_pyscript {python_script}")
     assert "Error reading script file" in err[0]
     assert base_app.last_result is False
 
@@ -49,7 +49,7 @@ def test_run_pyscript_with_non_python_file(base_app, request) -> None:
 
     test_dir = os.path.dirname(request.module.__file__)
     filename = os.path.join(test_dir, 'scripts', 'help.txt')
-    out, err = run_cmd(base_app, f'run_pyscript {filename}')
+    _out, err = run_cmd(base_app, f'run_pyscript {filename}')
     assert "does not have a .py extension" in err[0]
     assert base_app.last_result is False
 
@@ -63,7 +63,7 @@ def test_run_pyscript_with_odd_file_names(base_app, python_script) -> None:
     input_mock = mock.MagicMock(name='input', return_value='1')
     builtins.input = input_mock
 
-    out, err = run_cmd(base_app, f"run_pyscript {quote(python_script)}")
+    _out, err = run_cmd(base_app, f"run_pyscript {quote(python_script)}")
     err = ''.join(err)
     assert f"Error reading script file '{python_script}'" in err
     assert base_app.last_result is False
@@ -72,14 +72,14 @@ def test_run_pyscript_with_odd_file_names(base_app, python_script) -> None:
 def test_run_pyscript_with_exception(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'raises_exception.py')
-    out, err = run_cmd(base_app, f"run_pyscript {python_script}")
+    _out, err = run_cmd(base_app, f"run_pyscript {python_script}")
     assert err[0].startswith('Traceback')
     assert "TypeError: unsupported operand type(s) for +: 'int' and 'str'" in err[-1]
     assert base_app.last_result is True
 
 
 def test_run_pyscript_requires_an_argument(base_app) -> None:
-    out, err = run_cmd(base_app, "run_pyscript")
+    _out, err = run_cmd(base_app, "run_pyscript")
     assert "the following arguments are required: script_path" in err[1]
     assert base_app.last_result is None
 
@@ -87,8 +87,8 @@ def test_run_pyscript_requires_an_argument(base_app) -> None:
 def test_run_pyscript_help(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'help.py')
-    out1, err1 = run_cmd(base_app, 'help')
-    out2, err2 = run_cmd(base_app, f'run_pyscript {python_script}')
+    out1, _err1 = run_cmd(base_app, 'help')
+    out2, _err2 = run_cmd(base_app, f'run_pyscript {python_script}')
     assert out1
     assert out1 == out2
 
@@ -118,7 +118,7 @@ def test_run_pyscript_dir(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'pyscript_dir.py')
 
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
     assert out[0] == "['cmd_echo']"
 
 
@@ -126,7 +126,7 @@ def test_run_pyscript_capture(base_app, request) -> None:
     base_app.self_in_py = True
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'stdout_capture.py')
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
 
     assert out[0] == "print"
     assert out[1] == "poutput"
@@ -141,7 +141,7 @@ def test_run_pyscript_capture_custom_stdout(base_app, request) -> None:
     base_app.self_in_py = True
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'stdout_capture.py')
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
 
     assert "print" not in out
     assert out[0] == "poutput"
@@ -165,7 +165,7 @@ def test_run_pyscript_stop(base_app, request) -> None:
 def test_run_pyscript_environment(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'environment.py')
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
 
     assert out[0] == "PASSED"
 
@@ -176,12 +176,12 @@ def test_run_pyscript_self_in_py(base_app, request) -> None:
 
     # Set self_in_py to True and make sure we see self
     base_app.self_in_py = True
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
     assert 'I see self' in out[0]
 
     # Set self_in_py to False and make sure we can't see self
     base_app.self_in_py = False
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
     assert 'I do not see self' in out[0]
 
 
@@ -209,7 +209,7 @@ def test_run_pyscript_py_locals(base_app, request) -> None:
 def test_run_pyscript_app_echo(base_app, request) -> None:
     test_dir = os.path.dirname(request.module.__file__)
     python_script = os.path.join(test_dir, 'pyscript', 'echo.py')
-    out, err = run_cmd(base_app, f'run_pyscript {python_script}')
+    out, _err = run_cmd(base_app, f'run_pyscript {python_script}')
 
     # Only the edit help text should have been echoed to pytest's stdout
     assert out[0] == "Usage: edit [-h] [file_path]"

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -185,7 +185,7 @@ def test_history_transcript_bad_path(mocker) -> None:
 
     # Bad directory
     history_fname = '~/fakedir/this_does_not_exist.txt'
-    out, err = run_cmd(app, f'history -t "{history_fname}"')
+    _out, err = run_cmd(app, f'history -t "{history_fname}"')
     assert "is not a directory" in err[0]
 
     # Cause os.open to fail and make sure error gets printed
@@ -193,7 +193,7 @@ def test_history_transcript_bad_path(mocker) -> None:
     mock_remove.side_effect = OSError
 
     history_fname = 'outfile.txt'
-    out, err = run_cmd(app, f'history -t "{history_fname}"')
+    _out, err = run_cmd(app, f'history -t "{history_fname}"')
     assert "Error saving transcript file" in err[0]
 
 

--- a/tests_isolated/test_commandset/test_argparse_subcommands.py
+++ b/tests_isolated/test_commandset/test_argparse_subcommands.py
@@ -66,23 +66,23 @@ def subcommand_app():
 
 
 def test_subcommand_foo(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base foo -x2 5.0')
+    out, _err = run_cmd(subcommand_app, 'base foo -x2 5.0')
     assert out == ['10.0']
 
 
 def test_subcommand_bar(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base bar baz')
+    out, _err = run_cmd(subcommand_app, 'base bar baz')
     assert out == ['((baz))']
 
 
 def test_subcommand_invalid(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'base baz')
+    _out, err = run_cmd(subcommand_app, 'base baz')
     assert err[0].startswith('Usage: base')
     assert err[1].startswith("Error: argument SUBCOMMAND: invalid choice: 'baz'")
 
 
 def test_subcommand_base_help(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'help base')
+    out, _err = run_cmd(subcommand_app, 'help base')
     assert out[0].startswith('Usage: base')
     assert out[1] == ''
     assert out[2] == 'Base command help'
@@ -90,44 +90,44 @@ def test_subcommand_base_help(subcommand_app) -> None:
 
 def test_subcommand_help(subcommand_app) -> None:
     # foo has no aliases
-    out, err = run_cmd(subcommand_app, 'help base foo')
+    out, _err = run_cmd(subcommand_app, 'help base foo')
     assert out[0].startswith('Usage: base foo')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
     # bar has aliases (usage should never show alias name)
-    out, err = run_cmd(subcommand_app, 'help base bar')
+    out, _err = run_cmd(subcommand_app, 'help base bar')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base bar_1')
+    out, _err = run_cmd(subcommand_app, 'help base bar_1')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base bar_2')
+    out, _err = run_cmd(subcommand_app, 'help base bar_2')
     assert out[0].startswith('Usage: base bar')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
     # helpless has aliases and no help text (usage should never show alias name)
-    out, err = run_cmd(subcommand_app, 'help base helpless')
+    out, _err = run_cmd(subcommand_app, 'help base helpless')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base helpless_1')
+    out, _err = run_cmd(subcommand_app, 'help base helpless_1')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
-    out, err = run_cmd(subcommand_app, 'help base helpless_2')
+    out, _err = run_cmd(subcommand_app, 'help base helpless_2')
     assert out[0].startswith('Usage: base helpless')
     assert out[1] == ''
     assert out[2] == 'Positional Arguments:'
 
 
 def test_subcommand_invalid_help(subcommand_app) -> None:
-    out, err = run_cmd(subcommand_app, 'help base baz')
+    out, _err = run_cmd(subcommand_app, 'help base baz')
     assert out[0].startswith('Usage: base')

--- a/tests_isolated/test_commandset/test_commandset.py
+++ b/tests_isolated/test_commandset/test_commandset.py
@@ -123,7 +123,7 @@ class CommandSetB(CommandSetBase):
 def test_autoload_commands(command_sets_app) -> None:
     # verifies that, when autoload is enabled, CommandSets and registered functions all show up
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_app._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = command_sets_app._build_command_info()
 
     assert 'Alone' in cmds_cats
     assert 'elderberry' in cmds_cats['Alone']
@@ -184,7 +184,7 @@ def test_command_synonyms() -> None:
 
     # Make sure the alias command still exists, has the same parser, and works.
     assert alias_parser is app._command_parsers.get(cmd2.Cmd.do_alias)
-    out, err = run_cmd(app, 'alias --help')
+    out, _err = run_cmd(app, 'alias --help')
     assert normalize(alias_parser.format_help())[0] in out
 
 
@@ -199,7 +199,7 @@ def test_custom_construct_commandsets() -> None:
     # Verifies that a custom initialized CommandSet loads correctly when passed into the constructor
     app = WithCommandSets(command_sets=[command_set_b])
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = app._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = app._build_command_info()
     assert 'Command Set B' in cmds_cats
 
     # Verifies that the same CommandSet cannot be loaded twice
@@ -246,11 +246,11 @@ def test_load_commands(command_sets_manual, capsys) -> None:
     assert 'Apple!' in out.stdout
 
     # Make sure registration callbacks ran
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert "in on_register now" in out
     assert "in on_registered now" in out
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
 
     assert 'Alone' in cmds_cats
     assert 'elderberry' in cmds_cats['Alone']
@@ -266,13 +266,13 @@ def test_load_commands(command_sets_manual, capsys) -> None:
     # uninstall the command set and verify it is now also no longer accessible
     command_sets_manual.unregister_command_set(cmd_set)
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
 
     assert 'Alone' not in cmds_cats
     assert 'Fruits' not in cmds_cats
 
     # Make sure unregistration callbacks ran
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert "in on_unregister now" in out
     assert "in on_unregistered now" in out
 
@@ -282,7 +282,7 @@ def test_load_commands(command_sets_manual, capsys) -> None:
     # reinstall the command set and verify it is accessible
     command_sets_manual.register_command_set(cmd_set)
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
 
     assert 'Alone' in cmds_cats
     assert 'elderberry' in cmds_cats['Alone']
@@ -335,7 +335,7 @@ def test_load_commandset_errors(command_sets_manual, capsys) -> None:
         command_sets_manual.register_command_set(cmd_set)
 
     # verify that the commands weren't installed
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
 
     assert 'Alone' not in cmds_cats
     assert 'Fruits' not in cmds_cats
@@ -349,7 +349,7 @@ def test_load_commandset_errors(command_sets_manual, capsys) -> None:
 
     # now install a command set and verify the commands are now present
     command_sets_manual.register_command_set(cmd_set)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
 
     # verify aliases and macros are deleted with warning if they conflict with a command
     assert "Deleting alias 'banana'" in err
@@ -524,7 +524,7 @@ def test_subcommands(command_sets_manual) -> None:
         command_sets_manual.register_command_set(fruit_cmds)
 
     # verify that the commands weren't installed
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
     assert 'cut' in cmds_doc
     assert 'Fruits' not in cmds_cats
 
@@ -542,7 +542,7 @@ def test_subcommands(command_sets_manual) -> None:
     # verify that command set install without problems
     command_sets_manual.register_command_set(fruit_cmds)
     command_sets_manual.register_command_set(veg_cmds)
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
     assert 'Fruits' in cmds_cats
 
     text = ''
@@ -570,7 +570,7 @@ def test_subcommands(command_sets_manual) -> None:
 
     # verify that command set uninstalls without problems
     command_sets_manual.unregister_command_set(fruit_cmds)
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
     assert 'Fruits' not in cmds_cats
 
     # verify a double-unregister raises exception
@@ -587,7 +587,7 @@ def test_subcommands(command_sets_manual) -> None:
 
     command_sets_manual.enable_command('cut')
 
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
     assert 'Fruits' in cmds_cats
 
     text = ''
@@ -615,7 +615,7 @@ def test_subcommands(command_sets_manual) -> None:
 
     # verify that command set uninstalls without problems
     command_sets_manual.unregister_command_set(fruit_cmds)
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = command_sets_manual._build_command_info()
+    cmds_cats, cmds_doc, _cmds_undoc, _help_topics = command_sets_manual._build_command_info()
     assert 'Fruits' not in cmds_cats
 
     # verify a double-unregister raises exception
@@ -752,7 +752,7 @@ def static_subcommands_app():
 
 
 def test_static_subcommands(static_subcommands_app) -> None:
-    cmds_cats, cmds_doc, cmds_undoc, help_topics = static_subcommands_app._build_command_info()
+    cmds_cats, _cmds_doc, _cmds_undoc, _help_topics = static_subcommands_app._build_command_info()
     assert 'Fruits' in cmds_cats
 
     text = ''
@@ -929,7 +929,7 @@ def test_cross_commandset_completer(command_sets_manual, capsys) -> None:
     endidx = len(line)
     begidx = endidx
     first_match = complete_tester(text, line, begidx, endidx, command_sets_manual)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert first_match is None
     assert command_sets_manual.completion_matches == []
@@ -952,7 +952,7 @@ def test_cross_commandset_completer(command_sets_manual, capsys) -> None:
     endidx = len(line)
     begidx = endidx
     first_match = complete_tester(text, line, begidx, endidx, command_sets_manual)
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert first_match is None
     assert command_sets_manual.completion_matches == []
@@ -1145,7 +1145,7 @@ Parameter 'arbitrary_value' not supported (type 'set' for list of parameters).
 
     with pytest.raises(
         ValueError,
-        match="Cannot force settable prefixes. CommandSet WithSettablesNoPrefix does not have a settable prefix defined.",
+        match=r"Cannot force settable prefixes. CommandSet WithSettablesNoPrefix does not have a settable prefix defined.",
     ):
         app.always_prefix_settables = True
 


### PR DESCRIPTION
Upgrade from `ruff` 0.12.9 to ruff 0.13.0.

Most changes were done automatically by ruff.  ruff is now stricter about prefacing unused variables with an underscore.