### PR TITLE
uv run does its own sync of the project env with default groups

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install the project
         run: uv sync --no-default-groups --group docs
       - name: Check if the Zensical documentation can be built
-        run: uv run zensical build -s
+        run: uv run --no-default-groups --group docs zensical build -s

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Install the project
         run: uv sync --no-default-groups --group quality
       - name: Run prek
-        run: uv run prek run -a --show-diff-on-failure
+        run: uv run --no-default-groups --group quality prek run -a --show-diff-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,9 @@ jobs:
         run: uv sync --no-default-groups --group test
 
       - name: Run tests
-        run: uv run python -Xutf8 -m pytest --cov --cov-config=pyproject.toml --cov-report=xml tests
+        run:
+          uv run --no-default-groups --group test python -Xutf8 -m pytest --cov
+          --cov-config=pyproject.toml --cov-report=xml tests
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Check typing using ty
-        run: uv run ty check
+        run: uv run --no-default-groups --group validate ty check
 
       - name: Check typing using mypy
-        run: uv run mypy .
+        run: uv run --no-default-groups --group validate mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "pytest-cov>=5",
     "pytest-mock>=3.14.1",
 ]
-validate = ["mypy>=2.3.1", "ruff>=0.16.0", "ty>=0.0.75", "types-setuptools>=80.8.0"]
+validate = ["mypy>=2.3.1", "ty>=0.0.75", "types-setuptools>=80.8.0"]
 
 [tool.mypy]
 disallow_incomplete_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "pytest-cov>=5",
     "pytest-mock>=3.14.1",
 ]
-validate = ["mypy>=2.3.1", "ty>=0.0.75", "types-setuptools>=80.8.0"]
+validate = ["ipython>=8.23", "mypy>=2.3.1", "ty>=0.0.75", "types-setuptools>=80.8.0"]
 
 [tool.mypy]
 disallow_incomplete_defs = true


### PR DESCRIPTION
I noticed that test were taking much longer to run on Python 3.14t and the root cause was one dependency that wasn't needed to run tests didn't have a wheel available and needed to build from source.

It turns out that `uv run` does its own sync of the project env with default groups.

This PR modifies all "uv run" commands for GitHub Actions workflows to only install the dependency groups they need.

This reduces the time for running these workflows, dramatically so for test jobs on free-threaded variants of Python which was the long pole in our overall CI time for PRs. Hence this speeds up the overall time for GitHub CI to run for each PR.