### PR TITLE
Fixed some broken autoref links in the Zensical documentation

### DIFF
--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -552,7 +552,7 @@ class StatementParser:
     def parse_command_only(self, rawinput: str) -> PartialStatement:
         """Identify the command and arguments from raw input.
 
-        Partially parse input into a `cmd2.parsingPartialStatement` object.
+        Partially parse input into a [cmd2.parsing.PartialStatement][] object.
 
         The command is identified, and shortcuts and aliases are expanded.
         Multiline commands are identified, but terminators and output

--- a/cmd2/parsing.py
+++ b/cmd2/parsing.py
@@ -248,7 +248,7 @@ class PartialStatement:
 
     Note:
         Unlike [cmd2.parsing.Statement][], this is a simple data object
-        and does not inherit from [str][].
+        and does not inherit from `str`.
 
     """
 
@@ -552,7 +552,7 @@ class StatementParser:
     def parse_command_only(self, rawinput: str) -> PartialStatement:
         """Identify the command and arguments from raw input.
 
-        Partially parse input into a [cmd2.PartialStatement][] object.
+        Partially parse input into a `cmd2.parsingPartialStatement` object.
 
         The command is identified, and shortcuts and aliases are expanded.
         Multiline commands are identified, but terminators and output
@@ -561,7 +561,7 @@ class StatementParser:
         This method is optimized for completion code and gracefully handles
         unclosed quotes without raising exceptions.
 
-        [cmd2.parsing.PartialStatement.args][] will include all output redirection
+        `cmd2.parsing.PartialStatement.args` will include all output redirection
         clauses and command terminators.
 
         Note:
@@ -571,7 +571,7 @@ class StatementParser:
             whitespace only if all quotes are closed.
 
         :param rawinput: the command line as entered by the user
-        :return: a [cmd2.PartialStatement][] object representing the split input
+        :return: a `PartialStatement` object representing the split input
 
         """
         # Expand shortcuts and aliases

--- a/docs/features/argument_processing.md
+++ b/docs/features/argument_processing.md
@@ -226,15 +226,15 @@ benefit is that your `cmd2` applications now have more aesthetically pleasing he
 color to make it quicker and easier to visually parse help text. This works for all supported
 versions of Python.
 
-- [Cmd2HelpFormatter][cmd2.argparse_utils.Cmd2HelpFormatter] - default help formatter class
-- [ArgumentDefaultsCmd2HelpFormatter][cmd2.argparse_utils.ArgumentDefaultsCmd2HelpFormatter] - adds
+- [Cmd2HelpFormatter][cmd2.rich_utils.Cmd2HelpFormatter] - default help formatter class
+- [ArgumentDefaultsCmd2HelpFormatter][cmd2.rich_utils.ArgumentDefaultsCmd2HelpFormatter] - adds
   default values to argument help
-- [MetavarTypeCmd2HelpFormatter][cmd2.argparse_utils.MetavarTypeCmd2HelpFormatter] - uses the
-  argument 'type' as the default metavar value (instead of the argument 'dest')
-- [RawDescriptionCmd2HelpFormatter][cmd2.argparse_utils.RawDescriptionCmd2HelpFormatter] - retains
-  any formatting in descriptions and epilogs
-- [RawTextCmd2HelpFormatter][cmd2.argparse_utils.RawTextCmd2HelpFormatter] - retains formatting of
-  all help text
+- [MetavarTypeCmd2HelpFormatter][cmd2.rich_utils.MetavarTypeCmd2HelpFormatter] - uses the argument
+  'type' as the default metavar value (instead of the argument 'dest')
+- [RawDescriptionCmd2HelpFormatter][cmd2.rich_utils.RawDescriptionCmd2HelpFormatter] - retains any
+  formatting in descriptions and epilogs
+- [RawTextCmd2HelpFormatter][cmd2.rich_utils.RawTextCmd2HelpFormatter] - retains formatting of all
+  help text
 
 The default `Cmd2HelpFormatter` class inherits from `argparse.HelpFormatter`. If you want a
 different behavior, then pass the desired class to the `formatter_class` argument of your argparse

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -76,8 +76,8 @@ The major things users should be aware of when upgrading to 3.x are detailed in 
 #### ansi
 
 The functionality within the `cmd2.ansi` module has either been removed or changed to be based on
-`rich` and moved to one of the new modules: [cmd2.string_utils][], [cmd2.styles][], or
-[cmd2.terminal_utils][].
+`rich` and moved to one of the new modules: [cmd2.colors][], [cmd2.string_utils][], or
+[cmd2.styles][].
 
 To ease the migration path from `cmd2` 2.x to 3.x, we have created the `cmd2-ansi` module which is a
 backport of the `cmd2.ansi` module present in `cmd2` 2.7.0 in a standalone fashion. Relevant links:
@@ -163,11 +163,11 @@ example for a demonstration of how to use the common [cmd2.string_utils.stylize]
 #### terminal_utils
 
 Support for terminal control escape sequences for things like setting the window title and
-asynchronous alerts has been moved from `cmd2.ansi` to the new [cmd2.terminal_utils][] module.
+asynchronous alerts has been moved from `cmd2.ansi` to within the main `cmd2.Cmd` application class.
 
 This isn't really intended to be used by end users, but is used by higher-level functionality that
 is intended to be used by end users such as [cmd2.Cmd.set_window_title][] and
-[cmd2.Cmd.async_alert][].
+[cmd2.Cmd.add_alert][].
 
 See [async_printing.py](https://github.com/python-cmd2/cmd2/blob/main/examples/async_printing.py)
 for an example of how to use this functionality in a `cmd2` application.
@@ -177,11 +177,11 @@ for an example of how to use this functionality in a `cmd2` application.
 `cmd2` now has 5 different Argparse HelpFormatter classes, all of which are based on the
 `RichHelpFormatter` class from [rich-argparse](https://github.com/hamdanal/rich-argparse).
 
-- [Cmd2HelpFormatter][cmd2.argparse_custom.Cmd2HelpFormatter]
-- [ArgumentDefaultsCmd2HelpFormatter][cmd2.argparse_custom.ArgumentDefaultsCmd2HelpFormatter]
-- [MetavarTypeCmd2HelpFormatter][cmd2.argparse_custom.MetavarTypeCmd2HelpFormatter]
-- [RawDescriptionCmd2HelpFormatter][cmd2.argparse_custom.RawDescriptionCmd2HelpFormatter]
-- [RawTextCmd2HelpFormatter][cmd2.argparse_custom.RawTextCmd2HelpFormatter]
+- [Cmd2HelpFormatter][cmd2.rich_utils.Cmd2HelpFormatter]
+- [ArgumentDefaultsCmd2HelpFormatter][cmd2.rich_utils.ArgumentDefaultsCmd2HelpFormatter]
+- [MetavarTypeCmd2HelpFormatter][cmd2.rich_utils.MetavarTypeCmd2HelpFormatter]
+- [RawDescriptionCmd2HelpFormatter][cmd2.rich_utils.RawDescriptionCmd2HelpFormatter]
+- [RawTextCmd2HelpFormatter][cmd2.rich_utils.RawTextCmd2HelpFormatter]
 
 Previously the default `Cmd2HelpFormatter` class inherited from `argparse.RawTextHelpFormatter`,
 however it now inherits from `argparse.HelpFormatter`. If you want RawText behavior, then pass


### PR DESCRIPTION
Fixed some broken autoref links in the Zensical documentation.

In the recent Zensical 0.0.56 some code that validates Python documentation automatic reference links has been fixed.  This change fixes some broken links that got identified because we moved things around.