### PR TITLE
Fixed mypy 2.2.0 failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.1 (TBD)
+
+- Bug Fixes
+    - Fixed a couple type issues that emerged with the upgrade to `mypy` 2.2.0
+
 ## 4.1.0 (July 7, 2026)
 
 - Breaking Changes

--- a/cmd2/argparse_utils.py
+++ b/cmd2/argparse_utils.py
@@ -1035,13 +1035,13 @@ class Cmd2ArgumentParser(argparse.ArgumentParser):
 
         self.exit(2, f"{formatted_message}\n")
 
-    def _get_formatter(self, **_kwargs: Any) -> Cmd2HelpFormatter:
+    def _get_formatter(self, *_args: Any, **_kwargs: Any) -> Cmd2HelpFormatter:
         """Override with customizations for Cmd2HelpFormatter."""
         return self.formatter_class(prog=self.prog, file=self._thread_locals.current_output_file)
 
-    def format_help(self) -> str:
+    def format_help(self, *args: Any, **kwargs: Any) -> str:
         """Override to add a newline."""
-        return super().format_help() + "\n"
+        return super().format_help(*args, **kwargs) + "\n"
 
     def _get_nargs_pattern(self, action: argparse.Action) -> str:
         """Override to support nargs ranges."""


### PR DESCRIPTION
 `mypy` 2.2.0 updated its `typeshed` definitions for `argparse.ArgumentParser` to align with recent updates to the standard library in newer Python versions (such as the addition of the `file` argument for output coloring and the optional `formatter` parameter).

These new type stub signatures broke our overrides in `cmd2/argparse_utils.py`:
   - `_get_formatter` failed because the typeshed stub specifies it can accept an optional parameter `file` positionally, but our override only captured keyword arguments only (`**_kwargs: Any`).
   - `format_help` failed because our override strictly took no arguments (`def format_help(self)`), while the base class accepts `formatter`.

Closes #1708 