### PR TITLE
Address warning in GitHub Actions tests about deprecated action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           flags: python${{ matrix.python-version }}
           name: codecov-umbrella-test-results
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Address the following warning:

> Warning: This action is being deprecated in favor of 'codecov-action'.
      Please update CI accordingly to use 'codecov-action@v5' with
      'report_type: test_results'.
      The 'codecov-action' should and can be run at least once for
      coverage and once for test results