### PR TITLE
Refactor and standardize argparse-related naming and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,10 @@ prompt is displayed.
     - Removed `Cmd.ruler` since `cmd2` no longer uses it.
     - All parsers used with `cmd2` commands must be an instance of `Cmd2ArgumentParser` or a child
       class of it.
-    - Removed `set_ap_completer_type()` and `get_ap_completer_type()` since `ap_completer_type` is
-      now a public member of `Cmd2ArgumentParser`.
+    - Renamed `set_default_argument_parser_type()` to `set_default_argument_parser()`.
+    - Renamed `set_default_ap_completer_type()` to `set_default_argparse_completer()`.
+    - Removed `set_ap_completer_type()` and `get_ap_completer_type()` since `completer_class` is now
+      a public member of `Cmd2ArgumentParser`.
     - Moved `set_parser_prog()` to `Cmd2ArgumentParser.update_prog()`.
     - Renamed `cmd2_handler` to `cmd2_subcommand_func` in the `argparse.Namespace` for clarity.
     - Removed `Cmd2AttributeWrapper` class. `argparse.Namespace` objects passed to command functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ prompt is displayed.
     - Removed `set_ap_completer_type()` and `get_ap_completer_type()` since `ap_completer_type` is
       now a public member of `Cmd2ArgumentParser`.
     - Moved `set_parser_prog()` to `Cmd2ArgumentParser.update_prog()`.
-    - Renamed `cmd2_handler` to `cmd2_subcmd_handler` in the `argparse.Namespace` for clarity.
+    - Renamed `cmd2_handler` to `cmd2_subcommand_func` in the `argparse.Namespace` for clarity.
     - Removed `Cmd2AttributeWrapper` class. `argparse.Namespace` objects passed to command functions
