### PR TITLE
Change title to make it unambiguous 

### DIFF
--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -1,7 +1,8 @@
-# Migrating From cmd
+# Upgrading from cmd to cmd2
 
-If you're thinking of migrating your [cmd](https://docs.python.org/3/library/cmd.html) app to
-`cmd2`, this section will help you decide if it's right for your app, and show you how to do it.
+If you're thinking of upgrading your [cmd](https://docs.python.org/3/library/cmd.html) app to be
+based on `cmd2`, this section will help you decide if it's right for your app, and show you how to
+do it.
 
 - [Why cmd2](why.md) - we try and convince you to use `cmd2` instead of
   [cmd](https://docs.python.org/3/library/cmd.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,7 +147,7 @@ nav:
       - overview/integrating.md
       - overview/alternatives.md
       - overview/resources.md
-  - Migrating From cmd:
+  - Upgrading from cmd to cmd2:
       - migrating/index.md
       - migrating/why.md
       - migrating/incompatibilities.md


### PR DESCRIPTION
Change title for a documentation page to make it unambigous as well as more positive and action-oriented.

Changed title of one page in documentation from "Migrating From cmd" to "Upgrading from cmd to cmd2"

Closes #1677 