### PR TITLE
Fix ansi color dumb terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.2.0 (TBD)
+
+- Bug Fixes
+    - Fixed incompatibilities with Python 3.14.3.
+
+- Potentially Breaking Changes
+    - To avoid future incompatibilities with argparse, we removed most of our overridden help
+      functions. This should not break an application, but it could affect unit tests which parse
+      help text.
+
 ## 3.1.3 (February 3, 2026)
 
 - Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.2 (February 21, 2026)
+
+- Bug Fixes
+    - Updated `rich_utils.ANSI_STYLE_SEQUENCE_RE` to only match ANSI SGR (Select Graphic Rendition)
+      sequences for text styling.
+
 ## 3.2.1 (February 21, 2026)
 
 - Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - Bug Fixes
     - The `async_alert` and `async_prompt_update` methods of `cmd2.Cmd` now respect the current
       value of the `allow_style` settable
-        - If `allow_style` is `NEVER`, all ANSI escape codes will be stripped to ensure plain text
-          output
+        - If `allow_style` is `NEVER`, all style-related ANSI escape codes will be stripped to
+          ensure plain text output
 
 ## 3.2.0 (February 5, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0 (TBD)
+## 3.2.0 (February 5, 2026)
 
 - Bug Fixes
     - Fixed incompatibilities with Python 3.14.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.2.1 (February TBD, 2026)
+
+- Bug Fixes
+    - The `async_alert` and `async_prompt_update` methods of `cmd2.Cmd` now respect the current
+      value of the `allow_style` settable
+        - If `allow_style` is `NEVER`, all ANSI escape codes will be stripped to ensure plain text
+          output
+
 ## 3.2.0 (February 5, 2026)
 
 - Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.1 (February TBD, 2026)
+## 3.2.1 (February 21, 2026)
 
 - Bug Fixes
     - The `async_alert` and `async_prompt_update` methods of `cmd2.Cmd` now respect the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Bug Fixes
     - Updated `rich_utils.ANSI_STYLE_SEQUENCE_RE` to only match ANSI SGR (Select Graphic Rendition)
-      sequences for text styling.
+      sequences for text styling. It previously also matched DEC Private Mode sequences.
 
 ## 3.2.1 (February 21, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.4.0 (TBD)
+
+- Enhancements
+    - Moved cmd2-specific printing logic from `Cmd.print_to()` into `Cmd2BaseConsole.print()` and
+      `Cmd2BaseConsole.log()`. This removes need to pass a console object to `Cmd.print_to()`.
+    - Addressed a bug in `rich.console.Console` where complex renderables (like `Table` and `Rule`)
+      may not receive formatting settings passed to `console.print()` and `console.log()`.
+
+- Breaking Changes
+    - Renamed the `destination` parameter of `Cmd.print_to()` back to `file` since you can no longer
+      pass in a console.
+
 ## 3.3.0 (March 1, 2026)
 
 - Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.3.0 (March 1, 2026)
+## 3.3.0 (March 1, 2026)
 
 - Enhancements
     - Added ability to pass a console object to `Cmd.print_to()`. This provides support for things

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.0 (TBD)
+## 3.4.0 (March 3, 2026)
 
 - Enhancements
     - Moved cmd2-specific printing logic from `Cmd.print_to()` into `Cmd2BaseConsole.print()` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.3.0 (TBD)
+# 3.3.0 (March 1, 2026)
 
 - Enhancements
     - Added ability to pass a console object to `Cmd.print_to()`. This provides support for things

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 3.3.0 (TBD)
+
+- Enhancements
+    - Added ability to pass a console object to `Cmd.print_to()`. This provides support for things
+      like wrapping a `print_to()` call in a `console.status()` or `console.capture()` context
+      manager.
+
+- Breaking Changes
+    - Renamed the `file` parameter of `Cmd.print_to()` to `destination` to support file-like objects
+      and console objects.
+    - `Cmd2BaseConsole(file)` argument is now a keyword-only argument to be consistent with the
+      `rich.console.Console` class.
+
 ## 3.2.2 (February 21, 2026)
 
 - Bug Fixes

--- a/cmd2/argparse_custom.py
+++ b/cmd2/argparse_custom.py
@@ -1361,10 +1361,10 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
         self.print_usage(sys.stderr)
 
-        # Add error style to message
+        # Use console to add style since it will respect ALLOW_STYLE's value
         console = self._get_formatter().console
         with console.capture() as capture:
-            console.print(formatted_message, style=Cmd2Style.ERROR, crop=False)
+            console.print(formatted_message, style=Cmd2Style.ERROR)
         formatted_message = f"{capture.get()}"
 
         self.exit(2, f'{formatted_message}\n')

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -950,11 +950,12 @@ class Cmd:
 
     def _check_uninstallable(self, cmdset: CommandSet) -> None:
         def check_parser_uninstallable(parser: argparse.ArgumentParser) -> None:
+            cmdset_id = id(cmdset)
             for action in parser._actions:
                 if isinstance(action, argparse._SubParsersAction):
                     for subparser in action.choices.values():
-                        attached_cmdset = getattr(subparser, constants.PARSER_ATTR_COMMANDSET, None)
-                        if attached_cmdset is not None and attached_cmdset is not cmdset:
+                        attached_cmdset_id = getattr(subparser, constants.PARSER_ATTR_COMMANDSET_ID, None)
+                        if attached_cmdset_id is not None and attached_cmdset_id != cmdset_id:
                             raise CommandSetRegistrationError(
                                 'Cannot uninstall CommandSet when another CommandSet depends on it'
                             )
@@ -1049,7 +1050,7 @@ class Cmd:
             subcmd_parser.set_defaults(**defaults)
 
             # Set what instance the handler is bound to
