### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,13 +64,10 @@ See the `dependencies` list under the `[project]` heading in [pyproject.toml](..
 | Prerequisite                                                              | Minimum Version | Purpose                                                |
 | ------------------------------------------------------------------------- | --------------- | ------------------------------------------------------ |
 | [prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) | `3.0.52`        | Replacement for GNU `readline` that is cross-platform  |
-| [python](https://www.python.org/downloads/)                               | `3.10`          | Python programming language                            |
+| [python](https://www.python.org/downloads/)                               | `3.11`          | Python programming language                            |
 | [pyperclip](https://github.com/asweigart/pyperclip)                       | `1.8`           | Cross-platform clipboard functions                     |
 | [rich](https://github.com/Textualize/rich)                                | `14.3.0`        | Add rich text and beautiful formatting in the terminal |
 | [rich-argparse](https://github.com/hamdanal/rich-argparse)                | `1.7.1`         | A rich-enabled help formatter for argparse             |
-
-> Python 3.10 depends on [backports.strenum](https://github.com/clbarnes/backports.strenum) to use
-> the `enum.StrEnum` class introduced in Python 3.11.
 
 #### Additional prerequisites to build and publish cmd2
 
@@ -120,7 +117,7 @@ Linux). You can install `uv` using instructions at the link above.
 You can then install multiple versions of Python using `uv` like so:
 
 ```sh
-uv python install 3.10 3.11 3.12 3.13
+uv python install 3.11 3.12 3.13 3.14
 ```
 
 ### Forking the project

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.8"
+    rev: "v0.15.13"
     hooks:
       - id: ruff-format
         args: [--config=ruff.toml]
@@ -26,11 +26,11 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier@3.8.1
+          - prettier@3.8.3
           - prettier-plugin-toml@2.0.6
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.44.0
+    rev: v1.46.1
     hooks:
       - id: typos
         exclude: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ prompt is displayed.
       each platform and provided utility functions related to `readline`
     - Added a dependency on `prompt-toolkit` and a new `cmd2.pt_utils` module with supporting
       utilities
+    - Dropped support for Python 3.10. `cmd2` now requires Python 3.11 or later
     - Removed **Transcript Testing** feature set along with the `history -t` option for generating
       transcript files and the `cmd2.transcript` module
         - This was an extremely brittle regression testing framework which should never have been

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On all operating systems, the latest stable version of `cmd2` can be installed u
 pip install -U cmd2
 ```
 
-cmd2 works with Python 3.10+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party
+cmd2 works with Python 3.11+ on Windows, macOS, and Linux. It is pure Python code with few 3rd-party
 dependencies. It works with both conventional CPython and free-threaded variants.
 
 For information on other installation options, see

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3114,7 +3114,7 @@ class Cmd:
         while True:
             try:
                 return self._check_statement_complete(line)
-            except IncompleteStatement:  # noqa: PERF203
+            except IncompleteStatement:
                 # If incomplete, we need to fetch the next line
                 try:
                     try:

--- a/cmd2/colors.py
+++ b/cmd2/colors.py
@@ -1,11 +1,6 @@
 """Provides a convenient StrEnum for Rich color names."""
 
-import sys
-
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    from backports.strenum import StrEnum
+from enum import StrEnum
 
 
 class Color(StrEnum):

--- a/cmd2/completion.py
+++ b/cmd2/completion.py
@@ -2,7 +2,6 @@
 
 import copy
 import re
-import sys
 from collections.abc import (
     Iterable,
     Iterator,
@@ -14,22 +13,16 @@ from dataclasses import (
 )
 from typing import (
     Any,
+    Self,
     cast,
     overload,
 )
 
+from rich.protocol import is_renderable
 from rich.table import Table
 
-from . import string_utils as su
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
-from rich.protocol import is_renderable
-
 from . import rich_utils as ru
+from . import string_utils as su
 
 
 class _UnsetStr(str):

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -2,7 +2,6 @@
 
 import re
 import shlex
-import sys
 from collections.abc import (
     Iterable,
     Mapping,
@@ -16,12 +15,8 @@ from dataclasses import (
 from typing import (
     Any,
     ClassVar,
+    Self,
 )
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 from . import (
     constants,

--- a/cmd2/styles.py
+++ b/cmd2/styles.py
@@ -26,18 +26,13 @@ For prompt-toolkit default styles, see:
 https://github.com/prompt-toolkit/python-prompt-toolkit/blob/main/src/prompt_toolkit/styles/defaults.py
 """
 
-import sys
+from enum import StrEnum
 
 from rich.style import (
     Style,
     StyleType,
 )
 from rich_argparse import RichHelpFormatter
-
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    from backports.strenum import StrEnum
 
 from .colors import Color
 

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -1,7 +1,7 @@
 # Installation Instructions
 
 `cmd2` works on :simple-linux: Linux, :simple-apple: macOS, and :fontawesome-brands-windows:
-Windows. It requires Python 3.10 or higher, [pip](https://pypi.org/project/pip), and
+Windows. It requires Python 3.11 or higher, [pip](https://pypi.org/project/pip), and
 [setuptools](https://pypi.org/project/setuptools). If you've got all that, then you can just:
 
 ```shell
@@ -22,7 +22,7 @@ $ pip install cmd2
 
 ## Prerequisites
 
-If you have Python >=3.10 installed from [python.org](https://www.python.org), you will already have
+If you have Python >=3.11 installed from [python.org](https://www.python.org), you will already have
 [pip](https://pypi.org/project/pip) and [setuptools](https://pypi.org/project/setuptools), but may
 need to upgrade to the latest versions:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python"
 authors = [{ name = "cmd2 Contributors" }]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = ["CLI", "cmd", "command", "interactive", "prompt", "Python"]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -19,7 +19,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -29,12 +28,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "backports.strenum; python_version == '3.10'",
     "prompt-toolkit>=3.0.52",
     "pyperclip>=1.8.2",
     "rich>=15.0.0",
     "rich-argparse>=1.7.2",
-    "typing-extensions; python_version == '3.10'",
 ]
 
 [dependency-groups]

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,7 +31,7 @@ exclude = [
 # Same as Black.
 line-length = 127
 indent-width = 4
-target-version = "py310" # Minimum supported version of Python
+target-version = "py311" # Minimum supported version of Python
 output-format = "full"
 
 [lint]


### PR DESCRIPTION
This PR changes `cmd2` to require Python 3.11 or newer.