-      now contain direct attributes for `cmd2_statement` and `cmd2_subcmd_handler`.
+      now contain direct attributes for `cmd2_statement` and `cmd2_subcommand_func`.
     - Renamed `cmd2/command_definition.py` to `cmd2/command_set.py`.
     - Removed `Cmd.doc_header` and the `with_default_category` decorator. Help categorization is now
       driven by the `DEFAULT_CATEGORY` class variable (see **Simplified command categorization** in

--- a/cmd2/__init__.py
+++ b/cmd2/__init__.py
@@ -12,12 +12,12 @@ from . import (
     string_utils,
 )
 from .annotated import with_annotated
-from .argparse_completer import set_default_ap_completer_type
+from .argparse_completer import set_default_argparse_completer
 from .argparse_utils import (
     Cmd2ArgumentParser,
     SubcommandRecord,
     register_argparse_argument_parameter,
-    set_default_argument_parser_type,
+    set_default_argument_parser,
 )
 from .cmd2 import Cmd
 from .colors import Color
@@ -75,8 +75,8 @@ __all__: list[str] = [  # noqa: RUF022
     "Cmd2ArgumentParser",
     "SubcommandRecord",
     "register_argparse_argument_parameter",
-    "set_default_ap_completer_type",
-    "set_default_argument_parser_type",
+    "set_default_argparse_completer",
+    "set_default_argument_parser",
     # Cmd2
     "Cmd",
     "CommandResult",

--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -212,7 +212,6 @@ from rich.table import Column
 
 from . import constants
 from .argparse_utils import (
-    DEFAULT_ARGUMENT_PARSER,
     ArgparseCommandSpec,
     Cmd2ArgumentParser,
     SubcommandSpec,
@@ -1968,7 +1967,9 @@ def build_parser_from_function(
     :param parser_kwargs: forwarded [`Cmd2ParserKwargs`][cmd2.annotated.Cmd2ParserKwargs]
     :return: a fully configured ``Cmd2ArgumentParser``
     """
-    parser_cls = parser_class or DEFAULT_ARGUMENT_PARSER
+    from . import argparse_utils
+
+    parser_cls = parser_class or argparse_utils.DEFAULT_ARGUMENT_PARSER
     if "description" not in parser_kwargs:
         auto_description = _docstring_first_paragraph(func.__doc__)
         if auto_description is not None:

--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -213,7 +213,7 @@ from rich.table import Column
 from . import constants
 from .argparse_utils import (
     DEFAULT_ARGUMENT_PARSER,
-    ApCommandSpec,
+    ArgparseCommandSpec,
     Cmd2ArgumentParser,
     SubcommandSpec,
 )
@@ -2329,11 +2329,11 @@ def with_annotated(
             )
             return result
 
-        ap_command_spec = ApCommandSpec(
+        argparse_command_spec = ArgparseCommandSpec(
             parser_source=parser_builder,
             preserve_quotes=preserve_quotes,
         )
-        setattr(cmd_wrapper, constants.AP_COMMAND_ATTR_SPEC, ap_command_spec)
+        setattr(cmd_wrapper, constants.ARGPARSE_COMMAND_ATTR_SPEC, argparse_command_spec)
 
         return cmd_wrapper
 

--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -118,7 +118,7 @@ Parser-level customization is forwarded to [`Cmd2ArgumentParser`][cmd2.argparse_
 692 ``**parser_kwargs: Unpack[Cmd2ParserKwargs]``.  Anything the parser ctor accepts -- ``description``,
 ``epilog``, ``prog``, ``usage``, ``parents``, ``argument_default``, ``prefix_chars``,
 ``fromfile_prefix_chars``, ``conflict_handler``, ``add_help``, ``allow_abbrev``, ``exit_on_error``,
-``formatter_class``, ``ap_completer_type``, and on Python >= 3.14 ``suggest_on_error`` / ``color`` --
+``formatter_class``, ``completer_class``, and on Python >= 3.14 ``suggest_on_error`` / ``color`` --
 flows straight through; the [`Cmd2ParserKwargs`][cmd2.annotated.Cmd2ParserKwargs] ``TypedDict`` is the single source of truth
 and gives type-checkers/IDEs autocomplete on the decorator's call site.  ``parser_class`` stays as
 its own explicit kwarg because it selects the class itself, not a value passed to it.  Two
@@ -257,7 +257,7 @@ class Cmd2ParserKwargs(TypedDict, total=False):
     exit_on_error: bool
     suggest_on_error: bool
     color: bool
-    ap_completer_type: "type[ArgparseCompleter] | None"
+    completer_class: "type[ArgparseCompleter] | None"
 
 
 # ---------------------------------------------------------------------------

--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -18,7 +18,7 @@ collected into a tuple.  Underscores in a parameter name become dashes in the ge
 flag (``dry_run`` -> ``--dry-run``); pass an explicit ``Option("--my_flag")`` to opt out.
 Positional-only parameters (before ``/``) and ``**kwargs`` raise ``TypeError``.  The parameter
 names ``dest`` and ``subcommand`` are reserved; ``cmd2_statement`` receives the parsed
-``Statement`` and (with ``base_command=True``) ``cmd2_handler`` receives the subcommand handler:
+``Statement`` and (with ``base_command=True``) ``cmd2_subcommand_func`` receives the subcommand handler:
 
     class MyApp(cmd2.Cmd):
         @cmd2.with_annotated
@@ -1704,7 +1704,7 @@ _CONSTRAINTS: list[_Rule[_ArgparseArgument, Exception | None]] = [
 
 # Parameters handled specially by the decorator and not added to the parser.  The first positional
 # parameter (self/cls) is always skipped by position; these cover additional decorator-managed names.
-_SKIP_PARAMS = frozenset({"cmd2_handler", "cmd2_statement"})
+_SKIP_PARAMS = frozenset({constants.NS_ATTR_SUBCOMMAND_FUNC, constants.NS_ATTR_STATEMENT})
 
 
 def _link_group_membership(
@@ -1735,14 +1735,17 @@ def _resolve_parameters(
     """Resolve a function signature into a list of argparse-argument builders.
 
     ``base_command`` marks each argument's context for the base-command :data:`_CONSTRAINTS` rows and
-    drives the function-level ``cmd2_handler`` check below.  ``groups``/``mutually_exclusive_groups``
+    drives the function-level ``cmd2_subcommand_func`` check below.  ``groups``/``mutually_exclusive_groups``
     are linked onto each argument as membership facts for the cross-config constraint rows.
     """
     sig = inspect.signature(func)
     # Function-level check (not a per-argument _CONSTRAINTS row): a base command dispatches through
-    # cmd2_handler, so it must exist.  Here so it also fires when the function has zero parameters.
-    if base_command and "cmd2_handler" not in sig.parameters:
-        raise TypeError(f"with_annotated(base_command=True) requires a 'cmd2_handler' parameter in {func.__qualname__}")
+    # cmd2_subcommand_func, so it must exist.  Here so it also fires when the function has zero parameters.
+    if base_command and constants.NS_ATTR_SUBCOMMAND_FUNC not in sig.parameters:
+        raise TypeError(
+            f"with_annotated(base_command=True) requires a '{constants.NS_ATTR_SUBCOMMAND_FUNC}' "
+            f"parameter in {func.__qualname__}"
+        )
     try:
         hints = get_type_hints(func, include_extras=True)
     except (NameError, AttributeError, TypeError) as exc:
@@ -1848,8 +1851,6 @@ def _filtered_namespace_kwargs(
     filtered: dict[str, Any] = {}
     for key, value in vars(ns).items():
         if accepted is not None and key not in accepted:
-            continue
-        if key == constants.NS_ATTR_SUBCOMMAND_FUNC:
             continue
         if exclude_subcommand and key == "subcommand":
             continue
@@ -2120,10 +2121,10 @@ def _build_subcommand_handler(
     def handler(self_arg: Any, ns: Any) -> Any:
         """Unpack Namespace into typed kwargs for the subcommand handler."""
         filtered = _filtered_namespace_kwargs(ns, accepted=_accepted)
-        if "cmd2_handler" in filtered:
-            cmd2_h = filtered["cmd2_handler"]
+        if constants.NS_ATTR_SUBCOMMAND_FUNC in filtered:
+            cmd2_h = filtered[constants.NS_ATTR_SUBCOMMAND_FUNC]
             if isinstance(cmd2_h, functools.partial) and cmd2_h.func is handler:
-                filtered["cmd2_handler"] = None
+                filtered[constants.NS_ATTR_SUBCOMMAND_FUNC] = None
         return _invoke_command_func(
             func, self_arg, filtered, leading_names=_leading_names, var_positional_name=_var_positional_name
         )
@@ -2185,7 +2186,7 @@ def with_annotated(
     :param ns_provider: callable returning a prepopulated Namespace (not with ``subcommand_to``)
     :param preserve_quotes: preserve quotes in arguments (not with ``subcommand_to``)
     :param with_unknown_args: capture unknown args as the ``_unknown`` kwarg (not with ``subcommand_to``)
-    :param base_command: add ``add_subparsers()``; requires a ``cmd2_handler`` param and no positionals
+    :param base_command: add ``add_subparsers()``; requires a ``cmd2_subcommand_func`` param and no positionals
     :param subcommand_to: parent command name; function must be named ``{parent_underscored}_{subcommand}``
     :param help: subcommand help text (only with ``subcommand_to``)
     :param aliases: alternative subcommand names (only with ``subcommand_to``)
@@ -2247,9 +2248,10 @@ def with_annotated(
             if unknown_param.kind is inspect.Parameter.POSITIONAL_ONLY:
                 raise TypeError("Parameter _unknown must be keyword-compatible when with_unknown_args=True")
 
-        if not base_command and "cmd2_handler" in inspect.signature(fn).parameters:
+        if not base_command and constants.NS_ATTR_SUBCOMMAND_FUNC in inspect.signature(fn).parameters:
             raise TypeError(
-                f"Parameter 'cmd2_handler' in {fn.__qualname__} is only valid when with_annotated(base_command=True) is used."
+                f"Parameter '{constants.NS_ATTR_SUBCOMMAND_FUNC}' in {fn.__qualname__} "
+                "is only valid when with_annotated(base_command=True) is used."
             )
 
         if subcommand_to is not None:
@@ -2314,7 +2316,7 @@ def with_annotated(
             handler = getattr(ns, constants.NS_ATTR_SUBCOMMAND_FUNC, None)
             if base_command and handler is not None:
                 handler = functools.partial(handler, ns)
-            ns.cmd2_handler = handler
+            setattr(ns, constants.NS_ATTR_SUBCOMMAND_FUNC, handler)
 
             func_kwargs = _filtered_namespace_kwargs(ns, accepted=accepted, exclude_subcommand=base_command)
 

--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -181,8 +181,16 @@ import enum
 import functools
 import inspect
 import types
-from collections.abc import Callable, Container, Iterable, Sequence
-from dataclasses import dataclass, field
+from collections.abc import (
+    Callable,
+    Container,
+    Iterable,
+    Sequence,
+)
+from dataclasses import (
+    dataclass,
+    field,
+)
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -203,12 +211,21 @@ from typing import (
 from rich.table import Column
 
 from . import constants
-from .argparse_utils import DEFAULT_ARGUMENT_PARSER, Cmd2ArgumentParser, SubcommandSpec
+from .argparse_utils import (
+    DEFAULT_ARGUMENT_PARSER,
+    ApCommandSpec,
+    Cmd2ArgumentParser,
+    SubcommandSpec,
+)
 from .completion import CompletionItem
 from .decorators import _parse_positionals
 from .exceptions import Cmd2ArgparseError
 from .rich_utils import Cmd2HelpFormatter, HelpContent
-from .types import CmdOrSetT, UnboundChoicesProvider, UnboundCompleter
+from .types import (
+    CmdOrSetT,
+    UnboundChoicesProvider,
+    UnboundCompleter,
+)
 
 if TYPE_CHECKING:
     from .argparse_completer import ArgparseCompleter
@@ -1828,13 +1845,11 @@ def _filtered_namespace_kwargs(
     exclude_subcommand: bool = False,
 ) -> dict[str, Any]:
     """Filter a parsed Namespace down to user-visible kwargs."""
-    from .constants import NS_ATTR_SUBCMD_HANDLER
-
     filtered: dict[str, Any] = {}
     for key, value in vars(ns).items():
         if accepted is not None and key not in accepted:
             continue
-        if key == NS_ATTR_SUBCMD_HANDLER:
+        if key == constants.NS_ATTR_SUBCOMMAND_FUNC:
             continue
         if exclude_subcommand and key == "subcommand":
             continue
@@ -2244,7 +2259,7 @@ def with_annotated(
                 base_command=base_command,
                 options=options,
             )
-            spec = SubcommandSpec(
+            subcommand_spec = SubcommandSpec(
                 name=subcmd_name,
                 command=subcommand_to,
                 help=help,
@@ -2252,7 +2267,7 @@ def with_annotated(
                 deprecated=deprecated,
                 parser_source=subcmd_parser_builder,
             )
-            setattr(handler, constants.SUBCMD_ATTR_SPEC, spec)
+            setattr(handler, constants.SUBCOMMAND_ATTR_SPEC, subcommand_spec)
             return handler
 
         command_name = fn.__name__[len(constants.COMMAND_FUNC_PREFIX) :]
@@ -2296,7 +2311,7 @@ def with_annotated(
                 raise Cmd2ArgparseError from exc
 
             setattr(ns, constants.NS_ATTR_STATEMENT, statement)
-            handler = getattr(ns, constants.NS_ATTR_SUBCMD_HANDLER, None)
+            handler = getattr(ns, constants.NS_ATTR_SUBCOMMAND_FUNC, None)
             if base_command and handler is not None:
                 handler = functools.partial(handler, ns)
             ns.cmd2_handler = handler
@@ -2312,8 +2327,11 @@ def with_annotated(
             )
             return result
 
-        setattr(cmd_wrapper, constants.CMD_ATTR_PARSER_SOURCE, parser_builder)
-        setattr(cmd_wrapper, constants.CMD_ATTR_PRESERVE_QUOTES, preserve_quotes)
+        ap_command_spec = ApCommandSpec(
+            parser_source=parser_builder,
+            preserve_quotes=preserve_quotes,
+        )
+        setattr(cmd_wrapper, constants.AP_COMMAND_ATTR_SPEC, ap_command_spec)
 
         return cmd_wrapper
 

--- a/cmd2/argparse_completer.py
+++ b/cmd2/argparse_completer.py
@@ -366,8 +366,7 @@ class ArgparseCompleter:
                                 parent_tokens[action.dest] = [token]
 
                             parser = self._subcommand_action.choices[token]
-                            completer_type = self._cmd_app._determine_ap_completer_type(parser)
-                            completer = completer_type(parser, self._cmd_app, parent_tokens=parent_tokens)
+                            completer = parser.completer_class(parser, self._cmd_app, parent_tokens=parent_tokens)
                             return completer.complete(text, line, begidx, endidx, tokens[token_index + 1 :], cmd_set=cmd_set)
 
                         # Invalid subcommand entered, so no way to complete remaining tokens
@@ -668,8 +667,7 @@ class ArgparseCompleter:
             for token_index, token in enumerate(tokens):
                 if token in self._subcommand_action.choices:
                     parser = self._subcommand_action.choices[token]
-                    completer_type = self._cmd_app._determine_ap_completer_type(parser)
-                    completer = completer_type(parser, self._cmd_app)
+                    completer = parser.completer_class(parser, self._cmd_app)
                     return completer.complete_subcommand_help(text, line, begidx, endidx, tokens[token_index + 1 :])
 
                 if token_index == len(tokens) - 1:
@@ -690,8 +688,7 @@ class ArgparseCompleter:
         if tokens and self._subcommand_action is not None:
             parser = self._subcommand_action.choices.get(tokens[0])
             if parser is not None:
-                completer_type = self._cmd_app._determine_ap_completer_type(parser)
-                completer = completer_type(parser, self._cmd_app)
+                completer = parser.completer_class(parser, self._cmd_app)
                 completer.print_help(tokens[1:], file)
                 return
         self._parser.print_help(file)
@@ -800,13 +797,13 @@ class ArgparseCompleter:
 
 
 # The default ArgparseCompleter class for a cmd2 app
-DEFAULT_AP_COMPLETER: type[ArgparseCompleter] = ArgparseCompleter
+DEFAULT_ARGPARSE_COMPLETER: type[ArgparseCompleter] = ArgparseCompleter
 
 
-def set_default_ap_completer_type(completer_type: type[ArgparseCompleter]) -> None:
+def set_default_argparse_completer(completer_class: type[ArgparseCompleter]) -> None:
     """Set the default ArgparseCompleter class for a cmd2 app.
 
-    :param completer_type: Type that is a subclass of ArgparseCompleter.
+    :param completer_class: Type that is a subclass of ArgparseCompleter.
     """
-    global DEFAULT_AP_COMPLETER  # noqa: PLW0603
-    DEFAULT_AP_COMPLETER = completer_type
+    global DEFAULT_ARGPARSE_COMPLETER  # noqa: PLW0603
+    DEFAULT_ARGPARSE_COMPLETER = completer_class

--- a/cmd2/argparse_utils.py
+++ b/cmd2/argparse_utils.py
@@ -292,11 +292,31 @@ ParserSource: TypeAlias = Union[
 
 
 @dataclass(kw_only=True)
+class ApCommandSpec:
+    """Metadata for an argparse-based command function.
+
+    :param parser_source: an existing Cmd2ArgumentParser instance or a factory
+                          (callable, staticmethod, or classmethod) that returns one.
+    :param preserve_quotes: if True, then arguments passed to argparse maintain their quotes
+    """
+
+    parser_source: ParserSource[Any]
+    preserve_quotes: bool = False
+
+
+@dataclass(kw_only=True)
 class _SubcommandBase:
-    """Base metadata shared by all subcommand representations."""
+    """Base metadata shared by all subcommand representations.
+
+    :param name: the name of the subcommand
+    :param command: the full parent command path (e.g., 'foo bar')
+    :param help: optional help message for this subcommand
+    :param aliases: optional alternative names for this subcommand
+    :param deprecated: whether this subcommand is deprecated (requires Python 3.13+).
+    """
 
     name: str
-    command: str  # The full parent command path (e.g., 'foo bar')
+    command: str
     help: str | None = None
     aliases: tuple[str, ...] = ()
     deprecated: bool = False
@@ -304,7 +324,11 @@ class _SubcommandBase:
 
 @dataclass(kw_only=True)
 class SubcommandSpec(_SubcommandBase):
-    """Metadata used to build and register a subcommand."""
+    """Metadata used to build and register a subcommand.
+
+    :param parser_source: an existing Cmd2ArgumentParser instance or a factory
+                          (callable, staticmethod, or classmethod) that returns one.
+    """
 
     parser_source: ParserSource[Any]
 
@@ -314,6 +338,8 @@ class SubcommandRecord(_SubcommandBase):
     """A record of a subcommand's configuration and parser.
 
     Used primarily for attaching and detaching subcommands.
+
+    :param parser: the built Cmd2ArgumentParser instance for this subcommand
     """
 
     parser: "Cmd2ArgumentParser"

--- a/cmd2/argparse_utils.py
+++ b/cmd2/argparse_utils.py
@@ -728,13 +728,13 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
         suggest_on_error: bool = False,
         color: bool = False,
         *,
-        ap_completer_type: type["ArgparseCompleter"] | None = None,
+        completer_class: type["ArgparseCompleter"] | None = None,
     ) -> None:
         """Initialize the Cmd2ArgumentParser instance.
 
-        :param ap_completer_type: optional parameter which specifies a subclass of ArgparseCompleter for custom completion
-                                  behavior on this parser. If this is None or not present, then cmd2 will use
-                                  argparse_completer.DEFAULT_AP_COMPLETER when completing this parser's arguments
+        :param completer_class: optional parameter which specifies a subclass of ArgparseCompleter
+                                for custom completion behavior on this parser. If this is None, then
+                                it will be set to argparse_completer.DEFAULT_ARGPARSE_COMPLETER.
         """
         kwargs: dict[str, bool] = {}
         if sys.version_info >= (3, 14):
@@ -761,7 +761,11 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
             **kwargs,
         )
 
-        self.ap_completer_type = ap_completer_type
+        if completer_class is None:
+            from . import argparse_completer
+
+            completer_class = argparse_completer.DEFAULT_ARGPARSE_COMPLETER
+        self.completer_class = completer_class
 
         # To assist type checkers, recast these to reflect our usage of rich-argparse.
         self.formatter_class: type[Cmd2HelpFormatter]
@@ -1087,11 +1091,11 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
 
 # Parser type used by cmd2's built-in commands.
-# Set it using cmd2.set_default_argument_parser_type().
+# Set it using cmd2.set_default_argument_parser().
 DEFAULT_ARGUMENT_PARSER: type[Cmd2ArgumentParser] = Cmd2ArgumentParser
 
 
-def set_default_argument_parser_type(parser_type: type[Cmd2ArgumentParser]) -> None:
+def set_default_argument_parser(parser_class: type[Cmd2ArgumentParser]) -> None:
     """Set the default Cmd2ArgumentParser class for cmd2's built-in commands.
 
     Since built-in commands rely on customizations made in Cmd2ArgumentParser,
@@ -1102,4 +1106,4 @@ def set_default_argument_parser_type(parser_type: type[Cmd2ArgumentParser]) -> N
     See examples/custom_parser.py.
     """
     global DEFAULT_ARGUMENT_PARSER  # noqa: PLW0603
-    DEFAULT_ARGUMENT_PARSER = parser_type
+    DEFAULT_ARGUMENT_PARSER = parser_class

--- a/cmd2/argparse_utils.py
+++ b/cmd2/argparse_utils.py
@@ -292,7 +292,7 @@ ParserSource: TypeAlias = Union[
 
 
 @dataclass(kw_only=True)
-class ApCommandSpec:
+class ArgparseCommandSpec:
     """Metadata for an argparse-based command function.
 
     :param parser_source: an existing Cmd2ArgumentParser instance or a factory

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -111,7 +111,7 @@ from . import (
 from . import rich_utils as ru
 from . import string_utils as su
 from .argparse_utils import (
-    ApCommandSpec,
+    ArgparseCommandSpec,
     Cmd2ArgumentParser,
     ParserSource,
     SubcommandRecord,
@@ -281,7 +281,7 @@ class CommandParsers:
                 return None
             command = command_method.__name__[len(COMMAND_FUNC_PREFIX) :]
 
-            spec: ApCommandSpec | None = getattr(command_method, constants.AP_COMMAND_ATTR_SPEC, None)
+            spec: ArgparseCommandSpec | None = getattr(command_method, constants.ARGPARSE_COMMAND_ATTR_SPEC, None)
             if spec is None:
                 return None
 
@@ -2530,7 +2530,7 @@ class Cmd:
 
                     if command_func is not None and argparser is not None:
                         # Get arguments for complete()
-                        spec: ApCommandSpec = getattr(command_func, constants.AP_COMMAND_ATTR_SPEC)
+                        spec: ArgparseCommandSpec = getattr(command_func, constants.ARGPARSE_COMMAND_ATTR_SPEC)
                         cmd_set = self.find_commandset_for_command(command)
 
                         # Create the argparse completer

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1213,7 +1213,7 @@ class Cmd:
         root_command = tokens[0]
         subcommand_path = tokens[1:]
 
-        # Search for the base command function and verify it has an argparser defined
+        # Search for the base command function and verify it has a parser defined
         command_func = self.get_command_func(root_command)
         if command_func is None:
             raise ValueError(f"Root command '{root_command}' does not exist")
@@ -2449,18 +2449,6 @@ class Cmd:
         # Call the command's completer function
         return compfunc(text, line, begidx, endidx)
 
-    @staticmethod
-    def _determine_ap_completer_type(parser: Cmd2ArgumentParser) -> type[argparse_completer.ArgparseCompleter]:
-        """Determine what type of ArgparseCompleter to use on a given parser.
-
-        If the parser does not have one set, then use argparse_completer.DEFAULT_AP_COMPLETER.
-        :param parser: the parser to examine
-        :return: type of ArgparseCompleter
-        """
-        if parser.ap_completer_type is None:
-            return argparse_completer.DEFAULT_AP_COMPLETER
-        return parser.ap_completer_type
-
     def _perform_completion(
         self, text: str, line: str, begidx: int, endidx: int, custom_settings: utils.CustomCompletionSettings | None = None
     ) -> Completions:
@@ -2526,16 +2514,15 @@ class Cmd:
                 else:
                     # There's no completer function, next see if the command uses argparse
                     command_func = self.get_command_func(command)
-                    argparser = None if command_func is None else self.command_parsers.get(command_func)
+                    parser = None if command_func is None else self.command_parsers.get(command_func)
 
-                    if command_func is not None and argparser is not None:
+                    if command_func is not None and parser is not None:
                         # Get arguments for complete()
                         spec: ArgparseCommandSpec = getattr(command_func, constants.ARGPARSE_COMMAND_ATTR_SPEC)
                         cmd_set = self.find_commandset_for_command(command)
 
                         # Create the argparse completer
-                        completer_type = self._determine_ap_completer_type(argparser)
-                        completer = completer_type(argparser, self)
+                        completer = parser.completer_class(parser, self)
 
                         completer_func = functools.partial(
                             completer.complete, tokens=raw_tokens[1:] if spec.preserve_quotes else tokens[1:], cmd_set=cmd_set
@@ -2550,8 +2537,7 @@ class Cmd:
         # Otherwise we are completing the command token or performing custom completion
         else:
             # Create the argparse completer
-            completer_type = self._determine_ap_completer_type(custom_settings.parser)
-            completer = completer_type(custom_settings.parser, self)
+            completer = custom_settings.parser.completer_class(custom_settings.parser, self)
 
             completer_func = functools.partial(
                 completer.complete, tokens=raw_tokens if custom_settings.preserve_quotes else tokens, cmd_set=None
@@ -4274,11 +4260,11 @@ class Cmd:
 
         # Check if this command uses argparse
         if (command_func := self.get_command_func(command)) is None or (
-            argparser := self.command_parsers.get(command_func)
+            parser := self.command_parsers.get(command_func)
         ) is None:
             return Completions()
 
-        completer = argparse_completer.DEFAULT_AP_COMPLETER(argparser, self)
+        completer = parser.completer_class(parser, self)
         return completer.complete_subcommand_help(text, line, begidx, endidx, arg_tokens["subcommands"])
 
     def _build_command_info(self) -> tuple[dict[str, list[str]], list[str]]:
@@ -4382,11 +4368,11 @@ class Cmd:
                 return
 
             command_func = self.get_command_func(args.command)
-            argparser = None if command_func is None else self.command_parsers.get(command_func)
+            parser = None if command_func is None else self.command_parsers.get(command_func)
 
             # If the command function uses argparse, then use argparse's help
-            if command_func is not None and argparser is not None:
-                completer = argparse_completer.DEFAULT_AP_COMPLETER(argparser, self)
+            if command_func is not None and parser is not None:
+                completer = parser.completer_class(parser, self)
                 completer.print_help(args.subcommands, self.stdout)
 
             # If the command has a custom help function, then call it
@@ -4700,7 +4686,7 @@ class Cmd:
             completer=settable.completer,
         )
 
-        completer = argparse_completer.DEFAULT_AP_COMPLETER(settable_parser, self)
+        completer = settable_parser.completer_class(settable_parser, self)
 
         # Use raw_tokens since quotes have been preserved
         _, raw_tokens = self.tokens_for_completion(line, begidx, endidx)

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -111,6 +111,7 @@ from . import (
 from . import rich_utils as ru
 from . import string_utils as su
 from .argparse_utils import (
+    ApCommandSpec,
     Cmd2ArgumentParser,
     ParserSource,
     SubcommandRecord,
@@ -280,12 +281,12 @@ class CommandParsers:
                 return None
             command = command_method.__name__[len(COMMAND_FUNC_PREFIX) :]
 
-            parser_source = getattr(command_method, constants.CMD_ATTR_PARSER_SOURCE, None)
-            if parser_source is None:
+            spec: ApCommandSpec | None = getattr(command_method, constants.AP_COMMAND_ATTR_SPEC, None)
+            if spec is None:
                 return None
 
             owner = self._cmd_app.find_commandset_for_command(command) or self._cmd_app
-            parser = self._cmd_app._build_parser(owner, parser_source)
+            parser = self._cmd_app._build_parser(owner, spec.parser_source)
 
             # To ensure accurate usage strings, recursively update 'prog' values
             # within the parser to match the command name.
@@ -1063,9 +1064,21 @@ class Cmd:
             self._installed_command_sets.remove(cmdset)
 
     def _check_uninstallable(self, cmdset: CommandSet[Any]) -> None:
-        cmdset_id = id(cmdset)
+        """Verify if a CommandSet can be safely uninstalled from the application.
+
+        This method acts as a safety guard before unregistration. It inspects all
+        command parsers provided by the CommandSet and recursively checks their
+        subcommand hierarchies to ensure no other registrant (another CommandSet
+        or the main application) has attached subcommands to them.
+
+        :param cmdset: the CommandSet instance to check for uninstallation safety
+        :raises CommandSetRegistrationError: if any parser in the CommandSet is
+                                             required by another registrant
+        """
+        registrant_id = id(cmdset)
 
         def check_parser_uninstallable(parser: Cmd2ArgumentParser) -> None:
+            # Recursively verify no subcommands belong to a different registrant
             try:
                 subparsers_action = parser.get_subparsers_action()
             except ValueError:
@@ -1080,10 +1093,10 @@ class Cmd:
                     continue
                 checked_parsers.add(subparser)
 
-                attached_cmdset_id = getattr(subparser, constants.PARSER_ATTR_OWNER_ID, None)
-                if attached_cmdset_id is not None and attached_cmdset_id != cmdset_id:
+                attached_registrant_id = getattr(subparser, constants.PARSER_ATTR_REGISTRANT_ID, None)
+                if attached_registrant_id is not None and attached_registrant_id != registrant_id:
                     raise CommandSetRegistrationError(
-                        f"Cannot uninstall CommandSet: '{subparser.prog}' is required by another CommandSet"
+                        f"Cannot uninstall CommandSet: '{subparser.prog}' is required by another registrant"
                     )
                 check_parser_uninstallable(subparser)
 
@@ -1117,13 +1130,13 @@ class Cmd:
             owner,
             predicate=lambda meth: (
                 isinstance(meth, Callable)  # type: ignore[arg-type]
-                and hasattr(meth, constants.SUBCMD_ATTR_SPEC)
+                and hasattr(meth, constants.SUBCOMMAND_ATTR_SPEC)
             ),
         )
 
         # iterate through all matching methods
         for _method_name, method in methods:
-            spec: SubcommandSpec = getattr(method, constants.SUBCMD_ATTR_SPEC)
+            spec: SubcommandSpec = getattr(method, constants.SUBCOMMAND_ATTR_SPEC)
 
             subcommand_valid, errmsg = self.statement_parser.is_valid_command(spec.name, is_subcommand=True)
             if not subcommand_valid:
@@ -1134,12 +1147,12 @@ class Cmd:
             if subcmd_parser.description is None and method.__doc__:
                 subcmd_parser.description = strip_doc_annotations(method.__doc__)
 
-            # Set the subcommand handler
-            defaults = {constants.NS_ATTR_SUBCMD_HANDLER: method}
+            # Set the subcommand function
+            defaults = {constants.NS_ATTR_SUBCOMMAND_FUNC: method}
             subcmd_parser.set_defaults(**defaults)
 
-            # Set what instance the handler is bound to
-            setattr(subcmd_parser, constants.PARSER_ATTR_OWNER_ID, id(owner))
+            # Record the ID of the instance that registered this subcommand parser
+            setattr(subcmd_parser, constants.PARSER_ATTR_REGISTRANT_ID, id(owner))
 
             # Attach this subcommand
             record = SubcommandRecord(
@@ -1169,13 +1182,13 @@ class Cmd:
             owner,
             predicate=lambda meth: (
                 isinstance(meth, Callable)  # type: ignore[arg-type]
-                and hasattr(meth, constants.SUBCMD_ATTR_SPEC)
+                and hasattr(meth, constants.SUBCOMMAND_ATTR_SPEC)
             ),
         )
 
         # iterate through all matching methods
         for _method_name, method in methods:
-            spec: SubcommandSpec = getattr(method, constants.SUBCMD_ATTR_SPEC)
+            spec: SubcommandSpec = getattr(method, constants.SUBCOMMAND_ATTR_SPEC)
 
             with contextlib.suppress(ValueError):
                 self.detach_subcommand(spec.command, spec.name)
@@ -2517,7 +2530,7 @@ class Cmd:
 
                     if command_func is not None and argparser is not None:
                         # Get arguments for complete()
-                        preserve_quotes = getattr(command_func, constants.CMD_ATTR_PRESERVE_QUOTES)
+                        spec: ApCommandSpec = getattr(command_func, constants.AP_COMMAND_ATTR_SPEC)
                         cmd_set = self.find_commandset_for_command(command)
 
                         # Create the argparse completer
@@ -2525,7 +2538,7 @@ class Cmd:
                         completer = completer_type(argparser, self)
 
                         completer_func = functools.partial(
-                            completer.complete, tokens=raw_tokens[1:] if preserve_quotes else tokens[1:], cmd_set=cmd_set
+                            completer.complete, tokens=raw_tokens[1:] if spec.preserve_quotes else tokens[1:], cmd_set=cmd_set
                         )
                     else:
                         completer_func = self.completedefault  # type: ignore[assignment]
@@ -3380,8 +3393,8 @@ class Cmd:
         :return: category name
         """
         # Check if the command function has a category.
-        if hasattr(func, constants.CMD_ATTR_HELP_CATEGORY):
-            category: str = getattr(func, constants.CMD_ATTR_HELP_CATEGORY)
+        if hasattr(func, constants.COMMAND_ATTR_HELP_CATEGORY):
+            category: str = getattr(func, constants.COMMAND_ATTR_HELP_CATEGORY)
 
         # Otherwise get the category from its defining class.
         else:
@@ -3784,8 +3797,8 @@ class Cmd:
     @with_argparser(_build_alias_parser, preserve_quotes=True)
     def do_alias(self, args: argparse.Namespace) -> None:
         """Manage aliases."""
-        # Call handler for whatever subcommand was selected
-        args.cmd2_subcmd_handler(args)
+        # Call function for whatever subcommand was selected
+        args.cmd2_subcommand_func(args)
 
     # alias -> create
     @classmethod
@@ -3998,8 +4011,8 @@ class Cmd:
     @with_argparser(_build_macro_parser, preserve_quotes=True)
     def do_macro(self, args: argparse.Namespace) -> None:
         """Manage macros."""
-        # Call handler for whatever subcommand was selected
-        args.cmd2_subcmd_handler(args)
+        # Call function for whatever subcommand was selected
+        args.cmd2_subcommand_func(args)
 
     # macro -> create
     @classmethod

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -1068,17 +1068,16 @@ class Cmd:
 
         This method acts as a safety guard before unregistration. It inspects all
         command parsers provided by the CommandSet and recursively checks their
-        subcommand hierarchies to ensure no other registrant (another CommandSet
-        or the main application) has attached subcommands to them.
+        subcommand hierarchies to ensure no other CommandSet or Cmd instance has
+        attached subcommands to them.
 
         :param cmdset: the CommandSet instance to check for uninstallation safety
-        :raises CommandSetRegistrationError: if any parser in the CommandSet is
-                                             required by another registrant
+        :raises CommandSetRegistrationError: if it is not safe to uninstall the CommandSet
         """
-        registrant_id = id(cmdset)
+        cmdset_id = id(cmdset)
 
         def check_parser_uninstallable(parser: Cmd2ArgumentParser) -> None:
-            # Recursively verify no subcommands belong to a different registrant
+            # Recursively verify no subcommands belong to a different CommandSet or Cmd instance
             try:
                 subparsers_action = parser.get_subparsers_action()
             except ValueError:
@@ -1093,10 +1092,11 @@ class Cmd:
                     continue
                 checked_parsers.add(subparser)
 
-                attached_registrant_id = getattr(subparser, constants.PARSER_ATTR_REGISTRANT_ID, None)
-                if attached_registrant_id is not None and attached_registrant_id != registrant_id:
+                owner_id = getattr(subparser, constants.PARSER_ATTR_OWNER_ID, None)
+                if owner_id is not None and owner_id != cmdset_id:
                     raise CommandSetRegistrationError(
-                        f"Cannot uninstall CommandSet: '{subparser.prog}' is required by another registrant"
+                        f"Cannot uninstall CommandSet '{type(cmdset).__name__}' because it is still "
+                        f"required by subcommand '{subparser.prog}'"
                     )
                 check_parser_uninstallable(subparser)
 
@@ -1152,7 +1152,7 @@ class Cmd:
             subcmd_parser.set_defaults(**defaults)
 
             # Record the ID of the instance that registered this subcommand parser
-            setattr(subcmd_parser, constants.PARSER_ATTR_REGISTRANT_ID, id(owner))
+            setattr(subcmd_parser, constants.PARSER_ATTR_OWNER_ID, id(owner))
 
             # Attach this subcommand
             record = SubcommandRecord(

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -69,20 +69,17 @@ def cmd2_public_attr_name(name: str) -> str:
 
 # --- Private Internal Attributes ---
 
-# Attached to a command function; defines the source from which its parser is built
-CMD_ATTR_PARSER_SOURCE = cmd2_private_attr_name("parser_source")
-
 # Attached to a command function; defines its help section category
-CMD_ATTR_HELP_CATEGORY = cmd2_private_attr_name("help_category")
+COMMAND_ATTR_HELP_CATEGORY = cmd2_private_attr_name("help_category")
 
-# Attached to a command function; defines whether tokens are unquoted before reaching argparse
-CMD_ATTR_PRESERVE_QUOTES = cmd2_private_attr_name("preserve_quotes")
+# Attached to an argparse-based command function; defines its ApCommandSpec instance
+AP_COMMAND_ATTR_SPEC = cmd2_private_attr_name("ap_command_spec")
 
 # Attached to a subcommand function; defines its SubcommandSpec instance
-SUBCMD_ATTR_SPEC = cmd2_private_attr_name("subcommand_spec")
+SUBCOMMAND_ATTR_SPEC = cmd2_private_attr_name("subcommand_spec")
 
-# Attached to an argparse parser; identifies the Cmd or CommandSet instance it belongs to
-PARSER_ATTR_OWNER_ID = cmd2_private_attr_name("owner_id")
+# Attached to an argparse parser; stores the id() of the Cmd or CommandSet instance that registered it
+PARSER_ATTR_REGISTRANT_ID = cmd2_private_attr_name("registrant_id")
 
 
 # --- Public Developer Attributes ---
@@ -91,4 +88,4 @@ PARSER_ATTR_OWNER_ID = cmd2_private_attr_name("owner_id")
 NS_ATTR_STATEMENT = cmd2_public_attr_name("statement")
 
 # Attached to an argparse Namespace; the function to handle the subcommand (or None)
-NS_ATTR_SUBCMD_HANDLER = cmd2_public_attr_name("subcmd_handler")
+NS_ATTR_SUBCOMMAND_FUNC = cmd2_public_attr_name("subcommand_func")

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -78,8 +78,8 @@ AP_COMMAND_ATTR_SPEC = cmd2_private_attr_name("ap_command_spec")
 # Attached to a subcommand function; defines its SubcommandSpec instance
 SUBCOMMAND_ATTR_SPEC = cmd2_private_attr_name("subcommand_spec")
 
-# Attached to an argparse parser; stores the id() of the Cmd or CommandSet instance that registered it
-PARSER_ATTR_REGISTRANT_ID = cmd2_private_attr_name("registrant_id")
+# Attached to a subcommand parser; stores the id() of the Cmd or CommandSet instance that registered it
+PARSER_ATTR_OWNER_ID = cmd2_private_attr_name("owner_id")
 
 
 # --- Public Developer Attributes ---

--- a/cmd2/constants.py
+++ b/cmd2/constants.py
@@ -72,8 +72,8 @@ def cmd2_public_attr_name(name: str) -> str:
 # Attached to a command function; defines its help section category
 COMMAND_ATTR_HELP_CATEGORY = cmd2_private_attr_name("help_category")
 
-# Attached to an argparse-based command function; defines its ApCommandSpec instance
-AP_COMMAND_ATTR_SPEC = cmd2_private_attr_name("ap_command_spec")
+# Attached to an argparse-based command function; defines its ArgparseCommandSpec instance
+ARGPARSE_COMMAND_ATTR_SPEC = cmd2_private_attr_name("argparse_command_spec")
 
 # Attached to a subcommand function; defines its SubcommandSpec instance
 SUBCOMMAND_ATTR_SPEC = cmd2_private_attr_name("subcommand_spec")

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -16,7 +16,7 @@ from typing import (
 
 from . import constants
 from .argparse_utils import (
-    ApCommandSpec,
+    ArgparseCommandSpec,
     ClassParamParserFactory,
     Cmd2ArgumentParser,
     NoParamParserFactory,
@@ -366,11 +366,11 @@ def with_argparser(
 
         command_name = func.__name__[len(constants.COMMAND_FUNC_PREFIX) :]
 
-        spec = ApCommandSpec(
+        spec = ArgparseCommandSpec(
             parser_source=parser_source,
             preserve_quotes=preserve_quotes,
         )
-        setattr(cmd_wrapper, constants.AP_COMMAND_ATTR_SPEC, spec)
+        setattr(cmd_wrapper, constants.ARGPARSE_COMMAND_ATTR_SPEC, spec)
 
         return cmd_wrapper
 

--- a/cmd2/decorators.py
+++ b/cmd2/decorators.py
@@ -16,6 +16,7 @@ from typing import (
 
 from . import constants
 from .argparse_utils import (
+    ApCommandSpec,
     ClassParamParserFactory,
     Cmd2ArgumentParser,
     NoParamParserFactory,
@@ -354,18 +355,20 @@ def with_argparser(
             # Include the Statement object created from the command line
             setattr(parsed_namespace, constants.NS_ATTR_STATEMENT, statement)
 
-            # Ensure NS_ATTR_SUBCMD_HANDLER is always present.
-            if not hasattr(parsed_namespace, constants.NS_ATTR_SUBCMD_HANDLER):
-                setattr(parsed_namespace, constants.NS_ATTR_SUBCMD_HANDLER, None)
+            # Ensure subcommand function attribute is always present.
+            if not hasattr(parsed_namespace, constants.NS_ATTR_SUBCOMMAND_FUNC):
+                setattr(parsed_namespace, constants.NS_ATTR_SUBCOMMAND_FUNC, None)
 
             func_arg_list = _arg_swap(args, statement_arg, *parsing_results)
             return func(*func_arg_list, **kwargs)
 
         command_name = func.__name__[len(constants.COMMAND_FUNC_PREFIX) :]
 
-        # Set some custom attributes for this command
-        setattr(cmd_wrapper, constants.CMD_ATTR_PARSER_SOURCE, parser_source)
-        setattr(cmd_wrapper, constants.CMD_ATTR_PRESERVE_QUOTES, preserve_quotes)
+        spec = ApCommandSpec(
+            parser_source=parser_source,
+            preserve_quotes=preserve_quotes,
+        )
+        setattr(cmd_wrapper, constants.AP_COMMAND_ATTR_SPEC, spec)
 
         return cmd_wrapper
 
@@ -450,10 +453,10 @@ def as_subcommand_to(
     class MyApp(cmd2.Cmd):
         @cmd2.with_argparser(base_parser)
         def do_base(self, args: argparse.Namespace) -> None:
-            args.cmd2_subcmd_handler(args)
+            args.cmd2_subcommand_func(args)
 
         @cmd2.as_subcommand_to('base', 'sub', sub_parser, help="the subcommand")
-        def sub_handler(self, args: argparse.Namespace) -> None:
+        def sub_func(self, args: argparse.Namespace) -> None:
             self.poutput('Subcommand executed')
     ```
 
@@ -468,7 +471,7 @@ def as_subcommand_to(
             deprecated=deprecated,
             parser_source=parser_source,
         )
-        setattr(func, constants.SUBCMD_ATTR_SPEC, spec)
+        setattr(func, constants.SUBCOMMAND_ATTR_SPEC, spec)
         return func
 
     return arg_decorator

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -712,11 +712,11 @@ def categorize(func: Callable[..., Any] | Iterable[Callable[..., Any]], category
     """
     if isinstance(func, Iterable):
         for item in func:
-            setattr(item, constants.CMD_ATTR_HELP_CATEGORY, category)
+            setattr(item, constants.COMMAND_ATTR_HELP_CATEGORY, category)
     elif inspect.ismethod(func):
-        setattr(func.__func__, constants.CMD_ATTR_HELP_CATEGORY, category)
+        setattr(func.__func__, constants.COMMAND_ATTR_HELP_CATEGORY, category)
     else:
-        setattr(func, constants.CMD_ATTR_HELP_CATEGORY, category)
+        setattr(func, constants.COMMAND_ATTR_HELP_CATEGORY, category)
 
 
 def get_defining_class(meth: Callable[..., Any]) -> type[Any] | None:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -694,7 +694,7 @@ def categorize(func: Callable[..., Any] | Iterable[Callable[..., Any]], category
     The help command output will group the passed function under the
     specified category heading
 
-    :param func: function or list of functions to categorize
+    :param func: function or Iterable of functions to categorize
     :param category: category to put it in
 
     Example:
@@ -710,13 +710,13 @@ def categorize(func: Callable[..., Any] | Iterable[Callable[..., Any]], category
     For an alternative approach to categorizing commands using a decorator, see [cmd2.decorators.with_category][]
 
     """
-    if isinstance(func, Iterable):
-        for item in func:
-            setattr(item, constants.COMMAND_ATTR_HELP_CATEGORY, category)
-    elif inspect.ismethod(func):
-        setattr(func.__func__, constants.COMMAND_ATTR_HELP_CATEGORY, category)
-    else:
-        setattr(func, constants.COMMAND_ATTR_HELP_CATEGORY, category)
+    funcs = func if isinstance(func, Iterable) else (func,)
+
+    for cur_func in funcs:
+        if inspect.ismethod(cur_func):
+            setattr(cur_func.__func__, constants.COMMAND_ATTR_HELP_CATEGORY, category)
+        else:
+            setattr(cur_func, constants.COMMAND_ATTR_HELP_CATEGORY, category)
 
 
 def get_defining_class(meth: Callable[..., Any]) -> type[Any] | None:

--- a/docs/features/annotated.md
+++ b/docs/features/annotated.md
@@ -308,7 +308,7 @@ annotated decorator picks it up automatically.
 
 The forwarded kwargs are `description`, `epilog`, `prog`, `usage`, `parents`, `argument_default`,
 `prefix_chars`, `fromfile_prefix_chars`, `conflict_handler`, `add_help`, `allow_abbrev`,
-`exit_on_error`, `formatter_class`, `ap_completer_type`, and on Python ≥ 3.14 `suggest_on_error` /
+`exit_on_error`, `formatter_class`, `completer_class`, and on Python ≥ 3.14 `suggest_on_error` /
 `color`. Two of them layer extra behavior on top of the raw passthrough:
 
 - `description` -- when omitted, it is filled from the function's docstring (detailed below); pass

--- a/docs/features/annotated.md
+++ b/docs/features/annotated.md
@@ -116,8 +116,9 @@ Unsupported patterns raise `TypeError`, including:
   by the tuple. The tuple type already pins `nargs`; user metadata cannot change it.
 
 The parameter names `dest` and `subcommand` are reserved and may not be used as annotated parameter
-names. `cmd2_statement` receives the parsed [cmd2.Statement][] object, and `cmd2_handler` (only on a
-command decorated with `@with_annotated(base_command=True)`) receives the subcommand handler.
+names. `cmd2_statement` receives the parsed [cmd2.Statement][] object, and `cmd2_subcommand_func`
+(only on a command decorated with `@with_annotated(base_command=True)`) receives the subcommand
+handler.
 
 ## Annotated metadata
 
@@ -269,8 +270,8 @@ list the values.
 - `with_unknown_args` -- if `True`, unrecognised arguments are passed as `_unknown`
 - `subcommand_to` -- register the function as an annotated subcommand under a parent command
 - `base_command` -- create a base command whose parser also adds subparsers and exposes
-  `cmd2_handler`. A `cmd2_handler` parameter is only valid on a command decorated with
-  `base_command=True`; declaring one elsewhere raises `TypeError`.
+  `cmd2_subcommand_func`. A `cmd2_subcommand_func` parameter is only valid on a command decorated
+  with `base_command=True`; declaring one elsewhere raises `TypeError`.
 - `subcommand_required` -- whether a subcommand must be supplied (only with `base_command=True`,
   default `True`)
 - `subcommand_metavar` -- metavar shown for the subcommands group (only with `base_command=True`,
@@ -392,10 +393,9 @@ The remaining argparse kwargs cover less-common needs but are wired through unch
 
 ```py
 @with_annotated(base_command=True)
-def do_manage(self, *, cmd2_handler):
-    handler = cmd2_handler
-    if handler:
-        handler()
+def do_manage(self, *, cmd2_subcommand_func):
+    if cmd2_subcommand_func:
+        cmd2_subcommand_func()
 
 @with_annotated(subcommand_to="manage", help="list projects")
 def manage_list(self):
@@ -408,10 +408,9 @@ creates its own subparsers:
 
 ```py
 @with_annotated(subcommand_to="manage", base_command=True, help="manage projects")
-def manage_project(self, *, cmd2_handler):
-    handler = cmd2_handler
-    if handler:
-        handler()
+def manage_project(self, *, cmd2_subcommand_func):
+    if cmd2_subcommand_func:
+        cmd2_subcommand_func()
 
 @with_annotated(subcommand_to="manage project", help="add a project")
 def manage_project_add(self, name: str):

--- a/docs/features/argument_processing.md
+++ b/docs/features/argument_processing.md
@@ -400,4 +400,4 @@ example demonstrates both above cases in a concrete fashion.
 naming collisions, do not use any of these names for your argparse arguments.
 
 - `cmd2_statement` - [cmd2.Statement][] object that was created when parsing the command line.
-- `cmd2_subcmd_handler` - subcommand handler function or `None` if one was not set.
+- `cmd2_subcommand_func` - subcommand handler function or `None` if one was not set.

--- a/docs/features/modular_commands.md
+++ b/docs/features/modular_commands.md
@@ -378,19 +378,14 @@ class ExampleApp(cmd2.Cmd):
             self.poutput('Vegetables unloaded')
 
     cut_parser = cmd2.Cmd2ArgumentParser()
-    cut_subparsers = cut_parser.add_subparsers(title='item', help='item to cut')
+    cut_parser.add_subparsers(title="item", help="item to cut", metavar="ITEM", required=True)
 
     @with_argparser(cut_parser)
     def do_cut(self, ns: argparse.Namespace):
         """Cut Command."""
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-        else:
-            # No subcommand was provided, so call help
-            self.poutput('This command does nothing without sub-parsers registered')
-            self.do_help('cut')
+        # Call whatever subcommand function was selected
+        ns.cmd2_subcommand_func(ns)
+
 
 
 if __name__ == '__main__':

--- a/examples/annotated_example.py
+++ b/examples/annotated_example.py
@@ -440,7 +440,7 @@ class AnnotatedExample(Cmd):
 
     @with_annotated(base_command=True)
     @cmd2.with_category(ANNOTATED_CATEGORY)
-    def do_manage(self, verbose: bool = False, *, cmd2_handler: Callable[[], Any] | None = None) -> None:
+    def do_manage(self, verbose: bool = False, *, cmd2_subcommand_func: Callable[[], Any] | None = None) -> None:
         """Base command for annotated subcommands.
 
         Try:
@@ -449,13 +449,13 @@ class AnnotatedExample(Cmd):
         """
         if verbose:
             self.poutput("verbose mode")
-        if cmd2_handler:
-            cmd2_handler()
+        if cmd2_subcommand_func:
+            cmd2_subcommand_func()
 
     @with_annotated(subcommand_to="manage", base_command=True, help="manage projects")
-    def manage_project(self, *, cmd2_handler: Callable[[], Any] | None = None) -> None:
-        if cmd2_handler:
-            cmd2_handler()
+    def manage_project(self, *, cmd2_subcommand_func: Callable[[], Any] | None = None) -> None:
+        if cmd2_subcommand_func:
+            cmd2_subcommand_func()
 
     @with_annotated(subcommand_to="manage project", help="add a project")
     def manage_project_add(self, name: str) -> None:

--- a/examples/argparse_example.py
+++ b/examples/argparse_example.py
@@ -139,7 +139,7 @@ class ArgparsingApp(cmd2.Cmd):
     @cmd2.with_category(ARGPARSE_SUBCOMMANDS)
     def do_calculate(self, args: argparse.Namespace) -> None:
         """Calculate a simple mathematical operation on two integers."""
-        args.cmd2_subcmd_handler(args)
+        args.cmd2_subcommand_func(args)
 
 
 if __name__ == "__main__":

--- a/examples/command_sets.py
+++ b/examples/command_sets.py
@@ -18,6 +18,7 @@ import argparse
 import cmd2
 from cmd2 import (
     CommandSet,
+    CommandSetRegistrationError,
     with_argparser,
     with_category,
 )
@@ -121,14 +122,14 @@ class CommandSetApp(cmd2.Cmd):
             try:
                 self.register_command_set(self._fruits)
                 self.poutput("Fruits loaded")
-            except ValueError:
+            except CommandSetRegistrationError:
                 self.poutput("Fruits already loaded")
 
         if ns.cmds == "vegetables":
             try:
                 self.register_command_set(self._vegetables)
                 self.poutput("Vegetables loaded")
-            except ValueError:
+            except CommandSetRegistrationError:
                 self.poutput("Vegetables already loaded")
 
     @with_argparser(load_parser)
@@ -144,19 +145,13 @@ class CommandSetApp(cmd2.Cmd):
             self.poutput("Vegetables unloaded")
 
     cut_parser = cmd2.Cmd2ArgumentParser()
-    cut_subparsers = cut_parser.add_subparsers(title="item", help="item to cut")
+    cut_parser.add_subparsers(title="item", help="item to cut", metavar="ITEM", required=True)
 
     @with_argparser(cut_parser)
     @with_category(COMMANDSET_SUBCOMMAND)
     def do_cut(self, ns: argparse.Namespace) -> None:
         """Intended to be used with dynamically loaded subcommands specifically."""
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            handler(ns)
-        else:
-            # No subcommand was provided, so call help
-            self.poutput("This command does nothing without sub-parsers registered")
-            self.do_help("cut")
+        ns.cmd2_subcommand_func(ns)
 
 
 if __name__ == "__main__":

--- a/examples/custom_parser.py
+++ b/examples/custom_parser.py
@@ -9,7 +9,7 @@ from cmd2 import (
     Cmd2ArgumentParser,
     Cmd2Style,
     cmd2,
-    set_default_argument_parser_type,
+    set_default_argument_parser,
     stylize,
 )
 
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     import sys
 
     # Set the default parser type before instantiating app.
-    set_default_argument_parser_type(CustomParser)
+    set_default_argument_parser(CustomParser)
 
     app = cmd2.Cmd(include_ipy=True, persistent_history_file="cmd2_history.dat")
     app.self_in_py = True  # Enable access to "self" within the py command

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1121,7 +1121,7 @@ class TestParserCustomization:
         @with_annotated(ap_completer_type=MyCompleter)
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
+        builder = getattr(do_run, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
         assert builder().ap_completer_type is MyCompleter
 
     def test_ap_completer_type_threads_to_subcommand(self) -> None:
@@ -3005,7 +3005,7 @@ class TestSubcommandGroupConfig:
         @with_annotated(base_command=True, **subcommand_kwargs)
         def do_root(self, cmd2_subcommand_func) -> None: ...
 
-        builder = getattr(do_root, constants.AP_COMMAND_ATTR_SPEC).parser_source
+        builder = getattr(do_root, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
         return builder()
 
     @staticmethod
@@ -3116,7 +3116,7 @@ class TestDocstringDescription:
             Extra detail.
             """
 
-        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
+        builder = getattr(do_run, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
         assert builder().description == "Run the thing."
 
     def test_subcommand_uses_docstring(self) -> None:
@@ -3213,7 +3213,7 @@ class TestParserLevelKwargs:
         @with_annotated(prog="myprog", usage="usage line")
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
+        builder = getattr(do_run, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
         parser = builder()
         assert parser.prog == "myprog"
         assert parser.usage == "usage line"
@@ -3323,7 +3323,7 @@ class TestParserLowLevelKwargs:
         )
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
+        builder = getattr(do_run, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
         parser = builder()
         assert parser.prefix_chars == "+-"
         assert parser.fromfile_prefix_chars == "@"

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -23,9 +23,7 @@ from typing import (
 import pytest
 
 import cmd2
-from cmd2 import (
-    CompletionItem,
-)
+from cmd2 import CompletionItem
 from cmd2.annotated import (
     Argument,
     Group,
@@ -1121,7 +1119,7 @@ class TestParserCustomization:
         @with_annotated(ap_completer_type=MyCompleter)
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.CMD_ATTR_PARSER_SOURCE)
+        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
         assert builder().ap_completer_type is MyCompleter
 
     def test_ap_completer_type_threads_to_subcommand(self) -> None:
@@ -1134,7 +1132,7 @@ class TestParserCustomization:
         @with_annotated(subcommand_to="team", ap_completer_type=MyCompleter)
         def team_create(self, name: str) -> None: ...
 
-        spec = getattr(team_create, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_create, constants.SUBCOMMAND_ATTR_SPEC)
         assert spec.parser_source().ap_completer_type is MyCompleter
 
     def test_customization_via_decorator(self) -> None:
@@ -1178,7 +1176,7 @@ class TestParserCustomization:
 
         from cmd2 import constants
 
-        spec = getattr(App.team_add, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(App.team_add, constants.SUBCOMMAND_ATTR_SPEC)
         subparser = spec.parser_source()
         assert subparser.description == "add desc"
         assert subparser.epilog == "add epilog"
@@ -1678,12 +1676,12 @@ class TestCollectionRuntimeCast:
 
 class TestFilteredNamespaceKwargs:
     def test_excludes_subcmd_handler_key(self) -> None:
+        from cmd2 import constants
         from cmd2.annotated import _filtered_namespace_kwargs
-        from cmd2.constants import NS_ATTR_SUBCMD_HANDLER
 
-        ns = argparse.Namespace(**{NS_ATTR_SUBCMD_HANDLER: lambda: None, "name": "Alice"})
+        ns = argparse.Namespace(**{constants.NS_ATTR_SUBCOMMAND_FUNC: lambda: None, "name": "Alice"})
         result = _filtered_namespace_kwargs(ns)
-        assert NS_ATTR_SUBCMD_HANDLER not in result
+        assert constants.NS_ATTR_SUBCOMMAND_FUNC not in result
         assert result == {"name": "Alice"}
 
     def test_excludes_subcommand_key(self) -> None:
@@ -2376,7 +2374,7 @@ class TestSubcommandValidation:
         @with_annotated(subcommand_to="team", **decorator_kwargs)
         def team_create(self, name: str = "") -> None: ...
 
-        spec = getattr(team_create, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_create, constants.SUBCOMMAND_ATTR_SPEC)
         assert spec.command == "team"
         assert spec.name == "create"
         assert spec.help == expected_help
@@ -2390,7 +2388,7 @@ class TestSubcommandValidation:
         @with_annotated(subcommand_to="team", deprecated=deprecated)
         def team_create(self, name: str = "") -> None: ...
 
-        spec = getattr(team_create, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_create, constants.SUBCOMMAND_ATTR_SPEC)
         assert spec.deprecated is deprecated
 
 
@@ -3026,7 +3024,7 @@ class TestSubcommandGroupConfig:
         @with_annotated(base_command=True, **subcommand_kwargs)
         def do_root(self, cmd2_handler) -> None: ...
 
-        builder = getattr(do_root, constants.CMD_ATTR_PARSER_SOURCE)
+        builder = getattr(do_root, constants.AP_COMMAND_ATTR_SPEC).parser_source
         return builder()
 
     @staticmethod
@@ -3139,7 +3137,7 @@ class TestDocstringDescription:
             Extra detail.
             """
 
-        builder = getattr(do_run, constants.CMD_ATTR_PARSER_SOURCE)
+        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
         assert builder().description == "Run the thing."
 
     def test_subcommand_uses_docstring(self) -> None:
@@ -3149,7 +3147,7 @@ class TestDocstringDescription:
         def team_add(self, name: str) -> None:
             """Add a member to the team."""
 
-        spec = getattr(team_add, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_add, constants.SUBCOMMAND_ATTR_SPEC)
         assert spec.parser_source().description == "Add a member to the team."
 
 
@@ -3240,7 +3238,7 @@ class TestParserLevelKwargs:
         @with_annotated(prog="myprog", usage="usage line")
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.CMD_ATTR_PARSER_SOURCE)
+        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
         parser = builder()
         assert parser.prog == "myprog"
         assert parser.usage == "usage line"
@@ -3259,7 +3257,7 @@ class TestParserLevelKwargs:
         @with_annotated(subcommand_to="team", usage="team add NAME")
         def team_add(self, name: str) -> None: ...
 
-        spec = getattr(team_add, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_add, constants.SUBCOMMAND_ATTR_SPEC)
         assert spec.parser_source().usage == "team add NAME"
 
     def test_parents_allowed_on_subcommand(self) -> None:
@@ -3271,7 +3269,7 @@ class TestParserLevelKwargs:
         @with_annotated(subcommand_to="team", parents=[parent])
         def team_add(self, name: str) -> None: ...
 
-        spec = getattr(team_add, constants.SUBCMD_ATTR_SPEC)
+        spec = getattr(team_add, constants.SUBCOMMAND_ATTR_SPEC)
         dests = {a.dest for a in spec.parser_source()._actions}
         assert "shared" in dests
 
@@ -3354,7 +3352,7 @@ class TestParserLowLevelKwargs:
         )
         def do_run(self, name: str) -> None: ...
 
-        builder = getattr(do_run, constants.CMD_ATTR_PARSER_SOURCE)
+        builder = getattr(do_run, constants.AP_COMMAND_ATTR_SPEC).parser_source
         parser = builder()
         assert parser.prefix_chars == "+-"
         assert parser.fromfile_prefix_chars == "@"

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1100,41 +1100,43 @@ class TestParserCustomization:
         parser = build_parser_from_function(_make_func(str), parser_class=MyParser)
         assert isinstance(parser, MyParser)
 
-    def test_ap_completer_type(self) -> None:
+    def test_completer_class(self) -> None:
         from cmd2.argparse_completer import ArgparseCompleter
 
         class MyCompleter(ArgparseCompleter):
             pass
 
-        parser = build_parser_from_function(_make_func(str), ap_completer_type=MyCompleter)
-        assert parser.ap_completer_type is MyCompleter
+        parser = build_parser_from_function(_make_func(str), completer_class=MyCompleter)
+        assert parser.completer_class is MyCompleter
 
-    def test_ap_completer_type_defaults_to_none(self) -> None:
-        assert build_parser_from_function(_make_func(str)).ap_completer_type is None
+    def test_default_completer_class(self) -> None:
+        from cmd2 import argparse_completer
 
-    def test_ap_completer_type_via_decorator(self) -> None:
+        assert build_parser_from_function(_make_func(str)).completer_class is argparse_completer.DEFAULT_ARGPARSE_COMPLETER
+
+    def test_completer_class_via_decorator(self) -> None:
         from cmd2.argparse_completer import ArgparseCompleter
 
         class MyCompleter(ArgparseCompleter):
             pass
 
-        @with_annotated(ap_completer_type=MyCompleter)
+        @with_annotated(completer_class=MyCompleter)
         def do_run(self, name: str) -> None: ...
 
         builder = getattr(do_run, constants.ARGPARSE_COMMAND_ATTR_SPEC).parser_source
-        assert builder().ap_completer_type is MyCompleter
+        assert builder().completer_class is MyCompleter
 
-    def test_ap_completer_type_threads_to_subcommand(self) -> None:
+    def test_completer_class_threads_to_subcommand(self) -> None:
         from cmd2.argparse_completer import ArgparseCompleter
 
         class MyCompleter(ArgparseCompleter):
             pass
 
-        @with_annotated(subcommand_to="team", ap_completer_type=MyCompleter)
+        @with_annotated(subcommand_to="team", completer_class=MyCompleter)
         def team_create(self, name: str) -> None: ...
 
         spec = getattr(team_create, constants.SUBCOMMAND_ATTR_SPEC)
-        assert spec.parser_source().ap_completer_type is MyCompleter
+        assert spec.parser_source().completer_class is MyCompleter
 
     def test_customization_via_decorator(self) -> None:
         """description/epilog/titled Group flow through @with_annotated end-to-end."""

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -23,7 +23,10 @@ from typing import (
 import pytest
 
 import cmd2
-from cmd2 import CompletionItem
+from cmd2 import (
+    CompletionItem,
+    constants,
+)
 from cmd2.annotated import (
     Argument,
     Group,
@@ -633,7 +636,7 @@ class TestBuildParser:
         """Base-command validation should raise, not swallow, type hint failures."""
         from cmd2.annotated import _resolve_parameters
 
-        def do_broken(self, cmd2_handler, name: "NonExistentType"):  # noqa: F821
+        def do_broken(self, cmd2_subcommand_func, name: "NonExistentType"):  # noqa: F821
             pass
 
         with pytest.raises(TypeError, match="Failed to resolve type hints"):
@@ -1110,7 +1113,6 @@ class TestParserCustomization:
         assert build_parser_from_function(_make_func(str)).ap_completer_type is None
 
     def test_ap_completer_type_via_decorator(self) -> None:
-        from cmd2 import constants
         from cmd2.argparse_completer import ArgparseCompleter
 
         class MyCompleter(ArgparseCompleter):
@@ -1123,7 +1125,6 @@ class TestParserCustomization:
         assert builder().ap_completer_type is MyCompleter
 
     def test_ap_completer_type_threads_to_subcommand(self) -> None:
-        from cmd2 import constants
         from cmd2.argparse_completer import ArgparseCompleter
 
         class MyCompleter(ArgparseCompleter):
@@ -1162,9 +1163,9 @@ class TestParserCustomization:
 
         class App(cmd2.Cmd):
             @with_annotated(base_command=True)
-            def do_team(self, *, cmd2_handler=None) -> None:
-                if cmd2_handler:
-                    cmd2_handler()
+            def do_team(self, *, cmd2_subcommand_func=None) -> None:
+                if cmd2_subcommand_func:
+                    cmd2_subcommand_func()
 
             @with_annotated(subcommand_to="team", help="add a member", description="add desc", epilog="add epilog")
             def team_add(self, name: str) -> None:
@@ -1173,8 +1174,6 @@ class TestParserCustomization:
         app = App()
         out, _err = run_cmd(app, "team add bob")
         assert out == ["added bob"]
-
-        from cmd2 import constants
 
         spec = getattr(App.team_add, constants.SUBCOMMAND_ATTR_SPEC)
         subparser = spec.parser_source()
@@ -1675,15 +1674,6 @@ class TestCollectionRuntimeCast:
 
 
 class TestFilteredNamespaceKwargs:
-    def test_excludes_subcmd_handler_key(self) -> None:
-        from cmd2 import constants
-        from cmd2.annotated import _filtered_namespace_kwargs
-
-        ns = argparse.Namespace(**{constants.NS_ATTR_SUBCOMMAND_FUNC: lambda: None, "name": "Alice"})
-        result = _filtered_namespace_kwargs(ns)
-        assert constants.NS_ATTR_SUBCOMMAND_FUNC not in result
-        assert result == {"name": "Alice"}
-
     def test_excludes_subcommand_key(self) -> None:
         from cmd2.annotated import _filtered_namespace_kwargs
 
@@ -2158,13 +2148,12 @@ class TestGroupedParserIntegration:
 class _SubcommandApp(cmd2.Cmd):
     # Level 1: base command
     @with_annotated(base_command=True)
-    def do_manage(self, cmd2_handler, verbose: bool = False) -> None:
+    def do_manage(self, cmd2_subcommand_func, verbose: bool = False) -> None:
         """Management command with subcommands."""
         if verbose:
             self.poutput("verbose mode")
-        handler = cmd2_handler
-        if handler:
-            handler()
+        if cmd2_subcommand_func:
+            cmd2_subcommand_func()
 
     # Level 2: leaf subcommands
     @with_annotated(subcommand_to="manage", help="add something")
@@ -2181,10 +2170,9 @@ class _SubcommandApp(cmd2.Cmd):
 
     # Level 2: intermediate subcommand (also a base for level 3)
     @with_annotated(subcommand_to="manage", base_command=True, help="manage members")
-    def manage_member(self, cmd2_handler) -> None:
-        handler = cmd2_handler
-        if handler:
-            handler()
+    def manage_member(self, cmd2_subcommand_func) -> None:
+        if cmd2_subcommand_func:
+            cmd2_subcommand_func()
 
     # Level 3: nested subcommand
     @with_annotated(subcommand_to="manage member", help="add a member")
@@ -2244,7 +2232,7 @@ class TestSubcommandValidation:
         with pytest.raises(TypeError, match="positional"):
 
             @with_annotated(base_command=True)
-            def do_bad(self, name: str, cmd2_handler) -> None:
+            def do_bad(self, name: str, cmd2_subcommand_func) -> None:
                 pass
 
     def test_base_command_positional_annotated_raises(self) -> None:
@@ -2252,36 +2240,36 @@ class TestSubcommandValidation:
         with pytest.raises(TypeError, match="positional"):
 
             @with_annotated(base_command=True)
-            def do_bad(self, a: Annotated[str, Argument(help_text="x")], cmd2_handler) -> None:
+            def do_bad(self, a: Annotated[str, Argument(help_text="x")], cmd2_subcommand_func) -> None:
                 pass
 
-    def test_base_command_missing_handler_raises(self) -> None:
-        with pytest.raises(TypeError, match="cmd2_handler"):
+    def test_base_command_missing_subcommand_func_raises(self) -> None:
+        with pytest.raises(TypeError, match=constants.NS_ATTR_SUBCOMMAND_FUNC):
 
             @with_annotated(base_command=True)
             def do_bad(self, verbose: bool = False) -> None:
                 pass
 
-    def test_base_command_missing_handler_raises_with_no_parameters(self) -> None:
-        """A zero-parameter base command with no cmd2_handler must still raise.
+    def test_base_command_missing_subcommand_func_raises_with_no_parameters(self) -> None:
+        """A zero-parameter base command with no cmd2_subcommand_func must still raise.
 
-        Guards the function-level ``cmd2_handler`` check (a plain ``if`` in ``_resolve_parameters``,
+        Guards the function-level ``cmd2_subcommand_func`` check (a plain ``if`` in ``_resolve_parameters``,
         not a :data:`_CONSTRAINTS` row): the per-argument :data:`_CONSTRAINTS` loop never runs when
         no arguments exist, so this case is the sole reason the missing-handler check lives at
         function scope.
         """
-        with pytest.raises(TypeError, match="cmd2_handler"):
+        with pytest.raises(TypeError, match=constants.NS_ATTR_SUBCOMMAND_FUNC):
 
             @with_annotated(base_command=True)
             def do_bad(self) -> None:
                 pass
 
-    def test_cmd2_handler_without_base_command_raises(self) -> None:
-        """A 'cmd2_handler' parameter is only valid when base_command=True."""
+    def test_cmd2_subcommand_func_without_base_command_raises(self) -> None:
+        """A 'cmd2_subcommand_func' parameter is only valid when base_command=True."""
         with pytest.raises(TypeError, match="base_command=True"):
 
             @with_annotated
-            def do_bad(self, cmd2_handler, name: str = "") -> None:
+            def do_bad(self, cmd2_subcommand_func, name: str = "") -> None:
                 pass
 
     @pytest.mark.parametrize(
@@ -2319,10 +2307,9 @@ class TestSubcommandValidation:
 
         class App(cmd2.Cmd):
             @with_annotated(base_command=True)
-            def do_fmt(self, cmd2_handler) -> None:
-                handler = cmd2_handler
-                if handler:
-                    handler()
+            def do_fmt(self, cmd2_subcommand_func) -> None:
+                if cmd2_subcommand_func:
+                    cmd2_subcommand_func()
 
             @with_annotated(subcommand_to="fmt", help="output", mutually_exclusive_groups=(Group("json", "csv"),))
             def fmt_out(self, msg: str, json: bool = False, csv: bool = False) -> None:
@@ -2338,11 +2325,11 @@ class TestSubcommandValidation:
         with pytest.raises(TypeError, match="positional"):
 
             @with_annotated(subcommand_to="team", base_command=True)
-            def team_member(self, name: str, cmd2_handler) -> None:
+            def team_member(self, name: str, cmd2_subcommand_func) -> None:
                 pass
 
-    def test_intermediate_base_command_missing_handler_raises(self) -> None:
-        with pytest.raises(TypeError, match="cmd2_handler"):
+    def test_intermediate_base_command_missing_subcommand_func_raises(self) -> None:
+        with pytest.raises(TypeError, match=constants.NS_ATTR_SUBCOMMAND_FUNC):
 
             @with_annotated(subcommand_to="team", base_command=True)
             def team_member(self) -> None:
@@ -2369,8 +2356,6 @@ class TestSubcommandValidation:
         ],
     )
     def test_subcommand_spec_attributes(self, decorator_kwargs, expected_help, expected_aliases) -> None:
-        from cmd2 import constants
-
         @with_annotated(subcommand_to="team", **decorator_kwargs)
         def team_create(self, name: str = "") -> None: ...
 
@@ -2383,8 +2368,6 @@ class TestSubcommandValidation:
 
     @pytest.mark.parametrize("deprecated", [True, False])
     def test_subcommand_deprecated_flows_to_spec(self, deprecated) -> None:
-        from cmd2 import constants
-
         @with_annotated(subcommand_to="team", deprecated=deprecated)
         def team_create(self, name: str = "") -> None: ...
 
@@ -3019,10 +3002,8 @@ class TestRangedNargs:
 class TestSubcommandGroupConfig:
     @staticmethod
     def _base_parser(**subcommand_kwargs):
-        from cmd2 import constants
-
         @with_annotated(base_command=True, **subcommand_kwargs)
-        def do_root(self, cmd2_handler) -> None: ...
+        def do_root(self, cmd2_subcommand_func) -> None: ...
 
         builder = getattr(do_root, constants.AP_COMMAND_ATTR_SPEC).parser_source
         return builder()
@@ -3128,8 +3109,6 @@ class TestDocstringDescription:
         assert parser.description == "Summary line."
 
     def test_decorator_uses_docstring(self) -> None:
-        from cmd2 import constants
-
         @with_annotated
         def do_run(self, name: str) -> None:
             """Run the thing.
@@ -3141,8 +3120,6 @@ class TestDocstringDescription:
         assert builder().description == "Run the thing."
 
     def test_subcommand_uses_docstring(self) -> None:
-        from cmd2 import constants
-
         @with_annotated(subcommand_to="team")
         def team_add(self, name: str) -> None:
             """Add a member to the team."""
@@ -3233,8 +3210,6 @@ class TestParserLevelKwargs:
         assert ns.count == 1
 
     def test_decorator_passes_parser_kwargs(self) -> None:
-        from cmd2 import constants
-
         @with_annotated(prog="myprog", usage="usage line")
         def do_run(self, name: str) -> None: ...
 
@@ -3252,7 +3227,6 @@ class TestParserLevelKwargs:
 
     def test_usage_allowed_on_subcommand(self) -> None:
         """``usage`` doesn't conflict with subcommand prog rewriting."""
-        from cmd2 import constants
 
         @with_annotated(subcommand_to="team", usage="team add NAME")
         def team_add(self, name: str) -> None: ...
@@ -3261,8 +3235,6 @@ class TestParserLevelKwargs:
         assert spec.parser_source().usage == "team add NAME"
 
     def test_parents_allowed_on_subcommand(self) -> None:
-        from cmd2 import constants
-
         parent = argparse.ArgumentParser(add_help=False)
         parent.add_argument("--shared")
 
@@ -3340,7 +3312,6 @@ class TestParserLowLevelKwargs:
 
     def test_decorator_threads_all_low_level_kwargs(self) -> None:
         """End-to-end: each kwarg lands on the parser when set on the decorator."""
-        from cmd2 import constants
 
         @with_annotated(
             prefix_chars="+-",

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -358,7 +358,7 @@ class SubcommandApp(cmd2.Cmd):
     # Add subcommands using as_subcommand_to decorator
     @cmd2.with_argparser(_build_has_subcmd_parser)
     def do_test_subcmd_decorator(self, args: argparse.Namespace) -> None:
-        args.cmd2_subcmd_handler(args)
+        args.cmd2_subcommand_func(args)
 
     subcmd_parser = cmd2.Cmd2ArgumentParser(description="A subcommand")
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -364,7 +364,7 @@ class SubcommandApp(cmd2.Cmd):
 
     @cmd2.as_subcommand_to("test_subcmd_decorator", "subcmd", subcmd_parser, help=subcmd_parser.description.lower())
     def subcmd_func(self, args: argparse.Namespace) -> None:
-        # Make sure printing the Namespace works. The way we originally added cmd2_handler to it resulted in a RecursionError.
+        # Make sure printing the Namespace works.
         self.poutput(args)
 
     helpless_subcmd_parser = cmd2.Cmd2ArgumentParser(add_help=False, description="A subcommand with no help")
@@ -373,7 +373,7 @@ class SubcommandApp(cmd2.Cmd):
         "test_subcmd_decorator", "helpless_subcmd", helpless_subcmd_parser, help=helpless_subcmd_parser.description.lower()
     )
     def helpless_subcmd_func(self, args: argparse.Namespace) -> None:
-        # Make sure vars(Namespace) works. The way we originally added cmd2_handler to it resulted in a RecursionError.
+        # Make sure vars(Namespace) works.
         self.poutput(vars(args))
 
 

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -1314,7 +1314,7 @@ class CustomCompleterApp(cmd2.Cmd):
     def do_top(self, args: argparse.Namespace) -> None:
         """Top level command"""
         # Call handler for whatever subcommand was selected
-        args.cmd2_subcmd_handler(args)
+        args.cmd2_subcommand_func(args)
 
     # Parser for a subcommand with no custom completer type
     no_custom_completer_parser = Cmd2ArgumentParser(description="No custom completer")

--- a/tests/test_argparse_completer.py
+++ b/tests/test_argparse_completer.py
@@ -1288,17 +1288,23 @@ class CustomCompleterApp(cmd2.Cmd):
         super().__init__()
         self.is_ready = True
 
-    # Parser that's used to test setting the app-wide default ArgparseCompleter type
-    default_completer_parser = Cmd2ArgumentParser(description="Testing app-wide argparse completer")
-    default_completer_parser.add_argument("--myflag", complete_when_ready=True)
+    @staticmethod
+    def _build_default_completer_parser() -> Cmd2ArgumentParser:
+        """Build parser to test setting the app-wide default ArgparseCompleter type.
 
-    @with_argparser(default_completer_parser)
+        Use a factory so set_default_argparse_completer() can be called before parser initialization.
+        """
+        default_completer_parser = Cmd2ArgumentParser(description="Testing app-wide argparse completer")
+        default_completer_parser.add_argument("--myflag", complete_when_ready=True)
+        return default_completer_parser
+
+    @with_argparser(_build_default_completer_parser)
     def do_default_completer(self, args: argparse.Namespace) -> None:
         """Test command"""
 
     # Parser that's used to test setting a custom completer at the parser level
     custom_completer_parser = Cmd2ArgumentParser(
-        description="Testing parser-specific argparse completer", ap_completer_type=CustomCompleter
+        description="Testing parser-specific argparse completer", completer_class=CustomCompleter
     )
     custom_completer_parser.add_argument("--myflag", complete_when_ready=True)
 
@@ -1325,7 +1331,7 @@ class CustomCompleterApp(cmd2.Cmd):
         pass
 
     # Parser for a subcommand with a custom completer type
-    custom_completer_parser2 = Cmd2ArgumentParser(description="Custom completer", ap_completer_type=CustomCompleter)
+    custom_completer_parser2 = Cmd2ArgumentParser(description="Custom completer", completer_class=CustomCompleter)
     custom_completer_parser2.add_argument("--myflag", complete_when_ready=True)
 
     @cmd2.as_subcommand_to("top", "custom", custom_completer_parser2, help="custom completer")
@@ -1338,10 +1344,10 @@ def custom_completer_app():
     return CustomCompleterApp()
 
 
-def test_default_custom_completer_type(custom_completer_app: CustomCompleterApp) -> None:
+def test_default_custom_completer(custom_completer_app: CustomCompleterApp) -> None:
     """Test altering the app-wide default ArgparseCompleter type"""
     try:
-        argparse_completer.set_default_ap_completer_type(CustomCompleter)
+        argparse_completer.set_default_argparse_completer(CustomCompleter)
 
         text = "--m"
         line = f"default_completer {text}"
@@ -1360,7 +1366,7 @@ def test_default_custom_completer_type(custom_completer_app: CustomCompleterApp)
 
     finally:
         # Restore the default completer
-        argparse_completer.set_default_ap_completer_type(argparse_completer.ArgparseCompleter)
+        argparse_completer.set_default_argparse_completer(argparse_completer.ArgparseCompleter)
 
 
 def test_custom_completer_type(custom_completer_app: CustomCompleterApp) -> None:
@@ -1421,9 +1427,9 @@ def test_add_parser_custom_completer() -> None:
     subparsers = parser.add_subparsers()
 
     no_custom_completer_parser: Cmd2ArgumentParser = subparsers.add_parser(name="no_custom_completer")
-    assert no_custom_completer_parser.ap_completer_type is None
+    assert no_custom_completer_parser.completer_class is argparse_completer.DEFAULT_ARGPARSE_COMPLETER
 
     custom_completer_parser: Cmd2ArgumentParser = subparsers.add_parser(
-        name="custom_completer", ap_completer_type=CustomCompleter
+        name="custom_completer", completer_class=CustomCompleter
     )
-    assert custom_completer_parser.ap_completer_type is CustomCompleter
+    assert custom_completer_parser.completer_class is CustomCompleter

--- a/tests/test_argparse_utils.py
+++ b/tests/test_argparse_utils.py
@@ -863,3 +863,30 @@ def test_deprecated_subcommand() -> None:
     # Verify it was removed from _deprecated set
     assert "old" not in subparsers_action._deprecated  # type: ignore[attr-defined]
     assert "old_alias" not in subparsers_action._deprecated  # type: ignore[attr-defined]
+
+
+def test_set_default_argument_parser() -> None:
+    """Test altering the app-wide default Cmd2ArgumentParser class"""
+
+    class CustomParser(Cmd2ArgumentParser):
+        pass
+
+    try:
+        # Check the default parser type
+        assert argparse_utils.DEFAULT_ARGUMENT_PARSER is Cmd2ArgumentParser
+
+        default_app = cmd2.Cmd()
+        default_alias_parser = default_app.command_parsers.get(default_app.do_alias)
+        assert type(default_alias_parser) is Cmd2ArgumentParser
+
+        # Set a custom default parser type
+        argparse_utils.set_default_argument_parser(CustomParser)
+        assert argparse_utils.DEFAULT_ARGUMENT_PARSER is CustomParser
+
+        custom_app = cmd2.Cmd()
+        custom_alias_parser = custom_app.command_parsers.get(custom_app.do_alias)
+        assert type(custom_alias_parser) is CustomParser
+
+    finally:
+        # Restore the original parser
+        argparse_utils.set_default_argument_parser(Cmd2ArgumentParser)

--- a/tests/test_commandset.py
+++ b/tests/test_commandset.py
@@ -95,8 +95,8 @@ class CommandSetA(CommandSetBase):
     @cmd2.with_category("Alone")
     @cmd2.with_argparser(main_parser)
     def do_main(self, args: argparse.Namespace) -> None:
-        # Call handler for whatever subcommand was selected
-        args.cmd2_subcmd_handler(args)
+        # Call function for whatever subcommand was selected
+        args.cmd2_subcommand_func(args)
 
     # main -> sub
     subcmd_parser = cmd2.Cmd2ArgumentParser(description="Sub Command")
@@ -394,7 +394,7 @@ class LoadableBase(cmd2.CommandSet):
         self._cut_called = False
 
     cut_parser = cmd2.Cmd2ArgumentParser()
-    cut_subparsers = cut_parser.add_subparsers(title="item", help="item to cut")
+    cut_parser.add_subparsers(title="item", help="item to cut", metavar="ITEM", required=True)
 
     def namespace_provider(self) -> argparse.Namespace:
         ns = argparse.Namespace()
@@ -404,18 +404,12 @@ class LoadableBase(cmd2.CommandSet):
     @cmd2.with_argparser(cut_parser)
     def do_cut(self, ns: argparse.Namespace) -> None:
         """Cut something"""
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-            self._cut_called = True
-        else:
-            # No subcommand was provided, so call help
-            self._cmd.pwarning("This command does nothing without sub-parsers registered")
-            self._cmd.do_help("cut")
+        # Call whatever subcommand function was selected
+        ns.cmd2_subcommand_func(ns)
+        self._cut_called = True
 
     stir_parser = cmd2.Cmd2ArgumentParser()
-    stir_subparsers = stir_parser.add_subparsers(title="item", help="what to stir")
+    stir_subparsers = stir_parser.add_subparsers(title="item", help="what to stir", metavar="ITEM", required=True)
 
     @cmd2.with_argparser(stir_parser, ns_provider=namespace_provider)
     def do_stir(self, ns: argparse.Namespace) -> None:
@@ -424,27 +418,17 @@ class LoadableBase(cmd2.CommandSet):
             self._cmd.poutput("Need to cut before stirring")
             return
 
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-        else:
-            # No subcommand was provided, so call help
-            self._cmd.pwarning("This command does nothing without sub-parsers registered")
-            self._cmd.do_help("stir")
+        # Call whatever subcommand function was selected
+        ns.cmd2_subcommand_func(ns)
 
     stir_pasta_parser = cmd2.Cmd2ArgumentParser()
     stir_pasta_parser.add_argument("--option", "-o")
-    stir_pasta_parser.add_subparsers(title="style", help="Stir style")
+    stir_pasta_parser.add_subparsers(title="style", help="Stir style", required=True)
 
     @cmd2.as_subcommand_to("stir", "pasta", stir_pasta_parser)
     def stir_pasta(self, ns: argparse.Namespace) -> None:
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-        else:
-            self._cmd.poutput("Stir pasta haphazardly")
+        # Call whatever subcommand function was selected
+        ns.cmd2_subcommand_func(ns)
 
 
 class LoadableBadBase(cmd2.CommandSet):
@@ -452,16 +436,9 @@ class LoadableBadBase(cmd2.CommandSet):
         super().__init__()
         self._dummy = dummy  # prevents autoload
 
-    def do_cut(self, ns: argparse.Namespace) -> None:
+    # Create function which fails to decorate as an argparse base command.
+    def do_cut(self, _: cmd2.Statement) -> None:
         """Cut something"""
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-        else:
-            # No subcommand was provided, so call help
-            self._cmd.poutput("This command does nothing without sub-parsers registered")
-            self._cmd.do_help("cut")
 
 
 class LoadableFruits(cmd2.CommandSet):
@@ -548,7 +525,7 @@ def test_subcommands(manual_command_sets_app) -> None:
         manual_command_sets_app._register_subcommands(fruit_cmds)
 
     cmd_result = manual_command_sets_app.app_cmd("cut")
-    assert "This command does nothing without sub-parsers registered" in cmd_result.stderr
+    assert "Error: the following arguments are required" in cmd_result.stderr
 
     # verify that command set install without problems
     manual_command_sets_app.register_command_set(fruit_cmds)
@@ -722,19 +699,13 @@ class AppWithSubCommands(cmd2.Cmd):
         super().__init__(*args, **kwargs)
 
     cut_parser = cmd2.Cmd2ArgumentParser()
-    cut_subparsers = cut_parser.add_subparsers(title="item", help="item to cut")
+    cut_parser.add_subparsers(title="item", help="item to cut", metavar="ITEM", required=True)
 
     @cmd2.with_argparser(cut_parser)
     def do_cut(self, ns: argparse.Namespace) -> None:
         """Cut something"""
-        handler = ns.cmd2_subcmd_handler
-        if handler is not None:
-            # Call whatever subcommand function was selected
-            handler(ns)
-        else:
-            # No subcommand was provided, so call help
-            self.poutput("This command does nothing without sub-parsers registered")
-            self.do_help("cut")
+        # Call whatever subcommand function was selected
+        ns.cmd2_subcommand_func(ns)
 
     banana_parser = cmd2.Cmd2ArgumentParser()
     banana_parser.add_argument("direction", choices=["discs", "lengthwise"])
@@ -1001,7 +972,7 @@ def test_bad_subcommand() -> None:
             super().__init__(*args, **kwargs)
 
         cut_parser = cmd2.Cmd2ArgumentParser()
-        cut_subparsers = cut_parser.add_subparsers(title="item", help="item to cut")
+        cut_parser.add_subparsers(title="item", help="item to cut", metavar="ITEM", required=True)
 
         @cmd2.with_argparser(cut_parser)
         def do_cut(self, ns: argparse.Namespace) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -396,3 +396,37 @@ def test_get_types_method() -> None:
     param_name, param_value = next(iter(param_ann.items()))
     assert param_name == "x"
     assert param_value is bool
+
+
+def test_categorize() -> None:
+    from cmd2 import constants
+
+    category = "Test Category"
+    attr_name = constants.COMMAND_ATTR_HELP_CATEGORY
+
+    # Test single function
+    def func1() -> None:
+        pass
+
+    cu.categorize(func1, category)
+    assert getattr(func1, attr_name) == category
+
+    # Test iterable of functions
+    def func2() -> None:
+        pass
+
+    def func3() -> None:
+        pass
+
+    cu.categorize([func2, func3], category)
+    assert getattr(func2, attr_name) == category
+    assert getattr(func3, attr_name) == category
+
+    # Test bound method
+    class Foo:
+        def bar(self) -> None:
+            pass
+
+    f = Foo()
+    cu.categorize(f.bar, category)
+    assert getattr(Foo.bar, attr_name) == category

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -411,22 +411,24 @@ def test_categorize() -> None:
     cu.categorize(func1, category)
     assert getattr(func1, attr_name) == category
 
-    # Test iterable of functions
-    def func2() -> None:
-        pass
-
-    def func3() -> None:
-        pass
-
-    cu.categorize([func2, func3], category)
-    assert getattr(func2, attr_name) == category
-    assert getattr(func3, attr_name) == category
-
-    # Test bound method
+    # Test single method
     class Foo:
-        def bar(self) -> None:
+        def foo_method(self) -> None:
             pass
 
     f = Foo()
-    cu.categorize(f.bar, category)
-    assert getattr(Foo.bar, attr_name) == category
+    cu.categorize(f.foo_method, category)
+    assert getattr(Foo.foo_method, attr_name) == category
+
+    # Test iterable
+    def func2() -> None:
+        pass
+
+    class Bar:
+        def bar_method(self) -> None:
+            pass
+
+    b = Bar()
+    cu.categorize([func2, b.bar_method], category)
+    assert getattr(func2, attr_name) == category
+    assert getattr(Bar.bar_method, attr_name) == category


### PR DESCRIPTION
- Consistently use full words COMMAND and SUBCOMMAND over abbreviations
- Rename cmd2_subcmd_handler to cmd2_subcommand_func for consistency
- Consolidate command metadata into ArgparseCommandSpec dataclass
- Simplify subcommand examples by using required=True for subparsers
- Renamed set_default_argument_parser_type() to set_default_argument_parser().
- Renamed set_default_ap_completer_type() to set_default_argparse_completer().
- Renamed Cmd2ArgumentParser.ap_completer_type to completer_class.