-            setattr(subcmd_parser, constants.PARSER_ATTR_COMMANDSET, cmdset)
+            setattr(subcmd_parser, constants.PARSER_ATTR_COMMANDSET_ID, id(cmdset))
 
             # Find the argparse action that handles subcommands
             for action in target_parser._actions:
@@ -4059,25 +4060,31 @@ class Cmd:
                     self.perror(f"Macro '{cur_name}' does not exist")
 
     # macro -> list
-    macro_list_help = "list macros"
-    macro_list_description = Text.assemble(
-        "List specified macros in a reusable form that can be saved to a startup script to preserve macros across sessions.",
-        "\n\n",
-        "Without arguments, all macros will be listed.",
-    )
+    @classmethod
+    def _build_macro_list_parser(cls) -> Cmd2ArgumentParser:
+        macro_list_description = Text.assemble(
+            (
+                "List specified macros in a reusable form that can be saved to a startup script "
+                "to preserve macros across sessions."
+            ),
+            "\n\n",
+            "Without arguments, all macros will be listed.",
+        )
 
-    macro_list_parser = argparse_custom.DEFAULT_ARGUMENT_PARSER(description=macro_list_description)
-    macro_list_parser.add_argument(
-        'names',
-        nargs=argparse.ZERO_OR_MORE,
-        help='macro(s) to list',
-        choices_provider=_get_macro_completion_items,
-        descriptive_headers=["Value"],
-    )
+        macro_list_parser = argparse_custom.DEFAULT_ARGUMENT_PARSER(description=macro_list_description)
+        macro_list_parser.add_argument(
+            'names',
+            nargs=argparse.ZERO_OR_MORE,
+            help='macro(s) to list',
+            choices_provider=cls._get_macro_completion_items,
+            descriptive_headers=["Value"],
+        )
 
-    @as_subcommand_to('macro', 'list', macro_list_parser, help=macro_list_help)
+        return macro_list_parser
+
+    @as_subcommand_to('macro', 'list', _build_macro_list_parser, help="list macros")
     def _macro_list(self, args: argparse.Namespace) -> None:
-        """List some or all macros as 'macro create' commands."""
+        """List macros."""
         self.last_result = {}  # dict[macro_name, macro_value]
 
         tokens_to_quote = constants.REDIRECTION_TOKENS

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -5744,6 +5744,8 @@ class Cmd:
             update_terminal = False
 
             if alert_msg:
+                if self.allow_style == ru.AllowStyle.NEVER:
+                    alert_msg = su.strip_style(alert_msg)
                 alert_msg += '\n'
                 update_terminal = True
 

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -65,7 +65,11 @@ from typing import (
 )
 
 import rich.box
-from rich.console import Group, RenderableType
+from rich.console import (
+    Console,
+    Group,
+    RenderableType,
+)
 from rich.highlighter import ReprHighlighter
 from rich.rule import Rule
 from rich.style import Style, StyleType
