### PR TITLE
Fix MkDocs build warning mkdocstrings-python 2.0.0 was released and is stricter about warnings

### DIFF
--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -105,10 +105,10 @@ class Statement(str):  # noqa: SLOT000
        whether positional or denoted with switches.
 
     2. For commands with simple positional arguments, use
-       [args][cmd2.Statement.args] or [arg_list][cmd2.Statement.arg_list]
+       [args][cmd2.parsing.Statement.args] or [arg_list][cmd2.parsing.Statement.arg_list]
 
     3. If you don't want to have to worry about quoted arguments, see
-       [argv][cmd2.Statement.argv] for a trick which strips quotes off for you.
+       [argv][cmd2.parsing.Statement.argv] for a trick which strips quotes off for you.
     """
 
     # the arguments, but not the command, nor the output redirection clauses.
@@ -193,7 +193,7 @@ class Statement(str):  # noqa: SLOT000
 
     @property
     def expanded_command_line(self) -> str:
-        """Concatenate [command_and_args][cmd2.Statement.command_and_args] and [post_command][cmd2.Statement.post_command]."""
+        """Concatenate [cmd2.parsing.Statement.command_and_args]() and [cmd2.parsing.Statement.post_command]()."""
         return self.command_and_args + self.post_command
 
     @property

--- a/docs/features/generating_output.md
+++ b/docs/features/generating_output.md
@@ -71,7 +71,7 @@ def do_echo(self, args):
 
 When an error occurs in your program, you can display it on `sys.stderr` by calling the
 [perror][cmd2.Cmd.perror] method. By default this method applies
-[Cmd2Style.ERROR][cmd2.Cmd2Style.ERROR] to the output.
+[Cmd2Style.ERROR][cmd2.styles.Cmd2Style.ERROR] to the output.
 
 ## Warning Messages
 

--- a/docs/features/modular_commands.md
+++ b/docs/features/modular_commands.md
@@ -211,22 +211,23 @@ if __name__ == '__main__':
 The following functions are called at different points in the [CommandSet][cmd2.CommandSet] life
 cycle.
 
-[on_register][cmd2.CommandSet.on_register] - Called by `cmd2.Cmd` as the first step to registering a
-`CommandSet`. The commands defined in this class have not be added to the CLI object at this point.
-Subclasses can override this to perform any initialization requiring access to the Cmd object (e.g.
-configure commands and their parsers based on CLI state data).
+[on_register][cmd2.command_definition.CommandSet.on_register] - Called by `cmd2.Cmd` as the first
+step to registering a `CommandSet`. The commands defined in this class have not be added to the CLI
+object at this point. Subclasses can override this to perform any initialization requiring access to
+the Cmd object (e.g. configure commands and their parsers based on CLI state data).
 
-[on_registered][cmd2.CommandSet.on_registered] - Called by `cmd2.Cmd` after a `CommandSet` is
-registered and all its commands have been added to the CLI. Subclasses can override this to perform
-custom steps related to the newly added commands (e.g. setting them to a disabled state).
+[on_registered][cmd2.command_definition.CommandSet.on_registered] - Called by `cmd2.Cmd` after a
+`CommandSet` is registered and all its commands have been added to the CLI. Subclasses can override
+this to perform custom steps related to the newly added commands (e.g. setting them to a disabled
+state).
 
-[on_unregister][cmd2.CommandSet.on_unregister] - Called by `cmd2.Cmd` as the first step to
-unregistering a `CommandSet`. Subclasses can override this to perform any cleanup steps which
-require their commands being registered in the CLI.
+[on_unregister][cmd2.command_definition.CommandSet.on_unregister] - Called by `cmd2.Cmd` as the
+first step to unregistering a `CommandSet`. Subclasses can override this to perform any cleanup
+steps which require their commands being registered in the CLI.
 
-[on_unregistered][cmd2.CommandSet.on_unregistered] - Called by `cmd2.Cmd` after a `CommandSet` has
-been unregistered and all its commands removed from the CLI. Subclasses can override this to perform
-remaining cleanup steps.
+[on_unregistered][cmd2.command_definition.CommandSet.on_unregistered] - Called by `cmd2.Cmd` after a
+`CommandSet` has been unregistered and all its commands removed from the CLI. Subclasses can
+override this to perform remaining cleanup steps.
 
 ## Injecting Subcommands
 


### PR DESCRIPTION
`mkdocstrings-python` 2.0.0 was released and is stricter about warnings. This fixes some of the embedded documentation references which were not previouslyresolveable.