### PR TITLE
feat: Add Typer/Click support as alternative to argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ On all operating systems, the latest stable version of `cmd2` can be installed u
 pip install -U cmd2
 ```
 
+To enable Typer-based argument parsing, install the optional extra:
+
+```bash
+pip install -U cmd2[typer]
+```
+
 cmd2 works with Python 3.10+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party
 dependencies. It works with both conventional CPython and free-threaded variants.
 

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -38,6 +38,7 @@ from .decorators import (
     with_argparser,
     with_argument_list,
     with_category,
+    with_typer,
 )
 from .exceptions import (
     Cmd2ArgparseError,
@@ -84,6 +85,7 @@ __all__: list[str] = [  # noqa: RUF022
     'with_category',
     'with_default_category',
     'as_subcommand_to',
+    'with_typer',
     # Exceptions
     'Cmd2ArgparseError',
     'CommandSetRegistrationError',

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -204,6 +204,14 @@ from .utils import (
     suggest_similar,
 )
 
+try:
+    from .typer_custom import TyperParser
+except ImportError:
+
+    class TyperParser:  # type: ignore[no-redef]
+        """Sentinel: isinstance checks always return False when typer is not installed."""
+
+
 if TYPE_CHECKING:  # pragma: no cover
     StaticArgParseBuilder = staticmethod[[], argparse.ArgumentParser]
     ClassArgParseBuilder = classmethod['Cmd' | CommandSet, [], argparse.ArgumentParser]
@@ -229,6 +237,7 @@ class _CommandParsers:
     """Create and store all command method argument parsers for a given Cmd instance.
 
     Parser creation and retrieval are accomplished through the get() method.
+    Supports both argparse-based and Typer/Click-based commands.
     """
 
     def __init__(self, cmd: 'Cmd') -> None:
@@ -236,7 +245,8 @@ class _CommandParsers:
 
         # Keyed by the fully qualified method names. This is more reliable than
         # the methods themselves, since wrapping a method will change its address.
-        self._parsers: dict[str, argparse.ArgumentParser] = {}
+        # Values are argparse.ArgumentParser for argparse commands or TyperParser (click.Command) for Typer commands.
+        self._parsers: dict[str, argparse.ArgumentParser | TyperParser] = {}
 
     @staticmethod
     def _fully_qualified_name(command_method: CommandFunc) -> str:
@@ -250,15 +260,16 @@ class _CommandParsers:
         """Return whether a given method's parser is in self.
 
         If the parser does not yet exist, it will be created if applicable.
-        This is basically for checking if a method is argarse-based.
+        This is basically for checking if a method uses argparse or Typer.
         """
         parser = self.get(command_method)
         return bool(parser)
 
-    def get(self, command_method: CommandFunc) -> argparse.ArgumentParser | None:
-        """Return a given method's parser or None if the method is not argparse-based.
+    def get(self, command_method: CommandFunc) -> argparse.ArgumentParser | TyperParser | None:
+        """Return a given method's parser or None if the method is not parser-based.
 
         If the parser does not yet exist, it will be created.
+        Handles both argparse and Typer/Click commands.
         """
         full_method_name = self._fully_qualified_name(command_method)
         if not full_method_name:
@@ -268,6 +279,14 @@ class _CommandParsers:
             if not command_method.__name__.startswith(COMMAND_FUNC_PREFIX):
                 return None
             command = command_method.__name__[len(COMMAND_FUNC_PREFIX) :]
+
+            # Check for Typer command
+            if getattr(command_method, constants.CMD_ATTR_TYPER_FUNC, None) is not None:
+                from .typer_custom import build_typer_command
+
+                parent = self._cmd.find_commandset_for_command(command) or self._cmd
+                self._parsers[full_method_name] = build_typer_command(parent, command_method)
+                return self._parsers[full_method_name]
 
             parser_builder = getattr(command_method, constants.CMD_ATTR_ARGPARSER, None)
             if parser_builder is None:
@@ -1030,7 +1049,7 @@ class Cmd:
             # is the actual command since command synonyms don't own it.
             if cmd_func_name == command_method.__name__:
                 command_parser = self._command_parsers.get(command_method)
-                if command_parser is not None:
+                if isinstance(command_parser, argparse.ArgumentParser):
                     check_parser_uninstallable(command_parser)
 
     def _register_subcommands(self, cmdset: Union[CommandSet, 'Cmd']) -> None:
@@ -1075,7 +1094,7 @@ class Cmd:
             if command_func is None:
                 raise CommandSetRegistrationError(f"Could not find command '{command_name}' needed by subcommand: {method}")
             command_parser = self._command_parsers.get(command_func)
-            if command_parser is None:
+            if not isinstance(command_parser, argparse.ArgumentParser):
                 raise CommandSetRegistrationError(
                     f"Could not find argparser for command '{command_name}' needed by subcommand: {method}"
                 )
@@ -1161,7 +1180,7 @@ class Cmd:
                 # but keeping in case it does for some strange reason
                 raise CommandSetRegistrationError(f"Could not find command '{command_name}' needed by subcommand: {method}")
             command_parser = self._command_parsers.get(command_func)
-            if command_parser is None:  # pragma: no cover
+            if not isinstance(command_parser, argparse.ArgumentParser):  # pragma: no cover
                 # This really shouldn't be possible since _register_subcommands would prevent this from happening
                 # but keeping in case it does for some strange reason
                 raise CommandSetRegistrationError(
@@ -2333,11 +2352,11 @@ class Cmd:
                 if func_attr is not None:
                     completer_func = func_attr
                 else:
-                    # There's no completer function, next see if the command uses argparse
+                    # There's no completer function, next see if the command uses a parser
                     func = self.cmd_func(command)
                     argparser = None if func is None else self._command_parsers.get(func)
 
-                    if func is not None and argparser is not None:
+                    if func is not None and isinstance(argparser, argparse.ArgumentParser):
                         # Get arguments for complete()
                         preserve_quotes = getattr(func, constants.CMD_ATTR_PRESERVE_QUOTES)
                         cmd_set = self.find_commandset_for_command(command)
@@ -2348,6 +2367,16 @@ class Cmd:
 
                         completer_func = functools.partial(
                             completer.complete, tokens=raw_tokens[1:] if preserve_quotes else tokens[1:], cmd_set=cmd_set
+                        )
+                    elif func is not None and isinstance(argparser, TyperParser):
+                        from .typer_custom import typer_complete
+
+                        preserve_quotes = getattr(func, constants.CMD_ATTR_PRESERVE_QUOTES)
+                        completer_func = functools.partial(
+                            typer_complete,
+                            self,
+                            command_func=func,
+                            args=raw_tokens[1:] if preserve_quotes else tokens[1:],
                         )
                     else:
                         completer_func = self.completedefault  # type: ignore[assignment]
@@ -4097,11 +4126,30 @@ class Cmd:
             return Completions()
 
         # Check if this command uses argparse
-        if (func := self.cmd_func(command)) is None or (argparser := self._command_parsers.get(func)) is None:
+        func = self.cmd_func(command)
+        if func is None:
             return Completions()
 
-        completer = argparse_completer.DEFAULT_AP_COMPLETER(argparser, self)
-        return completer.complete_subcommand_help(text, line, begidx, endidx, arg_tokens['subcommands'])
+        argparser = self._command_parsers.get(func)
+        if isinstance(argparser, argparse.ArgumentParser):
+            completer = argparse_completer.DEFAULT_AP_COMPLETER(argparser, self)
+            return completer.complete_subcommand_help(text, line, begidx, endidx, arg_tokens['subcommands'])
+
+        # Typer/Click subcommand help completion
+        if isinstance(argparser, TyperParser):
+            from .typer_custom import typer_complete_subcommand_help
+
+            return typer_complete_subcommand_help(
+                self,
+                text,
+                line,
+                begidx,
+                endidx,
+                command_func=func,
+                subcommands=arg_tokens['subcommands'],
+            )
+
+        return Completions()
 
     def _build_command_info(self) -> tuple[dict[str, list[str]], list[str], list[str], list[str]]:
         """Categorizes and sorts visible commands and help topics for display.
@@ -4211,10 +4259,21 @@ class Cmd:
             argparser = None if func is None else self._command_parsers.get(func)
 
             # If the command function uses argparse, then use argparse's help
-            if func is not None and argparser is not None:
+            if func is not None and isinstance(argparser, argparse.ArgumentParser):
                 completer = argparse_completer.DEFAULT_AP_COMPLETER(argparser, self)
                 completer.print_help(args.subcommands, self.stdout)
+            # If the command function uses Typer, then use Click's help
+            elif func is not None and isinstance(argparser, TyperParser):
+                from .typer_custom import resolve_typer_subcommand
 
+                try:
+                    target_command, resolved_names = resolve_typer_subcommand(argparser, args.subcommands)
+                except KeyError:
+                    target_command, resolved_names = argparser, []
+                info_name = ' '.join([args.command, *resolved_names])
+                ctx = target_command.make_context(info_name, [], resilient_parsing=True)
+                with contextlib.redirect_stdout(self.stdout):
+                    target_command.get_help(ctx)
             # If the command has a custom help function, then call it
             elif help_func is not None:
                 help_func()

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -38,6 +38,12 @@ CLASS_ATTR_DEFAULT_HELP_CATEGORY = 'cmd2_default_help_category'
 # The argparse parser for the command
 CMD_ATTR_ARGPARSER = 'argparser'
 
+# The typer app for the command (or None if auto-built from function signature)
+CMD_ATTR_TYPER = 'typer'
+CMD_ATTR_TYPER_FUNC = 'typer_func'
+CMD_ATTR_TYPER_KWARGS = 'typer_kwargs'
+CMD_ATTR_TYPER_CONTEXT_SETTINGS = 'typer_context_settings'
+
 # Whether or not tokens are unquoted before sending to argparse
 CMD_ATTR_PRESERVE_QUOTES = 'preserve_quotes'
 

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -1,6 +1,8 @@
 """Decorators for ``cmd2`` commands."""
 
 import argparse
+import inspect
+import sys
 from collections.abc import (
     Callable,
     Sequence,
@@ -295,9 +297,9 @@ def with_argparser(
 
             # Pass cmd_wrapper instead of func, since it contains the parser info.
             arg_parser = cmd2_app._command_parsers.get(cmd_wrapper)
-            if arg_parser is None:
+            if not isinstance(arg_parser, argparse.ArgumentParser):
                 # This shouldn't be possible to reach
-                raise ValueError(f'No argument parser found for {command_name}')  # pragma: no cover
+                raise TypeError(f'No argument parser found for {command_name}')  # pragma: no cover
 
             if ns_provider is None:
                 namespace = None
@@ -341,6 +343,120 @@ def with_argparser(
 
         return cmd_wrapper
 
+    return arg_decorator
+
+
+def with_typer(
+    func_arg: CommandFunc | Any | None = None,
+    *,
+    preserve_quotes: bool = False,
+    context_settings: dict[str, Any] | None = None,
+) -> RawCommandFuncOptionalBoolReturn[CmdOrSet] | Callable[[CommandFunc], RawCommandFuncOptionalBoolReturn[CmdOrSet]]:
+    """Decorate a ``do_*`` method to process its arguments using Typer/Click.
+
+    :param func_arg: Single-element positional argument list containing ``do_*`` method
+                     this decorator is wrapping, or an explicit Typer app
+    :param preserve_quotes: if ``True``, then argument quotes will not be stripped
+    :param context_settings: optional dict of Click context settings passed to Typer
+    :return: function that gets passed Typer-parsed arguments
+
+    Example:
+    ```py
+    class MyApp(cmd2.Cmd):
+        @cmd2.with_typer
+        def do_add(
+            self,
+            a: int,
+            b: Annotated[int, typer.Option("--b")] = 2,
+        ) -> None:
+            self.poutput(str(a + b))
+    ```
+
+    """
+    import functools
+
+    try:
+        import typer
+    except ModuleNotFoundError as exc:
+        raise ImportError("Typer support requires the 'typer' package. Install it with: pip install cmd2[typer]") from exc
+
+    explicit_app = None
+    if isinstance(func_arg, typer.Typer):
+        explicit_app = func_arg
+
+    def arg_decorator(func: CommandFunc) -> RawCommandFuncOptionalBoolReturn[CmdOrSet]:
+        """Decorate function that ingests a command function and returns a raw command function.
+
+        The returned function will process the raw input through Typer/Click to be passed to the wrapped function.
+
+        :param func: The defined Typer command function
+        :return: Function that takes raw input and converts to Typer-parsed arguments passed to the wrapped function.
+        """
+
+        @functools.wraps(func)
+        def cmd_wrapper(*args: Any, **kwargs: dict[str, Any]) -> bool | None:
+            """Command function wrapper which translates command line into Typer-parsed arguments and command function.
+
+            :param args: All positional arguments to this function.  We're expecting there to be:
+                            cmd2_app, statement: Union[Statement, str]
+                            contiguously somewhere in the list
+            :param kwargs: any keyword arguments being passed to command function
+            :return: return value of command function
+            :raises Cmd2ArgparseError: if Typer/Click has error parsing command line
+            """
+            cmd2_app, statement_arg = _parse_positionals(args)
+            _, parsed_arglist = cmd2_app.statement_parser.get_command_arg_list(command_name, statement_arg, preserve_quotes)
+
+            # Pass cmd_wrapper instead of func, since it contains the typer attribute info.
+            import click
+
+            parser = cmd2_app._command_parsers.get(cmd_wrapper)
+            if not isinstance(parser, click.Command):
+                raise TypeError(f'No Typer command found for {command_name}')  # pragma: no cover
+
+            try:
+                setattr(cmd_wrapper, constants.CMD_ATTR_TYPER_KWARGS, dict(kwargs))
+                result = parser.main(
+                    args=parsed_arglist,
+                    prog_name=command_name,
+                    standalone_mode=False,
+                )
+            except Exception as exc:
+                if isinstance(exc, click.ClickException):
+                    exc.show(file=sys.stderr)
+                    raise Cmd2ArgparseError from exc
+                if isinstance(exc, (click.exceptions.Exit, SystemExit)):
+                    raise Cmd2ArgparseError from exc
+                raise
+            finally:
+                if hasattr(cmd_wrapper, constants.CMD_ATTR_TYPER_KWARGS):
+                    delattr(cmd_wrapper, constants.CMD_ATTR_TYPER_KWARGS)
+
+            # clicks command return Any type
+            return result  # type: ignore[no-any-return]
+
+        command_name = func.__name__[len(constants.COMMAND_FUNC_PREFIX) :]
+
+        # Typer relies on signature + annotations to build its CLI; strip self.
+        sig = inspect.signature(func)
+        params = list(sig.parameters.values())
+        if params and params[0].name == "self":
+            params = params[1:]
+            cmd_wrapper.__signature__ = sig.replace(parameters=params)  # type: ignore[attr-defined]
+            annotations = dict(getattr(func, "__annotations__", {}))
+            annotations.pop("self", None)
+            cmd_wrapper.__annotations__ = annotations
+
+        # Set some custom attributes for this command
+        setattr(cmd_wrapper, constants.CMD_ATTR_TYPER, explicit_app)
+        setattr(cmd_wrapper, constants.CMD_ATTR_TYPER_FUNC, func)
+        setattr(cmd_wrapper, constants.CMD_ATTR_TYPER_CONTEXT_SETTINGS, context_settings)
+        setattr(cmd_wrapper, constants.CMD_ATTR_PRESERVE_QUOTES, preserve_quotes)
+
+        return cmd_wrapper
+
+    if explicit_app is None and callable(func_arg):
+        return arg_decorator(func_arg)
     return arg_decorator
 
 

--- a/cmd2/typer_custom.py
+++ b/cmd2/typer_custom.py
@@ -1,0 +1,319 @@
+"""Module provides Typer/Click-based command parsing support for cmd2.
+
+This is the Typer equivalent of argparse_custom.py. It contains all
+Typer-specific logic for building Click commands, completing arguments,
+and resolving subcommands for help output.
+
+Typer support is optional and requires the ``typer`` package to be installed.
+Install it via ``pip install cmd2[typer]``.
+"""
+
+import copy
+import inspect
+from collections.abc import Callable, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeAlias,
+    get_type_hints,
+)
+
+import click
+
+from . import constants
+from .completion import (
+    CompletionItem,
+    Completions,
+)
+from .constants import COMMAND_FUNC_PREFIX
+from .types import CmdOrSet
+
+if TYPE_CHECKING:  # pragma: no cover
+    import typer
+
+    from .cmd2 import Cmd
+    from .command_definition import CommandFunc
+
+#: Type alias for the Click Command objects produced by the Typer integration.
+#: All Typer commands are converted to Click Commands via :func:`build_typer_command`.
+TyperParser: TypeAlias = click.Command
+
+
+def build_typer_callback(
+    target_func: Callable[..., Any],
+    parent: CmdOrSet,
+    command_method: 'CommandFunc',
+) -> Callable[..., Any]:
+    """Build a Click-compatible callback from a Typer-decorated command function.
+
+    Resolves type hints (including ``Annotated``) and strips the ``self``
+    parameter so Click/Typer can introspect the signature correctly.
+
+    :param target_func: the original command function to wrap
+    :param parent: object which owns the command (Cmd or CommandSet instance)
+    :param command_method: the decorated command method (used for extra kwargs)
+    :return: callback function with resolved type hints and bound self
+    """
+    sig = inspect.signature(target_func)
+    resolved_hints = get_type_hints(target_func, include_extras=True)
+    params = list(sig.parameters.values())
+    has_self = params and params[0].name == "self"
+    if has_self:
+        params = params[1:]
+
+    callback_params = [param.replace(annotation=resolved_hints.get(param.name, param.annotation)) for param in params]
+    callback_sig = sig.replace(
+        parameters=callback_params,
+        return_annotation=resolved_hints.get('return', sig.return_annotation),
+    )
+
+    def callback(*args: Any, **kwargs: Any) -> Any:
+        # Merge in kwargs passed programmatically (e.g. do_method(..., key=val))
+        # so they take effect even when Click doesn't see them on the command line.
+        extra_kwargs = getattr(command_method, constants.CMD_ATTR_TYPER_KWARGS, {})
+        merged_kwargs = dict(kwargs)
+        for key, value in extra_kwargs.items():
+            if key not in merged_kwargs or merged_kwargs[key] is None:
+                merged_kwargs[key] = value
+        if has_self:
+            return target_func(parent, *args, **merged_kwargs)
+        return target_func(*args, **merged_kwargs)
+
+    callback.__name__ = target_func.__name__
+    callback.__doc__ = target_func.__doc__
+    callback.__annotations__ = dict(resolved_hints)
+    callback.__annotations__.pop("self", None)
+    callback.__signature__ = callback_sig  # type: ignore[attr-defined]
+    return callback
+
+
+def bind_typer_app(app: 'typer.Typer', parent: CmdOrSet, command_method: 'CommandFunc') -> 'typer.Typer':
+    """Deep copy a Typer app and bind all callbacks to the given parent instance.
+
+    Recursively walks through all registered commands and groups in the app,
+    wrapping each callback with :func:`build_typer_callback` so that ``self``
+    is correctly bound.
+
+    :param app: the Typer app to bind
+    :param parent: object which owns the command (Cmd or CommandSet instance)
+    :param command_method: the decorated command method
+    :return: deep copy of the app with bound callbacks
+    """
+    bound_app = copy.deepcopy(app)
+
+    def _bind_group(group: 'typer.Typer') -> None:
+        if group.registered_callback is not None and callable(group.registered_callback.callback):
+            group.registered_callback.callback = build_typer_callback(
+                group.registered_callback.callback,
+                parent,
+                command_method,
+            )
+
+        for command_info in group.registered_commands:
+            if command_info.callback is not None:
+                command_info.callback = build_typer_callback(command_info.callback, parent, command_method)
+
+        for group_info in group.registered_groups:
+            if callable(group_info.callback):
+                group_info.callback = build_typer_callback(group_info.callback, parent, command_method)
+            if group_info.typer_instance is not None:
+                _bind_group(group_info.typer_instance)
+
+    _bind_group(bound_app)
+    return bound_app
+
+
+#: Options to strip from Click commands in a REPL context.
+#: --help is handled by cmd2's built-in help, and completion options
+#: are handled by prompt_toolkit / readline.
+_REPL_STRIP_NAMES = frozenset(('help', 'install_completion', 'show_completion'))
+
+
+def _strip_repl_options(command: click.Command) -> None:
+    """Remove ``--help``, ``--install-completion``, and ``--show-completion`` from a Click command tree.
+
+    These options are intended for standalone CLI tools. In a cmd2 REPL,
+    help is provided by the built-in ``help`` command and shell completion
+    is handled by prompt_toolkit / readline, so these options are unnecessary clutter.
+
+    Mutates the command (and any subcommands) in place.
+    """
+    command.params = [p for p in command.params if p.name not in _REPL_STRIP_NAMES]
+    # Prevent Click from re-adding --help
+    if hasattr(command, 'add_help_option'):
+        command.add_help_option = False
+
+    # Recurse into subcommands for Groups
+    sub_commands: dict[str, click.Command] | None = getattr(command, 'commands', None)
+    if sub_commands is not None:
+        for sub_cmd in sub_commands.values():
+            _strip_repl_options(sub_cmd)
+
+
+def build_typer_command(
+    parent: CmdOrSet,
+    command_method: 'CommandFunc',
+) -> TyperParser:
+    """Build a Typer/Click command for a command method.
+
+    This is the Typer equivalent of :meth:`Cmd._build_parser`. It creates a
+    Click ``Command`` object from the attributes set by the ``@with_typer``
+    decorator on the command method.
+
+    :param parent: object which owns the command (Cmd or CommandSet instance)
+    :param command_method: the decorated command method
+    :return: Click Command object
+    :raises ImportError: if typer is not installed
+    """
+    try:
+        import typer
+    except ModuleNotFoundError as exc:
+        raise ImportError("Typer support requires 'cmd2[typer]' to be installed") from exc
+
+    # CMD_ATTR_TYPER stores the explicit Typer app, or None for auto-build
+    explicit_app = getattr(command_method, constants.CMD_ATTR_TYPER, None)
+
+    if explicit_app is not None:
+        bound_app = bind_typer_app(explicit_app, parent, command_method)
+        bound_app._add_completion = False
+        click_command = typer.main.get_command(bound_app)
+    else:
+        target_func = getattr(command_method, constants.CMD_ATTR_TYPER_FUNC, command_method)
+        callback = build_typer_callback(target_func, parent, command_method)
+        context_settings = getattr(command_method, constants.CMD_ATTR_TYPER_CONTEXT_SETTINGS, None)
+        app = typer.Typer(add_completion=False, context_settings=context_settings)
+        command_name = command_method.__name__[len(COMMAND_FUNC_PREFIX) :]
+        app.command(name=command_name)(callback)
+        click_command = typer.main.get_command(app)
+
+    # Strip --help, --install-completion, --show-completion from the command tree.
+    # In a REPL, help is provided by cmd2's built-in ``help`` command and shell
+    # completion is handled by prompt_toolkit / readline.
+    _strip_repl_options(click_command)
+    return click_command
+
+
+def typer_complete(
+    cmd: 'Cmd',
+    text: str,
+    _line: str,
+    _begidx: int,
+    _endidx: int,
+    *,
+    command_func: 'CommandFunc',
+    args: Sequence[str],
+) -> Completions:
+    """Complete values for Typer/Click-based commands.
+
+    This is the Typer equivalent of :class:`ArgparseCompleter.complete`.
+    It delegates to Click's shell completion machinery to generate
+    completion candidates.
+
+    The signature matches the ``CompleterBound`` protocol so it can be used
+    with ``functools.partial`` the same way the argparse completer is.
+
+    :param cmd: the Cmd instance (used for error formatting and parser cache)
+    :param text: the string prefix we are attempting to match
+    :param _line: the current input line (unused, for signature compatibility)
+    :param _begidx: beginning index of text (unused, for signature compatibility)
+    :param _endidx: ending index of text (unused, for signature compatibility)
+    :param command_func: the command function being completed
+    :param args: parsed argument tokens so far
+    :return: a Completions object
+    """
+    from click.shell_completion import CompletionItem as ClickCompletionItem
+    from click.shell_completion import ShellComplete
+
+    try:
+        parser = cmd._command_parsers.get(command_func)
+        if not isinstance(parser, click.Command):
+            return Completions()
+        args_list = list(args)
+        remaining_args = args_list[:-1] if args_list else []
+        completer = ShellComplete(parser, {}, parser.name or "", "")
+        results = completer.get_completions(remaining_args, text)
+        items = [
+            CompletionItem(
+                value=item.value,
+                display=item.value,
+                display_meta=item.help or "",
+            )
+            if isinstance(item, ClickCompletionItem)
+            else CompletionItem(value=item)
+            for item in results
+        ]
+        return Completions(items=items)
+    except Exception as exc:  # noqa: BLE001
+        return Completions(error=cmd.format_exception(exc))
+
+
+def resolve_typer_subcommand(command: TyperParser, subcommands: Sequence[str]) -> tuple[TyperParser, list[str]]:
+    """Resolve nested Click subcommands for Typer-backed help paths.
+
+    :param command: the top-level Click Command or Group
+    :param subcommands: sequence of subcommand names to resolve
+    :return: tuple of (resolved command, list of resolved names)
+    :raises KeyError: if a subcommand is not found
+    """
+    current = command
+    resolved_names: list[str] = []
+    for subcommand in subcommands:
+        commands = getattr(current, 'commands', None)
+        if commands is None or subcommand not in commands:
+            raise KeyError(subcommand)
+        current = commands[subcommand]
+        resolved_names.append(current.name or subcommand)
+    return current, resolved_names
+
+
+def typer_complete_subcommand_help(
+    cmd: 'Cmd',
+    text: str,
+    _line: str,
+    _begidx: int,
+    _endidx: int,
+    *,
+    command_func: 'CommandFunc',
+    subcommands: Sequence[str],
+) -> Completions:
+    """Complete subcommand names for Typer/Click-based help paths.
+
+    This is the Typer equivalent of
+    :meth:`ArgparseCompleter.complete_subcommand_help`. It walks the Click
+    command tree using already-resolved subcommand tokens and returns
+    available child subcommand names for the current level.
+
+    :param cmd: the Cmd instance (used for parser cache and error formatting)
+    :param text: the string prefix we are attempting to match
+    :param _line: the current input line (unused, for signature compatibility)
+    :param _begidx: beginning index of text (unused, for signature compatibility)
+    :param _endidx: ending index of text (unused, for signature compatibility)
+    :param command_func: the command function being completed
+    :param subcommands: subcommand tokens already entered
+    :return: a Completions object with matching subcommand names
+    """
+    parser = cmd._command_parsers.get(command_func)
+    if not isinstance(parser, click.Command):
+        return Completions()
+
+    # Resolve already-entered subcommands to find the current group
+    try:
+        current, _ = resolve_typer_subcommand(parser, subcommands)
+    except KeyError:
+        return Completions()
+
+    # List available subcommands at this level
+    commands = getattr(current, 'commands', None)
+    if commands is None:
+        return Completions()
+
+    items = [
+        CompletionItem(
+            value=name,
+            display=name,
+            display_meta=sub_cmd.get_short_help_str() if hasattr(sub_cmd, 'get_short_help_str') else "",
+        )
+        for name, sub_cmd in commands.items()
+        if name.startswith(text)
+    ]
+    return Completions(items=items)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -3,6 +3,7 @@
 <div class="grid cards" markdown>
 <!--intro-start-->
 - [Argument Processing](argument_processing.md)
+- [Typer Support](typer.md)
 - [Async Commands](async_commands.md)
 - [Builtin Commands](builtin_commands.md)
 - [Clipboard Integration](clipboard.md)

--- a/docs/features/typer.md
+++ b/docs/features/typer.md
@@ -1,0 +1,188 @@
+# Typer Support
+
+cmd2 can optionally use [Typer](https://typer.tiangolo.com/) (built on
+[Click](https://click.palletsprojects.com/)) to parse command arguments from type annotations
+instead of `argparse`. This is an alternative to [@with_argparser][cmd2.with_argparser] for
+developers who prefer annotation-driven CLI definitions.
+
+## Installation
+
+```bash
+pip install -U cmd2[typer]
+```
+
+## Basic Usage
+
+Use the `@cmd2.with_typer` decorator and type annotations to define arguments.
+
+```py
+from typing import Annotated
+import typer
+import cmd2
+
+
+class App(cmd2.Cmd):
+    @cmd2.with_typer
+    def do_greet(
+        self,
+        name: Annotated[str, typer.Argument(help="Name to greet")],
+        times: Annotated[int, typer.Option("--times", min=1, help="Number of greetings")] = 1,
+    ) -> None:
+        for _ in range(times):
+            self.poutput(f"Hello, {name}")
+```
+
+cmd2 inspects the decorated method, builds a Typer command from its signature, and uses that command
+for parsing, help, and tab completion. The `self` parameter is handled automatically.
+
+### `preserve_quotes`
+
+By default, cmd2 strips quotes from user input before passing it to the parser. If your command
+needs to receive the raw quoted strings, pass `preserve_quotes=True`.
+
+```py
+@cmd2.with_typer(preserve_quotes=True)
+def do_raw(self, text: Annotated[str, typer.Argument()]) -> None:
+    self.poutput(text)  # input: raw "hello" -> output: "hello"
+```
+
+This behaves the same as `preserve_quotes` on `@with_argparser`.
+
+### Error Handling
+
+Parse errors from Typer/Click are caught and displayed to the user without exiting the REPL. For
+example, if a required argument is missing, the user sees the Click error message and remains at the
+prompt.
+
+## Subcommands
+
+For commands with subcommands, build a `typer.Typer()` app and pass it to `@cmd2.with_typer(...)`.
+
+```py
+from typing import Annotated
+import typer
+import cmd2
+
+
+class AdminCommands(cmd2.CommandSet):
+    base_command = typer.Typer(help="Base command help")
+    users_command = typer.Typer(help="User management commands")
+
+    @base_command.command("show")
+    def base_show(
+        self,
+        verbose: Annotated[bool, typer.Option("--verbose")] = False,
+    ) -> None:
+        self._cmd.poutput(f"verbose={verbose}")
+
+    @users_command.command("add")
+    def users_add(
+        self,
+        name: Annotated[str, typer.Argument(help="User name")],
+        admin: Annotated[bool, typer.Option("--admin")] = False,
+    ) -> None:
+        self._cmd.poutput(f"added {name}, admin={admin}")
+
+    base_command.add_typer(users_command, name="users")
+
+    @cmd2.with_typer(base_command)
+    def do_manage(self) -> None:
+        """Entry point for the Typer app."""
+        pass
+```
+
+That produces a cmd2 command tree like this:
+
+- `manage show --verbose`
+- `manage users add alice --admin`
+
+!!! note
+
+    This example uses a [CommandSet][cmd2.CommandSet], which is cmd2's mechanism for organizing
+    commands into reusable groups (see [Modular Commands](modular_commands.md)). Inside a
+    `CommandSet`, use `self._cmd` to access the `Cmd` instance (e.g. `self._cmd.poutput()`).
+    You can also define Typer commands directly on a `Cmd` subclass, where `self` is the
+    `Cmd` instance and you call `self.poutput()` directly.
+
+### What `add_typer()` Does
+
+This line:
+
+```py
+base_app.add_typer(users_app, name="users")
+```
+
+mounts one Typer app under another. In this case:
+
+- `base_app` is the root command tree for `manage`
+- `users_app` becomes a nested subcommand group named `users`
+
+That is why `add` is invoked through `users` instead of directly under `manage`:
+
+- `@base_app.command("show")` becomes `manage show`
+- `@users_app.command("add")` becomes `manage users add`
+
+Without `add_typer()`, the nested Typer app is not attached to the command tree and its commands are
+not reachable from cmd2.
+
+### How It Works
+
+There are two supported patterns:
+
+- **`@cmd2.with_typer`** (no arguments) cmd2 creates a one-command Typer app from the method
+  signature. Use this for simple commands.
+- **`@cmd2.with_typer(existing_typer_app)`** (explicit Typer app) cmd2 uses the Typer app you built.
+  Use this when you need subcommands or want explicit control over the Typer command tree.
+
+For explicit Typer apps, the decorated `do_*` method is only the cmd2 entry point. The real command
+handlers are the callbacks registered on the Typer app. Those callbacks can live on either a `Cmd`
+or a `CommandSet`, but they should still take `self` as their first argument so cmd2 can bind them
+to the active instance at runtime.
+
+### Running the Base Command
+
+When you pass an explicit Typer app to `@cmd2.with_typer(...)`, the cmd2 `do_*` method provides the
+command name, but Typer controls what happens after that.
+
+For the example above:
+
+- `manage show` runs the `show` command
+- `manage users add alice` runs the nested `add` command inside the `users` group
+- `manage` (with no subcommand) shows help or usage information by default
+
+If you want bare `manage` to perform some action, define a callback on the Typer app itself. If you
+want it to act only as a container for subcommands, leave the root without business logic and let
+Typer show help or usage text.
+
+### Help and Completion
+
+Subcommands integrate with cmd2 help and completion:
+
+- `help manage` shows the top-level Typer help
+- `help manage users add` shows nested subcommand help
+- Tab completion works for subcommand names, options, and Typer `autocompletion` callbacks
+
+## When To Use Typer vs argparse
+
+**Use Typer** when:
+
+- you want type-annotation-driven parsing
+- you already have Typer models or Click-style completion callbacks
+- you want to define nested subcommands with a Typer app
+
+**Use `argparse`** (`@with_argparser`) when:
+
+- you need cmd2 features that are specific to `with_argparser`, such as `ns_provider` or
+  `with_unknown_args`
+- your application already has substantial argparse parser customizations
+- you want `cmd2`'s rich-argparse help formatting (Typer uses Click's own help formatter)
+
+## Notes
+
+- `help <command>` uses Click's help output for Typer-based commands, not argparse help.
+- Parse errors use Click's error formatting and are caught so they do not exit the REPL.
+- Completion for Typer-based commands is provided by Click's `shell_complete` API.
+- Typer support is optional and requires installing the `typer` extra.
+
+See the [typer_example](https://github.com/python-cmd2/cmd2/blob/main/examples/typer_example.py) for
+a working application that demonstrates all of these features.

--- a/examples/typer_example.py
+++ b/examples/typer_example.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""A small example demonstrating Typer integration with cmd2.
+
+Shows how to use ``@cmd2.with_typer`` to define commands with
+type-safe arguments, options, and tab completion — all powered
+by Typer/Click instead of argparse.
+
+Requires the ``typer`` extra::
+
+    pip install cmd2[typer]
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated
+
+import typer
+
+import cmd2
+
+# ---------------------------------------------------------------------------
+# Enums for built-in choice completion
+# ---------------------------------------------------------------------------
+
+
+class Color(str, Enum):
+    """Typer auto-completes enum members as choices."""
+
+    red = "red"
+    green = "green"
+    blue = "blue"
+    yellow = "yellow"
+
+
+class Priority(str, Enum):
+    """Priority levels for tasks."""
+
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+# ---------------------------------------------------------------------------
+# Custom autocompletion callback
+# ---------------------------------------------------------------------------
+
+TEAM_MEMBERS = ["Alice", "Bob", "Charlie", "Diana", "Eve"]
+
+
+def _member_complete(incomplete: str) -> list[str]:
+    """Custom completer — returns matching team member names."""
+    return [m for m in TEAM_MEMBERS if m.lower().startswith(incomplete.lower())]
+
+
+# ---------------------------------------------------------------------------
+# Application — all features in one class
+# ---------------------------------------------------------------------------
+
+
+class TyperExampleApp(cmd2.Cmd):
+    """A cmd2 application showcasing every Typer integration feature."""
+
+    intro = "Welcome! Type 'help' to list commands. Try tab-completion!\n"
+    prompt = "typer-demo> "
+
+    # 1. Simple positional argument + option with default
+    @cmd2.with_typer
+    def do_greet(
+        self,
+        name: Annotated[str, typer.Argument(help="Person to greet")],
+        greeting: Annotated[str, typer.Option("--greeting", "-g", help="Greeting word")] = "Hello",
+        shout: Annotated[bool, typer.Option("--shout", help="SHOUT the greeting")] = False,
+    ) -> None:
+        """Greet someone by name.
+
+        Examples:
+            greet World
+            greet Alice --greeting Hi --shout
+        """
+        msg = f"{greeting}, {name}!"
+        self.poutput(msg.upper() if shout else msg)
+
+    # 2. Enum-based choices — Typer auto-generates completions from members
+    @cmd2.with_typer
+    def do_paint(
+        self,
+        item: Annotated[str, typer.Argument(help="What to paint")],
+        color: Annotated[Color, typer.Option("--color", "-c", help="Color to use")] = Color.blue,
+    ) -> None:
+        """Paint an item with a color (tab-complete the --color values!).
+
+        Examples:
+            paint wall --color red
+            paint fence
+        """
+        self.poutput(f"Painting {item} {color.value}.")
+
+    # 3. Custom autocompletion callback
+    @cmd2.with_typer
+    def do_assign(
+        self,
+        task: Annotated[str, typer.Argument(help="Task description")],
+        member: Annotated[
+            str,
+            typer.Option("--to", help="Team member to assign to", autocompletion=_member_complete),
+        ] = "unassigned",
+    ) -> None:
+        """Assign a task to a team member (tab-complete the --to values!).
+
+        Examples:
+            assign "Fix login bug" --to Alice
+            assign "Write docs"
+        """
+        self.poutput(f"Assigned '{task}' to {member}.")
+
+    # 4. Variadic list argument
+    @cmd2.with_typer
+    def do_sum(
+        self,
+        numbers: Annotated[list[float], typer.Argument(help="Numbers to add up")],
+    ) -> None:
+        """Sum a list of numbers.
+
+        Examples:
+            sum 1 2 3
+            sum 10.5 20.3
+        """
+        self.poutput(f"{' + '.join(str(n) for n in numbers)} = {sum(numbers)}")
+
+    # 5. preserve_quotes — raw string handling
+    @cmd2.with_typer(preserve_quotes=True)
+    def do_raw(
+        self,
+        text: Annotated[str, typer.Argument(help="Text echoed verbatim (quotes preserved)")],
+    ) -> None:
+        """Echo text exactly as typed, preserving quotes.
+
+        Examples:
+            raw "hello world"
+            raw 'single quotes'
+        """
+        self.poutput(f"raw: {text}")
+
+    # 6. Subcommands via an explicit Typer app
+    project_app = typer.Typer(help="Manage projects and tasks")
+    task_app = typer.Typer(help="Manage tasks within a project")
+
+    @project_app.command("list")
+    def _project_list(self) -> None:
+        """List all projects."""
+        self.poutput("  1. Website Redesign")
+        self.poutput("  2. Mobile App")
+        self.poutput("  3. API Gateway")
+
+    @project_app.command("create")
+    def _project_create(
+        self,
+        name: Annotated[str, typer.Argument(help="Project name")],
+        priority: Annotated[Priority, typer.Option("--priority", "-p", help="Priority level")] = Priority.medium,
+    ) -> None:
+        """Create a new project (tab-complete --priority from the enum!)."""
+        self.poutput(f"Created project '{name}' with {priority.value.upper()} priority.")
+
+    @task_app.command("add")
+    def _task_add(
+        self,
+        title: Annotated[str, typer.Argument(help="Task title")],
+        assignee: Annotated[
+            str,
+            typer.Option("--assignee", "-a", help="Who to assign", autocompletion=_member_complete),
+        ] = "unassigned",
+    ) -> None:
+        """Add a task (tab-complete --assignee!)."""
+        self.poutput(f"Added task '{title}' assigned to {assignee}.")
+
+    @task_app.command("done")
+    def _task_done(
+        self,
+        task_id: Annotated[int, typer.Argument(help="Task ID to mark done")],
+    ) -> None:
+        """Mark a task as done."""
+        self.poutput(f"Task #{task_id} marked as done.")
+
+    project_app.add_typer(task_app, name="task")
+
+    @cmd2.with_typer(project_app)
+    def do_project(self) -> None:
+        """Manage projects and tasks (try: project <TAB>, project task <TAB>)."""
+
+
+if __name__ == "__main__":
+    app = TyperExampleApp()
+    app.cmdloop()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
   - Features:
       - features/index.md
       - features/argument_processing.md
+      - features/typer.md
       - features/async_commands.md
       - features/builtin_commands.md
       - features/clipboard.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "typing-extensions; python_version == '3.10'",
 ]
 
+[project.optional-dependencies]
+typer = ["typer>=0.24.1"]
+
 [dependency-groups]
 build = ["build>=1.3.0", "setuptools>=80.8.0", "setuptools-scm>=9.2.1"]
 dev = [
@@ -51,6 +54,7 @@ dev = [
     "ruff>=0.14.10",
     "uv-publish>=1.3",
     "zensical>=0.0.17",
+    "typer>=0.24.1",
 ]
 docs = [
     "mkdocstrings[python]>=1",
@@ -65,6 +69,7 @@ test = [
     "pytest>=8.1.1",
     "pytest-cov>=5",
     "pytest-mock>=3.14.1",
+    "typer>=0.24.1",
 ]
 validate = ["mypy>=1.13", "ruff>=0.14.10", "types-setuptools>=80.8.0"]
 

--- a/tests/test_typer.py
+++ b/tests/test_typer.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+
+import cmd2
+from cmd2 import utils
+
+from .conftest import run_cmd
+
+typer = pytest.importorskip("typer")
+
+
+def _name_complete(incomplete: str):
+    return [name for name in ["Alice", "Bob"] if name.startswith(incomplete)]
+
+
+def _choice_complete(incomplete: str):
+    return [item for item in ["alpha", "beta", "gamma"] if item.startswith(incomplete)]
+
+
+def _second_choice_complete(incomplete: str):
+    return [item for item in ["azure", "beige"] if item.startswith(incomplete)]
+
+
+class TyperCommandSet(cmd2.CommandSet):
+    @cmd2.with_typer
+    def do_scale(
+        self,
+        value: int,
+        factor: Annotated[int, typer.Option("--factor")] = 2,
+    ) -> None:
+        self._cmd.poutput(str(value * factor))
+
+
+class TyperApp(cmd2.Cmd):
+    @cmd2.with_typer
+    def do_add(
+        self,
+        a: int,
+        b: Annotated[int, typer.Option("--b")] = 2,
+    ) -> None:
+        self.poutput(str(a + b))
+
+    @cmd2.with_typer
+    def do_echo(self, text: Annotated[str, typer.Argument()]) -> None:
+        self.poutput(text)
+
+    @cmd2.with_typer(preserve_quotes=True)
+    def do_wrap(self, text: Annotated[str, typer.Argument()]) -> None:
+        self.poutput(text)
+
+    @cmd2.with_typer
+    def do_repeat(
+        self,
+        words: Annotated[list[str], typer.Argument()],
+        shout: Annotated[bool, typer.Option("--shout")] = False,
+    ) -> None:
+        output = ' '.join(words)
+        self.poutput(output.upper() if shout else output)
+
+    @cmd2.with_typer
+    def do_keyword(
+        self,
+        text: Annotated[str, typer.Argument()],
+        *,
+        keyword_arg: str | None = None,
+    ) -> None:
+        self.poutput(text)
+        if keyword_arg is not None:
+            print(keyword_arg)
+
+    @cmd2.with_typer
+    def do_documented(self, value: Annotated[str, typer.Argument()]) -> None:
+        """Documented typer command."""
+        self.poutput(value)
+
+    @cmd2.with_typer
+    def do_greet(
+        self,
+        name: Annotated[str, typer.Option("--name", autocompletion=_name_complete)] = "",
+    ) -> None:
+        self.poutput(f"hi {name}")
+
+    @cmd2.with_typer
+    def do_choose(
+        self,
+        item: Annotated[str, typer.Argument(autocompletion=_choice_complete)],
+    ) -> None:
+        self.poutput(item)
+
+    @cmd2.with_typer
+    def do_pair(
+        self,
+        first: Annotated[str, typer.Argument(autocompletion=_choice_complete)],
+        second: Annotated[str, typer.Argument(autocompletion=_second_choice_complete)],
+    ) -> None:
+        self.poutput(f"{first} {second}")
+
+
+@pytest.fixture
+def typer_app() -> TyperApp:
+    return TyperApp()
+
+
+# ---------------------------------------------------------------------------
+# Execution tests (parameterized)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cmd_input", "expected"),
+    [
+        pytest.param('add 2 --b 3', ['5'], id="basic_execution"),
+        pytest.param('add 2', ['4'], id="option_default"),
+        pytest.param('echo "hello there"', ['hello there'], id="remove_quotes"),
+        pytest.param('wrap "hello there"', ['"hello there"'], id="preserve_quotes"),
+        pytest.param('repeat "hello  there" "rick & morty"', ['hello  there rick & morty'], id="multiple_quoted_args"),
+        pytest.param("repeat 'This  is a' --shout test of the system", ['THIS  IS A TEST OF THE SYSTEM'], id="midline_option"),
+    ],
+)
+def test_typer_execution(typer_app: TyperApp, cmd_input: str, expected: list[str]) -> None:
+    out, _err = run_cmd(typer_app, cmd_input)
+    assert out == expected
+
+
+def test_typer_invalid_syntax(typer_app: TyperApp) -> None:
+    _out, err = run_cmd(typer_app, 'add "')
+    assert err[0] == 'Invalid syntax: No closing quotation'
+
+
+def test_typer_with_no_args(typer_app: TyperApp) -> None:
+    with pytest.raises(TypeError) as excinfo:
+        typer_app.do_add()
+    assert 'Expected arguments' in str(excinfo.value)
+
+
+def test_typer_kwargs_passthrough(typer_app: TyperApp, capsys: pytest.CaptureFixture[str]) -> None:
+    typer_app.do_keyword('hello', keyword_arg='foo')
+    out, _err = capsys.readouterr()
+    assert out == 'foo\n'
+
+
+def test_typer_parse_error_stays_in_repl(typer_app: TyperApp, capsys: pytest.CaptureFixture[str]) -> None:
+    stop = typer_app.onecmd_plus_hooks('add 2 3')
+
+    assert stop is False
+    assert 'Got unexpected extra argument (3)' in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Help tests
+# ---------------------------------------------------------------------------
+
+
+def test_typer_help_uses_app_stdout(typer_app: TyperApp, capsys: pytest.CaptureFixture[str]) -> None:
+    typer_app.stdout = utils.StdSim(typer_app.stdout)
+
+    typer_app.onecmd_plus_hooks('help add')
+
+    out = typer_app.stdout.getvalue()
+    assert 'Usage: add' in out
+    assert '--b' in out
+    assert capsys.readouterr().out == ''
+
+
+def test_typer_help_uses_docstring(typer_app: TyperApp) -> None:
+    out, _err = run_cmd(typer_app, 'help documented')
+    assert any('Usage: documented' in line for line in out)
+    assert any('Documented typer command.' in line for line in out)
+
+
+def test_typer_help_prog_name(typer_app: TyperApp) -> None:
+    out, _err = run_cmd(typer_app, 'help add')
+    usage_line = next(line for line in out if 'Usage: add' in line)
+    assert usage_line.strip().startswith('Usage: add')
+
+
+# ---------------------------------------------------------------------------
+# Completion tests (parameterized)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "text", "expected"),
+    [
+        pytest.param('greet --n', '--n', ('--name',), id="option_name"),
+        pytest.param('greet --name A', 'A', ('Alice',), id="option_value"),
+        pytest.param('greet --name ', '', ('Alice', 'Bob'), id="option_blank_value"),
+        pytest.param('choose a', 'a', ('alpha',), id="positional"),
+        pytest.param('pair alpha a', 'a', ('azure',), id="second_positional"),
+        pytest.param('greet --name Z', 'Z', (), id="no_results"),
+    ],
+)
+def test_typer_completion(typer_app: TyperApp, line: str, text: str, expected: tuple[str, ...]) -> None:
+    endidx = len(line)
+    begidx = endidx - len(text)
+    completions = typer_app.complete(text, line, begidx, endidx)
+    assert completions.to_strings() == expected
+
+
+# ---------------------------------------------------------------------------
+# CommandSet tests
+# ---------------------------------------------------------------------------
+
+
+def test_typer_commandset_binding() -> None:
+    app = TyperApp(command_sets=[TyperCommandSet()])
+    out, err = run_cmd(app, 'scale 3 --factor 4')
+    assert out == ['12']
+    assert err == []
+
+
+def test_typer_commandset_help() -> None:
+    app = TyperApp(command_sets=[TyperCommandSet()])
+    out, _err = run_cmd(app, 'help scale')
+    assert any('Usage: scale' in line for line in out)
+    assert any('--factor' in line for line in out)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TyperSubcommandSet(cmd2.CommandSet):
+    base_app = typer.Typer(help='Base command help')
+    admin_app = typer.Typer(help='Admin command help')
+
+    @base_app.command('foo')
+    def base_foo(
+        self,
+        y: Annotated[float, typer.Argument()],
+        x: Annotated[int, typer.Option('--x', '-x')] = 1,
+    ) -> None:
+        self._cmd.poutput(str(x * y))
+
+    @admin_app.command('bar')
+    def base_bar(self, z: Annotated[str, typer.Argument()]) -> None:
+        self._cmd.poutput(f'(({z}))')
+
+    @admin_app.command('lookup')
+    def admin_lookup(
+        self,
+        name: Annotated[str, typer.Option('--name', autocompletion=_name_complete)] = '',
+    ) -> None:
+        self._cmd.poutput(name)
+
+    base_app.add_typer(admin_app, name='admin')
+
+    @cmd2.with_typer(base_app)
+    def do_base(self) -> None:
+        pass
+
+
+@pytest.fixture
+def subcmd_app() -> TyperApp:
+    return TyperApp(command_sets=[TyperSubcommandSet()])
+
+
+@pytest.mark.parametrize(
+    ("cmd_input", "expected"),
+    [
+        pytest.param('base foo --x 2 5.0', ['10.0'], id="foo"),
+        pytest.param('base admin bar baz', ['((baz))'], id="admin_bar"),
+    ],
+)
+def test_typer_subcommand_execution(subcmd_app: TyperApp, cmd_input: str, expected: list[str]) -> None:
+    out, err = run_cmd(subcmd_app, cmd_input)
+    assert out == expected
+    assert err == []
+
+
+def test_typer_subcommand_invalid(subcmd_app: TyperApp) -> None:
+    _out, err = run_cmd(subcmd_app, 'base baz')
+    assert any(line.startswith('Usage: base') for line in err)
+    assert any("No such command 'baz'" in line for line in err)
+
+
+@pytest.mark.parametrize(
+    ("cmd_input", "expected_strings"),
+    [
+        pytest.param('help base', ['Usage: base', 'Base command help', 'foo', 'admin'], id="base_help"),
+        pytest.param('help base foo', ['Usage: base foo'], id="foo_help"),
+        pytest.param('help base admin bar', ['Usage: base admin bar'], id="admin_bar_help"),
+        pytest.param('help base baz', ['Usage: base', 'Base command help'], id="invalid_help_fallback"),
+    ],
+)
+def test_typer_subcommand_help(subcmd_app: TyperApp, cmd_input: str, expected_strings: list[str]) -> None:
+    out, _err = run_cmd(subcmd_app, cmd_input)
+    for s in expected_strings:
+        assert any(s in line for line in out)
+
+
+def test_typer_subcommand_parse_error_stays_in_repl(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app = TyperApp(command_sets=[TyperSubcommandSet()])
+
+    stop = app.onecmd_plus_hooks('base foo --x 2')
+
+    assert stop is False
+    assert 'Missing argument' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("line", "text", "expected_in"),
+    [
+        pytest.param('base a', 'a', ['admin'], id="subcommand_prefix"),
+        pytest.param('base admin b', 'b', ['bar'], id="nested_subcommand_prefix"),
+        pytest.param('base ', '', ['foo', 'admin'], id="blank_subcommand"),
+        pytest.param('base admin ', '', ['bar', 'lookup'], id="blank_nested_subcommand"),
+        pytest.param('base admin lookup --n', '--n', ['--name'], id="subcmd_option_name"),
+        pytest.param('base admin lookup --name A', 'A', ['Alice'], id="subcmd_option_value"),
+    ],
+)
+def test_typer_subcommand_completion(subcmd_app: TyperApp, line: str, text: str, expected_in: list[str]) -> None:
+    endidx = len(line)
+    begidx = endidx - len(text)
+    completions = subcmd_app.complete(text, line, begidx, endidx)
+    completion_strings = completions.to_strings()
+    for item in expected_in:
+        assert item in completion_strings

--- a/tests/test_typer.py
+++ b/tests/test_typer.py
@@ -5,6 +5,7 @@ from typing import Annotated
 import pytest
 
 import cmd2
+from cmd2 import string_utils as su
 from cmd2 import utils
 
 from .conftest import run_cmd
@@ -127,7 +128,7 @@ def test_typer_execution(typer_app: TyperApp, cmd_input: str, expected: list[str
 
 def test_typer_invalid_syntax(typer_app: TyperApp) -> None:
     _out, err = run_cmd(typer_app, 'add "')
-    assert err[0] == 'Invalid syntax: No closing quotation'
+    assert su.strip_style(err[0]) == 'Invalid syntax: No closing quotation'
 
 
 def test_typer_with_no_args(typer_app: TyperApp) -> None:
@@ -159,7 +160,7 @@ def test_typer_help_uses_app_stdout(typer_app: TyperApp, capsys: pytest.CaptureF
 
     typer_app.onecmd_plus_hooks('help add')
 
-    out = typer_app.stdout.getvalue()
+    out = su.strip_style(typer_app.stdout.getvalue())
     assert 'Usage: add' in out
     assert '--b' in out
     assert capsys.readouterr().out == ''
@@ -167,13 +168,15 @@ def test_typer_help_uses_app_stdout(typer_app: TyperApp, capsys: pytest.CaptureF
 
 def test_typer_help_uses_docstring(typer_app: TyperApp) -> None:
     out, _err = run_cmd(typer_app, 'help documented')
-    assert any('Usage: documented' in line for line in out)
-    assert any('Documented typer command.' in line for line in out)
+    plain = [su.strip_style(line) for line in out]
+    assert any('Usage: documented' in line for line in plain)
+    assert any('Documented typer command.' in line for line in plain)
 
 
 def test_typer_help_prog_name(typer_app: TyperApp) -> None:
     out, _err = run_cmd(typer_app, 'help add')
-    usage_line = next(line for line in out if 'Usage: add' in line)
+    plain = [su.strip_style(line) for line in out]
+    usage_line = next(line for line in plain if 'Usage: add' in line)
     assert usage_line.strip().startswith('Usage: add')
 
 
@@ -215,8 +218,9 @@ def test_typer_commandset_binding() -> None:
 def test_typer_commandset_help() -> None:
     app = TyperApp(command_sets=[TyperCommandSet()])
     out, _err = run_cmd(app, 'help scale')
-    assert any('Usage: scale' in line for line in out)
-    assert any('--factor' in line for line in out)
+    plain = [su.strip_style(line) for line in out]
+    assert any('Usage: scale' in line for line in plain)
+    assert any('--factor' in line for line in plain)
 
 
 # ---------------------------------------------------------------------------
@@ -289,8 +293,9 @@ def test_typer_subcommand_invalid(subcmd_app: TyperApp) -> None:
 )
 def test_typer_subcommand_help(subcmd_app: TyperApp, cmd_input: str, expected_strings: list[str]) -> None:
     out, _err = run_cmd(subcmd_app, cmd_input)
+    plain = [su.strip_style(line) for line in out]
     for s in expected_strings:
-        assert any(s in line for line in out)
+        assert any(s in line for line in plain)
 
 
 def test_typer_subcommand_parse_error_stays_in_repl(


### PR DESCRIPTION
  Summary                                                                                                   
                                                                                                            
  - Add `@cmd2.with_typer` decorator for defining commands using type annotations and Typer/Click instead of argparse                               
  - Support two patterns: auto-built from method signature (simple commands) and explicit `typer.Typer()` app (subcommands)
  - Integrate with cmd2 help, tab completion, error handling, and CommandSet                                                                      
                                                                                                                                                  
  What's included                                                                                                                                 
                                                                                                                                                  
  - cmd2/typer_custom.py — Typer-specific logic for building Click commands, completion, and subcommand resolution                                
  - cmd2/decorators.py — `@with_typer` decorator                                                              
  - cmd2/cmd2.py — Extended _CommandParsers and help/completion paths to handle both argparse and Typer commands                                  
  - tests/test_typer.py — 35 tests covering execution, help, completion, CommandSet, and subcommands                                              
  - docs/features/typer.md — Documentation with usage examples                                                                                    
  - examples/typer_example.py — Working example app                                                                                               
  - Optional dependency via `pip install cmd2[typer]`                                                                                               
                                                                                                                                                  
  Test plan                                                                                                                                       
                                                                                                                                                  
  - make check passes (ruff, mypy)                                                                                                                
  - All existing tests pass (no regressions)                                                                
  - python examples/typer_example.py runs, and tab completion works

The following is a screenshot of the typer_example.py

<img width="1251" height="870" alt="image" src="https://github.com/user-attachments/assets/13806c58-e1b6-4a07-ae4c-4aaadbd235a4" />
