### PR TITLE
docs: fix deprecated git:// URL in installation guide

### DIFF
--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -55,7 +55,7 @@ The latest version of `cmd2` can be installed directly from the main branch on :
 GitHub using [pip](https://pypi.org/project/pip):
 
 ```shell
-$ pip install -U git+git://github.com/python-cmd2/cmd2.git
+$ pip install -U git+https://github.com/python-cmd2/cmd2.git
 ```
 
 ## Install from Debian or Ubuntu repos


### PR DESCRIPTION
## What

The "Install from GitHub" section of the installation docs uses the `git://` protocol:

```
pip install -U git+git://github.com/python-cmd2/cmd2.git
```

GitHub [disabled the unauthenticated Git protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/) (`git://`) on March 15, 2022. Anyone following this instruction today will see an error like:

```
fatal: remote error: The unauthenticated git protocol on port 9418 is no longer supported.
```

## Fix

Replace `git://` with `https://`:

```
pip install -U git+https://github.com/python-cmd2/cmd2.git
```

## Verification

The fixed command works correctly and pip is able to install cmd2 directly from the GitHub main branch.