### PR TITLE
tests: make tests compatible with rich 14.3.3

### DIFF
--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -3692,7 +3692,7 @@ def test_ansi_pouterr_always_tty(mocker, capsys) -> None:
     mocker.patch.object(sys.stderr, "isatty", return_value=True)
 
     expected_plain = "oopsie\n"
-    expected_styled = su.stylize("oopsie\n", Cmd2Style.ERROR)
+    expected_styled = su.stylize('oopsie', Cmd2Style.ERROR) + '\n'
 
     app.onecmd_plus_hooks("echo_error oopsie")
     out, err = capsys.readouterr()
@@ -3712,7 +3712,7 @@ def test_ansi_pouterr_always_notty(mocker, capsys) -> None:
     mocker.patch.object(sys.stderr, "isatty", return_value=False)
 
     expected_plain = "oopsie\n"
-    expected_styled = su.stylize("oopsie\n", Cmd2Style.ERROR)
+    expected_styled = su.stylize('oopsie', Cmd2Style.ERROR) + '\n'
 
     app.onecmd_plus_hooks("echo_error oopsie")
     out, err = capsys.readouterr()
@@ -3732,7 +3732,7 @@ def test_ansi_terminal_tty(mocker, capsys) -> None:
     mocker.patch.object(sys.stderr, "isatty", return_value=True)
 
     expected_plain = "oopsie\n"
-    expected_styled = su.stylize("oopsie\n", Cmd2Style.ERROR)
+    expected_styled = su.stylize('oopsie', Cmd2Style.ERROR) + '\n'
 
     app.onecmd_plus_hooks("echo_error oopsie")
     out, err = capsys.readouterr()


### PR DESCRIPTION
It seems that with the upgrade to rich 14.3.3 (what we have in openSUSE/Tumbleweed) `stylize` function eats EOLs. I have modified tests to acommodate that, and I hope it should be universal enough so that even with older versions of rich nothing should break.