### PR TITLE
Fixed crash in Python 3.15.0a6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ prompt is displayed.
     - `cmd2.Cmd.select` has been revamped to use the
       [choice](https://python-prompt-toolkit.readthedocs.io/en/3.0.52/pages/asking_for_a_choice.html)
       function from `prompt-toolkit` when both **stdin** and **stdout** are TTYs
+    - Add support for Python 3.15 by fixing various bugs related to internal `argparse` changes
     - Added `common_prefix` method to `cmd2.string_utils` module as a replacement for
       `os.path.commonprefix` since that is now deprecated in Python 3.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ prompt is displayed.
     - `cmd2.Cmd.select` has been revamped to use the
       [choice](https://python-prompt-toolkit.readthedocs.io/en/3.0.52/pages/asking_for_a_choice.html)
       function from `prompt-toolkit` when both **stdin** and **stdout** are TTYs
+    - Added `common_prefix` method to `cmd2.string_utils` module as a replacement for
+      `os.path.commonprefix` since that is now deprecated in Python 3.15
 
 ## 3.4.0 (March 3, 2026)
 

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1036,7 +1036,11 @@ class Cmd2HelpFormatter(RichHelpFormatter):
         This override is needed because Python 3.15 added a 'file' keyword argument
         to _set_color() which some versions of RichHelpFormatter don't support.
         """
-        try:
+        # Argparse didn't add color support until 3.14
+        if sys.version_info < (3, 14):
+            return
+
+        try:  # type: ignore[unreachable]
             super()._set_color(color, **kwargs)
         except TypeError:
             # Fallback for older versions of RichHelpFormatter that don't support keyword arguments

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1030,6 +1030,18 @@ class Cmd2HelpFormatter(RichHelpFormatter):
         """Set our console instance."""
         self._console = console
 
+    def _set_color(self, color: bool, **kwargs: Any) -> None:
+        """Set the color for the help output.
+
+        This override is needed because Python 3.15 added a 'file' keyword argument
+        to _set_color() which some versions of RichHelpFormatter don't support.
+        """
+        try:
+            super()._set_color(color, **kwargs)
+        except TypeError:
+            # Fallback for older versions of RichHelpFormatter that don't support keyword arguments
+            super()._set_color(color)
+
     def _build_nargs_range_str(self, nargs_range: tuple[int, int | float]) -> str:
         """Generate nargs range string for help text."""
         if nargs_range[1] == constants.INFINITY:
@@ -1134,7 +1146,7 @@ class TextGroup:
         self,
         title: str,
         text: RenderableType,
-        formatter_creator: Callable[[], Cmd2HelpFormatter],
+        formatter_creator: Callable[..., Cmd2HelpFormatter],
     ) -> None:
         """TextGroup initializer.
 
@@ -1258,9 +1270,9 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
         self.exit(2, f'{formatted_message}\n')
 
-    def _get_formatter(self) -> Cmd2HelpFormatter:
+    def _get_formatter(self, **kwargs: Any) -> Cmd2HelpFormatter:
         """Override with customizations for Cmd2HelpFormatter."""
-        return cast(Cmd2HelpFormatter, super()._get_formatter())
+        return cast(Cmd2HelpFormatter, super()._get_formatter(**kwargs))
 
     def format_help(self) -> str:
         """Override to add a newline."""

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1921,7 +1921,7 @@ class Cmd:
         match_strings = basic_completions.to_strings()
 
         # Calculate what portion of the match we are completing
-        common_prefix = os.path.commonprefix(match_strings)
+        common_prefix = su.common_prefix(match_strings)
         prefix_tokens = common_prefix.split(delimiter)
         display_token_index = len(prefix_tokens) - 1
 

--- a/cmd2/string_utils.py
+++ b/cmd2/string_utils.py
@@ -5,6 +5,10 @@ These utilities are designed to correctly handle strings with ANSI style sequenc
 full-width characters (like those used in CJK languages).
 """
 
+from collections.abc import (
+    Sequence,
+)
+
 from rich.align import AlignMethod
 from rich.style import StyleType
 from rich.text import Text
@@ -167,3 +171,22 @@ def norm_fold(val: str) -> str:
     import unicodedata
 
     return unicodedata.normalize("NFC", val).casefold()
+
+
+def common_prefix(m: Sequence[str]) -> str:
+    """Return the longest common leading component of a list of strings.
+
+    This is a replacement for os.path.commonprefix which is deprecated in Python 3.15.
+
+    :param m: list of strings
+    :return: common prefix
+    """
+    if not m:
+        return ""
+
+    s1 = min(m)
+    s2 = max(m)
+    for i, c in enumerate(s1):
+        if i >= len(s2) or c != s2[i]:
+            return s1[:i]
+    return s1

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -353,3 +353,46 @@ def test_completion_items_as_choices(capsys) -> None:
     # Confirm error text contains correct value type of int
     _out, err = capsys.readouterr()
     assert 'invalid choice: 3 (choose from 1, 2)' in err
+
+
+def test_formatter_coverage(mocker) -> None:
+    import sys
+
+    from cmd2.argparse_custom import (
+        Cmd2HelpFormatter,
+        Cmd2RichArgparseConsole,
+    )
+
+    # Line 1031: self._console = console (inside console.setter)
+    formatter = Cmd2HelpFormatter(prog='test')
+    new_console = Cmd2RichArgparseConsole()
+    formatter.console = new_console
+    assert formatter._console is new_console
+
+    # Line 1041: return (inside _set_color if sys.version_info < (3, 14))
+    mocker.patch('cmd2.argparse_custom.sys.version_info', (3, 13, 0))
+    # This should return early without calling super()._set_color
+    mock_set_color = mocker.patch('rich_argparse.RichHelpFormatter._set_color')
+    formatter._set_color(True)
+    mock_set_color.assert_not_called()
+
+    # Line 1045 and 1047: except TypeError and super()._set_color(color)
+    mocker.patch('cmd2.argparse_custom.sys.version_info', (3, 15, 0))
+
+    # Reset mock and make it raise TypeError when called with kwargs
+    mock_set_color.reset_mock()
+
+    def side_effect(color, **kwargs):
+        if kwargs:
+            raise TypeError("unexpected keyword argument 'file'")
+        return
+
+    mock_set_color.side_effect = side_effect
+
+    # This call should trigger the TypeError and then the fallback call
+    formatter._set_color(True, file=sys.stdout)
+
+    # It should have been called twice: once with kwargs (failed) and once without (fallback)
+    assert mock_set_color.call_count == 2
+    mock_set_color.assert_any_call(True, file=sys.stdout)
+    mock_set_color.assert_any_call(True)

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -1,6 +1,7 @@
 """Unit/functional testing for argparse customizations in cmd2"""
 
 import argparse
+import sys
 
 import pytest
 
@@ -12,6 +13,8 @@ from cmd2 import (
 )
 from cmd2.argparse_custom import (
     ChoicesCallable,
+    Cmd2HelpFormatter,
+    Cmd2RichArgparseConsole,
     generate_range_error,
 )
 
@@ -355,28 +358,29 @@ def test_completion_items_as_choices(capsys) -> None:
     assert 'invalid choice: 3 (choose from 1, 2)' in err
 
 
-def test_formatter_coverage(mocker) -> None:
-    import sys
-
-    from cmd2.argparse_custom import (
-        Cmd2HelpFormatter,
-        Cmd2RichArgparseConsole,
-    )
-
-    # Line 1031: self._console = console (inside console.setter)
+def test_formatter_console() -> None:
+    # self._console = console (inside console.setter)
     formatter = Cmd2HelpFormatter(prog='test')
     new_console = Cmd2RichArgparseConsole()
     formatter.console = new_console
     assert formatter._console is new_console
 
-    # Line 1041: return (inside _set_color if sys.version_info < (3, 14))
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Argparse didn't support color until Python 3.14",
+)
+def test_formatter_set_color(mocker) -> None:
+    formatter = Cmd2HelpFormatter(prog='test')
+
+    # return (inside _set_color if sys.version_info < (3, 14))
     mocker.patch('cmd2.argparse_custom.sys.version_info', (3, 13, 0))
     # This should return early without calling super()._set_color
     mock_set_color = mocker.patch('rich_argparse.RichHelpFormatter._set_color')
     formatter._set_color(True)
     mock_set_color.assert_not_called()
 
-    # Line 1045 and 1047: except TypeError and super()._set_color(color)
+    # except TypeError and super()._set_color(color)
     mocker.patch('cmd2.argparse_custom.sys.version_info', (3, 15, 0))
 
     # Reset mock and make it raise TypeError when called with kwargs

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -246,3 +246,29 @@ def test_unicode_casefold() -> None:
     micro_cf = micro.casefold()
     assert micro != micro_cf
     assert su.norm_fold(micro) == su.norm_fold(micro_cf)
+
+
+def test_common_prefix() -> None:
+    # Empty list
+    assert su.common_prefix([]) == ""
+
+    # Single item
+    assert su.common_prefix(["abc"]) == "abc"
+
+    # Common prefix exists
+    assert su.common_prefix(["abcdef", "abcde", "abcd"]) == "abcd"
+
+    # No common prefix
+    assert su.common_prefix(["abc", "def"]) == ""
+
+    # One is a prefix of another
+    assert su.common_prefix(["apple", "app"]) == "app"
+
+    # Identical strings
+    assert su.common_prefix(["test", "test"]) == "test"
+
+    # Case sensitivity (matches os.path.commonprefix behavior)
+    assert su.common_prefix(["Apple", "apple"]) == ""
+
+    # Empty string in list
+    assert su.common_prefix(["abc", ""]) == ""


### PR DESCRIPTION
The crash was caused by changes in the `argparse` internal API in Python 3.15, specifically in how it handles colorization and formatter initialization.

Changes Made:

1. Add testing for Python `3.15-dev`: Start testing on Python 3.15 pre-release versions, currently 3.15.0a6

2. `Cmd2HelpFormatter._set_color`: Added an override for the _set_color method to handle the new file keyword argument introduced in Python 3.15. It uses a try-except block to fall back to the older signature if the underlying RichHelpFormatter (from rich-argparse) does not yet support the new keyword argument.

3. `Cmd2ArgumentParser._get_formatter`: Updated the _get_formatter method to accept **kwargs and pass them to the superclass. This is necessary because Python 3.15's argparse now passes a file argument to this method in several places (e.g., print_usage).

4. `TextGroup.__init__`: Updated the type hint for the formatter_creator parameter from Callable[[], Cmd2HelpFormatter] to Callable[..., Cmd2HelpFormatter] to remain consistent with the updated _get_formatter signature.

5. `string_utils.common_prefix` function added as a replacement for `os.path.commonprefix` which is deprecated in Python 3.15.

Closes #1603 