@@ -133,6 +137,7 @@ from .parsing import (
     shlex_split,
 )
 from .rich_utils import (
+    Cmd2BaseConsole,
     Cmd2ExceptionConsole,
     Cmd2GeneralConsole,
     RichPrintKwargs,
@@ -165,7 +170,7 @@ from .utils import (
 
 # Set up readline
 if rl_type == RlType.NONE:  # pragma: no cover
-    Cmd2GeneralConsole(sys.stderr).print(rl_warning, style=Cmd2Style.WARNING)
+    Cmd2GeneralConsole(file=sys.stderr).print(rl_warning, style=Cmd2Style.WARNING)
 else:
     from .rl_utils import (
         readline,
@@ -1247,30 +1252,66 @@ class Cmd:
 
     def print_to(
         self,
-        file: IO[str],
+        destination: IO[str] | Cmd2BaseConsole,
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
-        """Print objects to a given file stream.
+        """Print objects to a given destination (file stream or cmd2 console).
 
-        This method is configured for general-purpose printing. By default, it enables
-        soft wrap and disables Rich's automatic detection for markup, emoji, and highlighting.
-        These defaults can be overridden by passing explicit keyword arguments.
+        If ``destination`` is a file-like object, it is wrapped in a ``Cmd2GeneralConsole``
+        which is configured for general-purpose printing. By default, it enables soft wrap and
+        disables Rich's automatic detection for markup, emoji, and highlighting. These defaults
+        can be overridden by passing explicit keyword arguments.
 
-        :param file: file stream being written to
+        If ``destination`` is a ``Cmd2BaseConsole``, the console's default settings for
+        soft wrap, markup, emoji, and highlighting are used unless overridden by passing
+        explicit keyword arguments.
+
+        See the Rich documentation for more details on emoji codes, markup tags, and highlighting.
+
+        **Why use this method instead of console.print()?**
+
+        This method calls ``cmd2.rich_utils.prepare_objects_for_rendering()`` on the objects
+        being printed. This ensures that strings containing ANSI style sequences are converted
+        to Rich Text objects, so that Rich can correctly calculate their display width when
+        printing.
+
+        Example:
+        ```py
+        with console.capture() as capture:
+            self.print_to(console, some_ansi_styled_string)
+        ```
+
+        !!! note
+
+            To ensure consistent behavior, this method requires a file-like object or
+            an instance of ``Cmd2BaseConsole``.
+            Consoles not derived from ``Cmd2BaseConsole`` are disallowed because:
+
+            1. **Style Control**: They ignore the global ``ALLOW_STYLE`` setting.
+            2. **Theming**: They do not respect the application-wide ``APP_THEME``.
+            3. **Error Handling**: They trigger a ``SystemExit`` on broken pipes.
+               ``Cmd2BaseConsole`` instead raises a catchable ``BrokenPipeError``,
+               ensuring the CLI application remains alive if a pipe is closed.
+
+        :param destination: The output target. File-like objects are automatically
+                            wrapped in a ``Cmd2GeneralConsole`` to ensure they respect
+                            cmd2 global settings; otherwise, this must be an
+                            instance of ``Cmd2BaseConsole``.
         :param objects: objects to print
         :param sep: string to write between printed text. Defaults to " ".
         :param end: string to write at end of printed text. Defaults to a newline.
         :param style: optional style to apply to output
-        :param soft_wrap: Enable soft wrap mode. Defaults to True.
+        :param soft_wrap: Enable soft wrap mode. Defaults to None.
+                          If None, the destination console's default behavior is used.
                           If True, text that doesn't fit will run on to the following line,
                           just like with print(). This is useful for raw text and logs.
                           If False, Rich wraps text to fit the terminal width.
@@ -1279,24 +1320,43 @@ class Cmd:
                           For example, when soft_wrap is True Panels truncate text
                           which is wider than the terminal.
         :param emoji: If True, Rich will replace emoji codes (e.g., :smiley:) with their
-                      corresponding Unicode characters. Defaults to False.
+                      corresponding Unicode characters. Defaults to None.
+                      If None, the destination console's default behavior is used.
         :param markup: If True, Rich will interpret strings with tags (e.g., [bold]hello[/bold])
-                       as styled output. Defaults to False.
+                       as styled output. Defaults to None.
+                       If None, the destination console's default behavior is used.
         :param highlight: If True, Rich will automatically apply highlighting to elements within
                           strings, such as common Python data types like numbers, booleans, or None.
                           This is particularly useful when pretty printing objects like lists and
-                          dictionaries to display them in color. Defaults to False.
+                          dictionaries to display them in color. Defaults to None.
+                          If None, the destination console's default behavior is used.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
                        These arguments are not passed to Rich's Console.print().
+        :raises TypeError: If ``destination`` is a non-cmd2 ``Console`` instance that
+                           does not derive from ``Cmd2BaseConsole``.
 
-        See the Rich documentation for more details on emoji codes, markup tags, and highlighting.
         """
+        if isinstance(destination, Console):
+            if not isinstance(destination, Cmd2BaseConsole):
+                # Explicitly reject non-cmd2 consoles to ensure safe behavior
+                raise TypeError(
+                    f"destination must be a 'Cmd2BaseConsole' or a file-like object, "
+                    f"not a non-cmd2 '{type(destination).__name__}'. "
+                    "Consoles not derived from 'Cmd2BaseConsole' bypass cmd2's "
+                    "'ALLOW_STYLE' logic, 'APP_THEME' settings, and trigger 'SystemExit' "
+                    "on broken pipes."
+                )
+            console = destination
+        else:
+            # It's a file-like object (e.g., sys.stdout, StringIO)
+            console = Cmd2GeneralConsole(file=destination)
+
         prepared_objects = ru.prepare_objects_for_rendering(*objects)
 
         try:
-            Cmd2GeneralConsole(file).print(
+            console.print(
                 *prepared_objects,
                 sep=sep,
                 end=end,
@@ -1313,8 +1373,8 @@ class Cmd:
             # writing. If you would like your application to print a
             # warning message, then set the broken_pipe_warning attribute
             # to the message you want printed.
-            if self.broken_pipe_warning and file != sys.stderr:
-                Cmd2GeneralConsole(sys.stderr).print(self.broken_pipe_warning)
+            if self.broken_pipe_warning and console.file != sys.stderr:
+                Cmd2GeneralConsole(file=sys.stderr).print(self.broken_pipe_warning)
 
     def poutput(
         self,
@@ -1322,10 +1382,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1352,10 +1412,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = Cmd2Style.ERROR,
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1383,10 +1443,10 @@ class Cmd:
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1411,10 +1471,10 @@ class Cmd:
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1447,7 +1507,7 @@ class Cmd:
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
         """
-        console = Cmd2ExceptionConsole(sys.stderr)
+        console = Cmd2ExceptionConsole(file=sys.stderr)
 
         # Only print a traceback if we're in debug mode and one exists.
         if self.debug and sys.exc_info() != (None, None, None):
@@ -1494,10 +1554,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        soft_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1542,9 +1602,9 @@ class Cmd:
         style: StyleType | None = None,
         chop: bool = False,
         soft_wrap: bool = True,
-        emoji: bool = False,
-        markup: bool = False,
-        highlight: bool = False,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1581,17 +1641,16 @@ class Cmd:
 
         # Check if we are outputting to a pager.
         if functional_terminal and can_block:
-            prepared_objects = ru.prepare_objects_for_rendering(*objects)
-
             # Chopping overrides soft_wrap
             if chop:
                 soft_wrap = True
 
             # Generate the bytes to send to the pager
-            console = Cmd2GeneralConsole(self.stdout)
+            console = Cmd2GeneralConsole(file=self.stdout)
             with console.capture() as capture:
-                console.print(
-                    *prepared_objects,
+                self.print_to(
+                    console,
+                    *objects,
                     sep=sep,
                     end=end,
                     style=style,

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -66,7 +66,6 @@ from typing import (
 
 import rich.box
 from rich.console import (
-    Console,
     Group,
     RenderableType,
 )
@@ -1252,66 +1251,30 @@ class Cmd:
 
     def print_to(
         self,
-        destination: IO[str] | Cmd2BaseConsole,
+        file: IO[str],
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
-        """Print objects to a given destination (file stream or cmd2 console).
+        """Print objects to a given file stream.
 
-        If ``destination`` is a file-like object, it is wrapped in a ``Cmd2GeneralConsole``
-        which is configured for general-purpose printing. By default, it enables soft wrap and
-        disables Rich's automatic detection for markup, emoji, and highlighting. These defaults
-        can be overridden by passing explicit keyword arguments.
+        This method is configured for general-purpose printing. By default, it enables
+        soft wrap and disables Rich's automatic detection for markup, emoji, and highlighting.
+        These defaults can be overridden by passing explicit keyword arguments.
 
-        If ``destination`` is a ``Cmd2BaseConsole``, the console's default settings for
-        soft wrap, markup, emoji, and highlighting are used unless overridden by passing
-        explicit keyword arguments.
-
-        See the Rich documentation for more details on emoji codes, markup tags, and highlighting.
-
-        **Why use this method instead of console.print()?**
-
-        This method calls ``cmd2.rich_utils.prepare_objects_for_rendering()`` on the objects
-        being printed. This ensures that strings containing ANSI style sequences are converted
-        to Rich Text objects, so that Rich can correctly calculate their display width when
-        printing.
-
-        Example:
-        ```py
-        with console.capture() as capture:
-            self.print_to(console, some_ansi_styled_string)
-        ```
-
-        !!! note
-
-            To ensure consistent behavior, this method requires a file-like object or
-            an instance of ``Cmd2BaseConsole``.
-            Consoles not derived from ``Cmd2BaseConsole`` are disallowed because:
-
-            1. **Style Control**: They ignore the global ``ALLOW_STYLE`` setting.
-            2. **Theming**: They do not respect the application-wide ``APP_THEME``.
-            3. **Error Handling**: They trigger a ``SystemExit`` on broken pipes.
-               ``Cmd2BaseConsole`` instead raises a catchable ``BrokenPipeError``,
-               ensuring the CLI application remains alive if a pipe is closed.
-
-        :param destination: The output target. File-like objects are automatically
-                            wrapped in a ``Cmd2GeneralConsole`` to ensure they respect
-                            cmd2 global settings; otherwise, this must be an
-                            instance of ``Cmd2BaseConsole``.
+        :param file: file stream being written to
         :param objects: objects to print
         :param sep: string to write between printed text. Defaults to " ".
         :param end: string to write at end of printed text. Defaults to a newline.
         :param style: optional style to apply to output
-        :param soft_wrap: Enable soft wrap mode. Defaults to None.
-                          If None, the destination console's default behavior is used.
+        :param soft_wrap: Enable soft wrap mode. Defaults to True.
                           If True, text that doesn't fit will run on to the following line,
                           just like with print(). This is useful for raw text and logs.
                           If False, Rich wraps text to fit the terminal width.
@@ -1320,44 +1283,23 @@ class Cmd:
                           For example, when soft_wrap is True Panels truncate text
                           which is wider than the terminal.
         :param emoji: If True, Rich will replace emoji codes (e.g., :smiley:) with their
-                      corresponding Unicode characters. Defaults to None.
-                      If None, the destination console's default behavior is used.
+                      corresponding Unicode characters. Defaults to False.
         :param markup: If True, Rich will interpret strings with tags (e.g., [bold]hello[/bold])
-                       as styled output. Defaults to None.
-                       If None, the destination console's default behavior is used.
+                       as styled output. Defaults to False.
         :param highlight: If True, Rich will automatically apply highlighting to elements within
                           strings, such as common Python data types like numbers, booleans, or None.
                           This is particularly useful when pretty printing objects like lists and
-                          dictionaries to display them in color. Defaults to None.
-                          If None, the destination console's default behavior is used.
+                          dictionaries to display them in color. Defaults to False.
         :param rich_print_kwargs: optional additional keyword arguments to pass to Rich's Console.print().
         :param kwargs: Arbitrary keyword arguments. This allows subclasses to extend the signature of this
                        method and still call `super()` without encountering unexpected keyword argument errors.
                        These arguments are not passed to Rich's Console.print().
-        :raises TypeError: If ``destination`` is a non-cmd2 ``Console`` instance that
-                           does not derive from ``Cmd2BaseConsole``.
 
+        See the Rich documentation for more details on emoji codes, markup tags, and highlighting.
         """
-        if isinstance(destination, Console):
-            if not isinstance(destination, Cmd2BaseConsole):
-                # Explicitly reject non-cmd2 consoles to ensure safe behavior
-                raise TypeError(
-                    f"destination must be a 'Cmd2BaseConsole' or a file-like object, "
-                    f"not a non-cmd2 '{type(destination).__name__}'. "
-                    "Consoles not derived from 'Cmd2BaseConsole' bypass cmd2's "
-                    "'ALLOW_STYLE' logic, 'APP_THEME' settings, and trigger 'SystemExit' "
-                    "on broken pipes."
-                )
-            console = destination
-        else:
-            # It's a file-like object (e.g., sys.stdout, StringIO)
-            console = Cmd2GeneralConsole(file=destination)
-
-        prepared_objects = ru.prepare_objects_for_rendering(*objects)
-
         try:
-            console.print(
-                *prepared_objects,
+            Cmd2BaseConsole(file=file).print(
+                *objects,
                 sep=sep,
                 end=end,
                 style=style,
@@ -1373,7 +1315,7 @@ class Cmd:
             # writing. If you would like your application to print a
             # warning message, then set the broken_pipe_warning attribute
             # to the message you want printed.
-            if self.broken_pipe_warning and console.file != sys.stderr:
+            if self.broken_pipe_warning and file != sys.stderr:
                 Cmd2GeneralConsole(file=sys.stderr).print(self.broken_pipe_warning)
 
     def poutput(
@@ -1382,10 +1324,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1412,10 +1354,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = Cmd2Style.ERROR,
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1443,10 +1385,10 @@ class Cmd:
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1471,10 +1413,10 @@ class Cmd:
         *objects: Any,
         sep: str = " ",
         end: str = "\n",
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1554,10 +1496,10 @@ class Cmd:
         sep: str = " ",
         end: str = "\n",
         style: StyleType | None = None,
-        soft_wrap: bool | None = None,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        soft_wrap: bool = True,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1602,9 +1544,9 @@ class Cmd:
         style: StyleType | None = None,
         chop: bool = False,
         soft_wrap: bool = True,
-        emoji: bool | None = None,
-        markup: bool | None = None,
-        highlight: bool | None = None,
+        emoji: bool = False,
+        markup: bool = False,
+        highlight: bool = False,
         rich_print_kwargs: RichPrintKwargs | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -1646,10 +1588,9 @@ class Cmd:
                 soft_wrap = True
 
             # Generate the bytes to send to the pager
-            console = Cmd2GeneralConsole(file=self.stdout)
+            console = Cmd2BaseConsole(file=self.stdout)
             with console.capture() as capture:
-                self.print_to(
-                    console,
+                console.print(
                     *objects,
                     sep=sep,
                     end=end,

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -47,8 +47,8 @@ SUBCMD_ATTR_COMMAND = 'parent_command'
 SUBCMD_ATTR_NAME = 'subcommand_name'
 SUBCMD_ATTR_ADD_PARSER_KWARGS = 'subcommand_add_parser_kwargs'
 
-# arpparse attribute linking to command set instance
-PARSER_ATTR_COMMANDSET = 'command_set'
+# arpparse attribute uniquely identifying the command set instance
+PARSER_ATTR_COMMANDSET_ID = 'command_set_id'
 
 # custom attributes added to argparse Namespaces
 NS_ATTR_SUBCMD_HANDLER = '__subcmd_handler__'

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -30,8 +30,11 @@ from rich_argparse import RichHelpFormatter
 
 from .styles import DEFAULT_CMD2_STYLES
 
-# A compiled regular expression to detect ANSI style sequences.
-ANSI_STYLE_SEQUENCE_RE = re.compile(r"\x1b\[[0-9;?]*m")
+# Matches ANSI SGR (Select Graphic Rendition) sequences for text styling.
+# \x1b[   - the CSI (Control Sequence Introducer)
+# [0-9;]* - zero or more digits or semicolons (parameters for the style)
+# m       - the SGR final character
+ANSI_STYLE_SEQUENCE_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class AllowStyle(Enum):

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -1,6 +1,7 @@
 """Provides common utilities to support Rich in cmd2-based applications."""
 
 import re
+import threading
 from collections.abc import Mapping
 from enum import Enum
 from typing import (
@@ -173,11 +174,151 @@ class Cmd2BaseConsole(Console):
             theme=APP_THEME,
             **kwargs,
         )
+        self._thread_local = threading.local()
 
     def on_broken_pipe(self) -> None:
         """Override which raises BrokenPipeError instead of SystemExit."""
         self.quiet = True
         raise BrokenPipeError
+
+    def render_str(
+        self,
+        text: str,
+        highlight: bool | None = None,
+        markup: bool | None = None,
+        emoji: bool | None = None,
+        **kwargs: Any,
+    ) -> Text:
+        """Override to ensure formatting overrides passed to print() and log() are respected."""
+        if emoji is None:
+            emoji = getattr(self._thread_local, "emoji", None)
+        if markup is None:
+            markup = getattr(self._thread_local, "markup", None)
+        if highlight is None:
+            highlight = getattr(self._thread_local, "highlight", None)
+
+        return super().render_str(text, highlight=highlight, markup=markup, emoji=emoji, **kwargs)
+
+    def print(
+        self,
+        *objects: Any,
+        sep: str = " ",
+        end: str = "\n",
+        style: StyleType | None = None,
+        justify: JustifyMethod | None = None,
+        overflow: OverflowMethod | None = None,
+        no_wrap: bool | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        crop: bool = True,
+        soft_wrap: bool | None = None,
+        new_line_start: bool = False,
+    ) -> None:
+        """Override to support ANSI sequences and address a bug in Rich.
+
+        This method calls [cmd2.rich_utils.prepare_objects_for_rendering][] on the
+        objects being printed. This ensures that strings containing ANSI style
+        sequences are converted to Rich Text objects, so that Rich can correctly
+        calculate their display width.
+
+        Additionally, it works around a bug in Rich where complex renderables
+        (like Table and Rule) may not receive formatting settings passed to print().
+        By temporarily injecting these settings into thread-local storage, we ensure
+        that all internal rendering calls within the print() operation respect the
+        requested overrides.
+
+        There is an issue on Rich to fix the latter:
+        https://github.com/Textualize/rich/issues/4028
+        """
+        prepared_objects = prepare_objects_for_rendering(*objects)
+
+        # Inject overrides into thread-local storage
+        self._thread_local.emoji = emoji
+        self._thread_local.markup = markup
+        self._thread_local.highlight = highlight
+
+        try:
+            super().print(
+                *prepared_objects,
+                sep=sep,
+                end=end,
+                style=style,
+                justify=justify,
+                overflow=overflow,
+                no_wrap=no_wrap,
+                emoji=emoji,
+                markup=markup,
+                highlight=highlight,
+                width=width,
+                height=height,
+                crop=crop,
+                soft_wrap=soft_wrap,
+                new_line_start=new_line_start,
+            )
+        finally:
+            # Clear overrides from thread-local storage
+            self._thread_local.emoji = None
+            self._thread_local.markup = None
+            self._thread_local.highlight = None
+
+    def log(
+        self,
+        *objects: Any,
+        sep: str = " ",
+        end: str = "\n",
+        style: StyleType | None = None,
+        justify: JustifyMethod | None = None,
+        emoji: bool | None = None,
+        markup: bool | None = None,
+        highlight: bool | None = None,
+        log_locals: bool = False,
+        _stack_offset: int = 1,
+    ) -> None:
+        """Override to support ANSI sequences and address a bug in Rich.
+
+        This method calls [cmd2.rich_utils.prepare_objects_for_rendering][] on the
+        objects being logged. This ensures that strings containing ANSI style
+        sequences are converted to Rich Text objects, so that Rich can correctly
+        calculate their display width.
+
+        Additionally, it works around a bug in Rich where complex renderables
+        (like Table and Rule) may not receive formatting settings passed to log().
+        By temporarily injecting these settings into thread-local storage, we ensure
+        that all internal rendering calls within the log() operation respect the
+        requested overrides.
+
+        There is an issue on Rich to fix the latter:
+        https://github.com/Textualize/rich/issues/4028
+        """
+        prepared_objects = prepare_objects_for_rendering(*objects)
+
+        # Inject overrides into thread-local storage
+        self._thread_local.emoji = emoji
+        self._thread_local.markup = markup
+        self._thread_local.highlight = highlight
+
+        try:
+            # Increment _stack_offset because we added this wrapper frame
+            super().log(
+                *prepared_objects,
+                sep=sep,
+                end=end,
+                style=style,
+                justify=justify,
+                emoji=emoji,
+                markup=markup,
+                highlight=highlight,
+                log_locals=log_locals,
+                _stack_offset=_stack_offset + 1,
+            )
+        finally:
+            # Clear overrides from thread-local storage
+            self._thread_local.emoji = None
+            self._thread_local.markup = None
+            self._thread_local.highlight = None
 
 
 class Cmd2GeneralConsole(Cmd2BaseConsole):

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -158,8 +158,11 @@ class Cmd2BaseConsole(Console):
         force_terminal: bool | None = None
         force_interactive: bool | None = None
 
+        color_system: str | None = "auto"
+
         if ALLOW_STYLE == AllowStyle.ALWAYS:
             force_terminal = True
+            color_system = "truecolor"
 
             # Turn off interactive mode if dest is not actually a terminal which supports it
             tmp_console = Console(file=file)
@@ -171,6 +174,7 @@ class Cmd2BaseConsole(Console):
             file=file,
             force_terminal=force_terminal,
             force_interactive=force_interactive,
+            color_system=color_system,
             theme=APP_THEME,
             **kwargs,
         )
@@ -412,6 +416,7 @@ def rich_text_to_string(text: Text) -> str:
     """
     console = Console(
         force_terminal=True,
+        color_system="truecolor",
         soft_wrap=True,
         no_color=False,
         theme=APP_THEME,

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -414,9 +414,6 @@ def rich_text_to_string(text: Text) -> str:
         force_terminal=True,
         soft_wrap=True,
         no_color=False,
-        markup=False,
-        emoji=False,
-        highlight=False,
         theme=APP_THEME,
     )
     with console.capture() as capture:

--- a/cmd2/rich_utils.py
+++ b/cmd2/rich_utils.py
@@ -124,6 +124,7 @@ class Cmd2BaseConsole(Console):
 
     def __init__(
         self,
+        *,
         file: IO[str] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -180,17 +181,19 @@ class Cmd2BaseConsole(Console):
 
 
 class Cmd2GeneralConsole(Cmd2BaseConsole):
-    """Rich console for general-purpose printing."""
+    """Rich console for general-purpose printing.
 
-    def __init__(self, file: IO[str] | None = None) -> None:
+    It enables soft wrap and disables Rich's automatic detection for markup,
+    emoji, and highlighting. These defaults can be overridden in calls to the
+    console's or cmd2's print methods.
+    """
+
+    def __init__(self, *, file: IO[str] | None = None) -> None:
         """Cmd2GeneralConsole initializer.
 
         :param file: optional file object where the console should write to.
                      Defaults to sys.stdout.
         """
-        # This console is configured for general-purpose printing. It enables soft wrap
-        # and disables Rich's automatic detection for markup, emoji, and highlighting.
-        # These defaults can be overridden in calls to the console's or cmd2's print methods.
         super().__init__(
             file=file,
             soft_wrap=True,
@@ -203,23 +206,25 @@ class Cmd2GeneralConsole(Cmd2BaseConsole):
 class Cmd2RichArgparseConsole(Cmd2BaseConsole):
     """Rich console for rich-argparse output.
 
-    This class ensures long lines in help text are not truncated by avoiding soft_wrap,
+    Ensures long lines in help text are not truncated by disabling soft_wrap,
     which conflicts with rich-argparse's explicit no_wrap and overflow settings.
+
+    Since this console is used to print error messages which may not be intended
+    for Rich formatting, it disables Rich's automatic detection for markup, emoji,
+    and highlighting. Because rich-argparse does markup and highlighting without
+    involving the console, disabling these settings does not affect the library's
+    internal functionality.
     """
 
-    def __init__(self, file: IO[str] | None = None) -> None:
+    def __init__(self, *, file: IO[str] | None = None) -> None:
         """Cmd2RichArgparseConsole initializer.
 
         :param file: optional file object where the console should write to.
                      Defaults to sys.stdout.
         """
-        # Since this console is used to print error messages which may not have
-        # been pre-formatted by rich-argparse, disable Rich's automatic detection
-        # for markup, emoji, and highlighting. rich-argparse does markup and
-        # highlighting without involving the console so these won't affect its
-        # internal functionality.
         super().__init__(
             file=file,
+            soft_wrap=False,
             markup=False,
             emoji=False,
             highlight=False,
@@ -227,10 +232,26 @@ class Cmd2RichArgparseConsole(Cmd2BaseConsole):
 
 
 class Cmd2ExceptionConsole(Cmd2BaseConsole):
-    """Rich console for printing exceptions.
+    """Rich console for printing exceptions and Rich Tracebacks.
 
-    Ensures that long exception messages word wrap for readability by keeping soft_wrap disabled.
+    Ensures that output is always word-wrapped for readability and disables
+    Rich's automatic detection for markup, emoji, and highlighting to prevent
+    interference with raw error data.
     """
+
+    def __init__(self, *, file: IO[str] | None = None) -> None:
+        """Cmd2ExceptionConsole initializer.
+
+        :param file: optional file object where the console should write to.
+                     Defaults to sys.stdout.
+        """
+        super().__init__(
+            file=file,
+            soft_wrap=False,
+            markup=False,
+            emoji=False,
+            highlight=False,
+        )
 
 
 def console_width() -> int:

--- a/cmd2/string_utils.py
+++ b/cmd2/string_utils.py
@@ -95,7 +95,10 @@ def stylize(val: str, style: StyleType) -> str:
 
 
 def strip_style(val: str) -> str:
-    """Strip all ANSI style sequences from a string.
+    """Strip all ANSI style sequences (colors, bold, etc.) from a string.
+
+    This targets SGR sequences specifically and leaves other terminal
+    control codes intact.
 
     :param val: string to be stripped
     :return: the stripped string

--- a/tests/test_argparse_custom.py
+++ b/tests/test_argparse_custom.py
@@ -271,13 +271,6 @@ def test_generate_range_error() -> None:
     assert err_str == "expected 0 to 2 arguments"
 
 
-def test_apcustom_required_options() -> None:
-    # Make sure a 'required arguments' section shows when a flag is marked required
-    parser = Cmd2ArgumentParser()
-    parser.add_argument('--required_flag', required=True)
-    assert 'Required Arguments' in parser.format_help()
-
-
 def test_apcustom_metavar_tuple() -> None:
     # Test the case when a tuple metavar is used with nargs an integer > 1
     parser = Cmd2ArgumentParser()

--- a/tests/test_async_alert.py
+++ b/tests/test_async_alert.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import cmd2
+import cmd2.cmd2  # to patch vt100_support
+from cmd2 import rich_utils as ru
+
+
+class TestAsyncAlert(unittest.TestCase):
+    def test_async_alert_strips_ansi_when_allow_style_is_never(self):
+        app = cmd2.Cmd()
+
+        # Patch vt100_support to True
+        with patch('cmd2.cmd2.vt100_support', True):
+            # Patch threading functions
+            mock_current_thread = MagicMock()
+            mock_current_thread.name = "NotMainThread"
+
+            with (
+                patch('threading.current_thread', return_value=mock_current_thread),
+                patch('threading.main_thread', return_value=MagicMock()),
+                patch('cmd2.cmd2.rl_get_display_prompt', return_value='(Cmd) '),
+                patch('cmd2.cmd2.readline.get_line_buffer', return_value=''),
+                patch('cmd2.cmd2.rl_get_point', return_value=0),
+                patch('cmd2.cmd2.rl_force_redisplay'),
+                patch('sys.stdout', new_callable=MagicMock) as mock_stdout,
+            ):
+                # Set allow_style to NEVER
+                app.allow_style = ru.AllowStyle.NEVER
+
+                # Styled message
+                msg = "\033[31mError\033[0m"
+
+                # Call async_alert
+                app.async_alert(msg)
+
+                # Capture calls to write
+                # mock_stdout.write.call_args_list -> [call(str), call(str)...]
+                # We look at all written strings
+                written_content = "".join([call.args[0] for call in mock_stdout.write.call_args_list])
+
+                # Check that ANSI codes for color are NOT present
+                if "\033[31m" in written_content:
+                    raise AssertionError(f"Found ANSI color code in output: {written_content!r}")
+                if "Error" not in written_content:
+                    raise AssertionError(f"Message 'Error' not found in output: {written_content!r}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -1739,7 +1739,7 @@ def test_help_with_no_docstring(capsys) -> None:
         out
         == """Usage: greet [-h] [-s]
 
-Optional Arguments:
+Options:
   -h, --help   show this help message and exit
   -s, --shout  N00B EMULATION MODE
 

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -3019,6 +3019,9 @@ def test_ansi_terminal_tty(mocker, capsys) -> None:
     app = AnsiApp()
     mocker.patch.object(app.stdout, 'isatty', return_value=True)
     mocker.patch.object(sys.stderr, 'isatty', return_value=True)
+    # Simulate a color-capable terminal: TERMINAL mode respects the TERM env var,
+    # so TERM=dumb would suppress colors even with isatty=True.
+    mocker.patch.dict('os.environ', {'TERM': 'xterm-256color'})
 
     app.onecmd_plus_hooks('echo_error oopsie')
     # if colors are on, the output should have some ANSI style sequences in it

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -6,9 +6,7 @@ import os
 import signal
 import sys
 import tempfile
-from code import (
-    InteractiveConsole,
-)
+from code import InteractiveConsole
 from typing import NoReturn
 from unittest import mock
 
@@ -2128,6 +2126,22 @@ def test_read_command_line_eof(base_app, monkeypatch) -> None:
 
     line = base_app._read_command_line("Prompt> ")
     assert line == 'eof'
+
+
+def test_print_to_custom_console(base_app) -> None:
+    console = ru.Cmd2GeneralConsole()
+    with console.capture() as capture:
+        base_app.print_to(console, "hello")
+    assert capture.get() == "hello\n"
+
+
+def test_print_to_invalid_console_type(base_app) -> None:
+    from rich.console import Console
+
+    console = Console()
+    with pytest.raises(TypeError) as excinfo:
+        base_app.print_to(console, "hello")
+    assert "destination must be a 'Cmd2BaseConsole'" in str(excinfo.value)
 
 
 def test_poutput_string(outsim_app) -> None:

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -2128,22 +2128,6 @@ def test_read_command_line_eof(base_app, monkeypatch) -> None:
     assert line == 'eof'
 
 
-def test_print_to_custom_console(base_app) -> None:
-    console = ru.Cmd2GeneralConsole()
-    with console.capture() as capture:
-        base_app.print_to(console, "hello")
-    assert capture.get() == "hello\n"
-
-
-def test_print_to_invalid_console_type(base_app) -> None:
-    from rich.console import Console
-
-    console = Console()
-    with pytest.raises(TypeError) as excinfo:
-        base_app.print_to(console, "hello")
-    assert "destination must be a 'Cmd2BaseConsole'" in str(excinfo.value)
-
-
 def test_poutput_string(outsim_app) -> None:
     msg = 'This is a test'
     outsim_app.poutput(msg)

--- a/tests/test_rich_utils.py
+++ b/tests/test_rich_utils.py
@@ -13,6 +13,8 @@ from cmd2 import (
 )
 from cmd2 import rich_utils as ru
 
+from .conftest import with_ansi_style
+
 
 def test_cmd2_base_console() -> None:
     # Test the keyword arguments which are not allowed.
@@ -142,3 +144,51 @@ def test_from_ansi_wrapper() -> None:
     # Test empty string
     input_string = ""
     assert Text.from_ansi(input_string).plain == input_string
+
+
+@with_ansi_style(ru.AllowStyle.ALWAYS)
+def test_cmd2_base_console_print() -> None:
+    """Test that Cmd2BaseConsole.print() correctly propagates formatting overrides to structured renderables."""
+    from rich.rule import Rule
+
+    # Create a console that defaults to no formatting
+    console = ru.Cmd2BaseConsole(emoji=False, markup=False)
+
+    # Use a Rule with emoji and markup in the title
+    rule = Rule(title="[green]Success :1234:[/green]")
+
+    with console.capture() as capture:
+        # Override settings in the print() call
+        console.print(rule, emoji=True, markup=True)
+
+    result = capture.get()
+
+    # Verify that the overrides were respected by checking for the emoji and the color code
+    assert "🔢" in result
+    assert "\x1b[32mSuccess" in result
+
+
+@with_ansi_style(ru.AllowStyle.ALWAYS)
+def test_cmd2_base_console_log() -> None:
+    """Test that Cmd2BaseConsole.log() correctly propagates formatting overrides to structured renderables."""
+    from rich.rule import Rule
+
+    # Create a console that defaults to no formatting
+    console = ru.Cmd2BaseConsole(emoji=False, markup=False)
+
+    # Use a Rule with emoji and markup in the title
+    rule = Rule(title="[green]Success :1234:[/green]")
+
+    with console.capture() as capture:
+        # Override settings in the log() call
+        console.log(rule, emoji=True, markup=True)
+
+    result = capture.get()
+
+    # Verify that the formatting overrides were respected
+    assert "🔢" in result
+    assert "\x1b[32mSuccess" in result
+
+    # Verify stack offset: the log line should point to this file, not rich_utils.py
+    # Rich logs include the filename and line number on the right.
+    assert "test_rich_utils.py" in result

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -150,7 +150,7 @@ def test_preserve_non_style_csi() -> None:
 
 
 def test_preserve_private_modes() -> None:
-    # Test that DEC private modes (containing '?') are not stripped
+    # Test that DEC Private Modes (containing '?') are not stripped
     # Hide cursor (\x1b[?25l) and Show cursor (\x1b[?25h)
     hide_cursor = "\x1b[?25l"
     show_cursor = "\x1b[?25h"

--- a/tests/transcripts/from_cmdloop.txt
+++ b/tests/transcripts/from_cmdloop.txt
@@ -6,11 +6,11 @@ Usage: speak [-h] [-p] [-s] [-r REPEAT]/ */
 
 Repeats what you tell me to./ */
 
-Optional Arguments:/ */
-  -h, --help           show this help message and exit/ */
-  -p, --piglatin       atinLay/ */
-  -s, --shout          N00B EMULATION MODE/ */
-  -r, --repeat REPEAT  output [n] times/ */
+Options:/ */
+  -h, --help/ */show this help message and exit/ */
+  -p, --piglatin/ */atinLay/ */
+  -s, --shout/ */N00B EMULATION MODE/ */
+  -r, --repeat REPEAT/ */output [n] times/ */
 
 (Cmd) say goodnight, Gracie
 goodnight, Gracie


### PR DESCRIPTION
Hi

I am the Debian package maintainer for cmd2. While updating the package to
version 3.4.0 and running the test suite in the Debian build infrastructure
(sbuild/autopkgtest), I encountered 16 test failures related to ANSI color
output.

The Debian build infrastructure always sets TERM=dumb to prevent any
interactive terminal usage during builds. This exposed a bug in cmd2: even
with ALLOW_STYLE=ALWAYS explicitly set, all ANSI sequences were silently
stripped and no colors were emitted.

The root cause is in Rich's Console initialization. When color_system is not
explicitly specified, Rich calls _detect_color_system() to auto-detect the
terminal capabilities. With TERM=dumb, is_dumb_terminal returns True and
_detect_color_system() returns None — meaning no color support — regardless
of force_terminal=True. So force_terminal=True alone is not sufficient to
guarantee color output when the terminal is detected as dumb.

This affects two places in rich_utils.py:
- Cmd2BaseConsole.__init__() sets force_terminal=True when ALLOW_STYLE=ALWAYS
  but does not set color_system, so Rich silently discards all colors.
- rich_text_to_string() has the same issue.

The fix passes color_system="truecolor" explicitly in both places when the
intent is to always emit ANSI styles, bypassing the broken auto-detection.
The default mode (TERMINAL) is unaffected and continues to respect TERM=dumb
as expected.

Additionally, test_ansi_terminal_tty was implicitly relying on the developer's
TERM environment variable. The fix adds a mock for TERM=xterm-256color to make
the test self-contained and environment-independent.

Nilson Silva