### PR TITLE
Make backwards compatibility slightly easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ time reading the [rich documentation](https://rich.readthedocs.io/).
         - `descriptive_header: str` replaced with `descriptive_headers: Sequence[str | rich.Column]`
             - Applies to parameter name when adding an argument to a parser as well as
               `set_descriptive_headers` and `get_descriptive_headers`
-        - `CompletionItem.description: str` changed to
-          `CompletionItem.descriptive_data: Sequence[str | rich.Column]`
+        - Restored `CompletionItem.description` and expanded its type to work with either `str` or
+          `Sequence[str | rich.Column]`
     - `decorators` module breaking changes:
         - `_set_parser_prog` renamed to `set_parser_prog` (without the leading underscore) and moved
           to `argparse_custom` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ time reading the [rich documentation](https://rich.readthedocs.io/).
         - `descriptive_header: str` replaced with `descriptive_headers: Sequence[str | rich.Column]`
             - Applies to parameter name when adding an argument to a parser as well as
               `set_descriptive_headers` and `get_descriptive_headers`
-        - Restored `CompletionItem.description` and expanded its type to work with either `str` or
-          `Sequence[str | rich.Column]`
+        - `CompletionItem.description` type expanded from `str` to `str | Sequence[Any]`
     - `decorators` module breaking changes:
         - `_set_parser_prog` renamed to `set_parser_prog` (without the leading underscore) and moved
           to `argparse_custom` module

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -582,7 +582,7 @@ class ArgparseCompleter:
                 border_style=Cmd2Style.TABLE_BORDER,
             )
             for item in completion_items:
-                hint_table.add_row(item, *item.descriptive_data)
+                hint_table.add_row(item, *item.description)
 
             # Generate the hint table string
             console = Cmd2GeneralConsole()

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -2306,7 +2306,7 @@ def test_get_alias_completion_items(base_app) -> None:
     for cur_res in results:
         assert cur_res in base_app.aliases
         # Strip trailing spaces from table output
-        assert cur_res.descriptive_data[0].rstrip() == base_app.aliases[cur_res]
+        assert cur_res.description[0].rstrip() == base_app.aliases[cur_res]
 
 
 def test_get_macro_completion_items(base_app) -> None:
@@ -2319,7 +2319,7 @@ def test_get_macro_completion_items(base_app) -> None:
     for cur_res in results:
         assert cur_res in base_app.macros
         # Strip trailing spaces from table output
-        assert cur_res.descriptive_data[0].rstrip() == base_app.macros[cur_res].value
+        assert cur_res.description[0].rstrip() == base_app.macros[cur_res].value
 
 
 def test_get_settable_completion_items(base_app) -> None:
@@ -2333,11 +2333,11 @@ def test_get_settable_completion_items(base_app) -> None:
         # These CompletionItem descriptions are a two column table (Settable Value and Settable Description)
         # First check if the description text starts with the value
         str_value = str(cur_settable.value)
-        assert cur_res.descriptive_data[0].startswith(str_value)
+        assert cur_res.description[0].startswith(str_value)
 
         # The second column is likely to have wrapped long text. So we will just examine the
         # first couple characters to look for the Settable's description.
-        assert cur_settable.description[0:10] in cur_res.descriptive_data[1]
+        assert cur_settable.description[0:10] in cur_res.description[1]
 
 
 def test_alias_no_subcommand(base_app) -> None:


### PR DESCRIPTION
Revert `CompletionItem.description` field to original name, but expand type from `str` to `str | Sequence[Any]`