### PR TITLE
Keep the right prompt out of the committed prompt frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.2.4 (TBD)
+
+- Bug Fixes
+    - Fixed the right prompt being redrawn beside every accepted command line in the scrollback.
+      prompt-toolkit includes it in the final frame of each prompt, which is the frame left on the
+      terminal; it is now hidden there, as the bottom toolbar already was, and stays on the live
+      prompt line only
+
 ## 4.2.3 (September 2, 2026)
 
 - Bug Fixes

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -80,6 +80,8 @@ from prompt_toolkit.input import DummyInput, create_input
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPress, KeyPressEvent
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import Window, walk
+from prompt_toolkit.layout.containers import ConditionalContainer, FloatContainer
 from prompt_toolkit.output import DummyOutput, create_output
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession, choice, set_title
@@ -552,6 +554,8 @@ class Cmd:
             enable_rprompt=enable_rprompt,
             refresh_interval=refresh_interval,
         )
+        if enable_rprompt:
+            self._hide_rprompt_when_done(self.main_session)
 
         # The session currently holding focus (either the main REPL or a command's
         # custom prompt). Completion and UI logic should reference this variable
@@ -844,6 +848,30 @@ class Cmd:
             }
         )
         return PromptSession(**kwargs)
+
+    @staticmethod
+    def _hide_rprompt_when_done(session: PromptSession[str]) -> None:
+        """Keep the right prompt out of the frame that is committed to the scrollback.
+
+        prompt-toolkit ends every ``Application.run()`` with a final render, and that
+        frame is what stays on the terminal. Its bottom toolbar container is filtered
+        with ``~is_done`` so it is excluded, but the right prompt is a plain ``Float``
+        with no such filter, which left a copy of the right prompt beside every
+        accepted command line. This applies the same rule the toolbar already gets.
+
+        The right prompt is cosmetic, so an upstream layout change must not stop the
+        application from starting. If the float cannot be found, nothing happens and
+        the previous behavior remains.
+
+        :param session: the PromptSession whose right prompt should be hidden when done
+        """
+        for container in walk(session.layout.container):
+            if not isinstance(container, FloatContainer):
+                continue
+            for float_ in container.floats:
+                content = float_.content
+                if isinstance(content, Window) and content.style == "class:rprompt":
+                    float_.content = ConditionalContainer(content, filter=~filters.is_done)
 
     def find_commandsets(
         self, commandset_type: type[CommandSet[Any]], *, subclass_match: bool = False

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -13,7 +13,7 @@ from typing import (
 from unittest import mock
 
 import pytest
-from prompt_toolkit.application import get_app
+from prompt_toolkit.application import create_app_session, get_app
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import DummyCompleter
 from prompt_toolkit.input import DummyInput, create_pipe_input
@@ -4460,11 +4460,15 @@ def test_rprompt_is_not_drawn_into_the_committed_line() -> None:
             drawn_while_done.append(get_app().is_done)
             return [("", "RPROMPT")]
 
-    app = RPromptApp(allow_cli_args=False, enable_rprompt=True)
-    with create_pipe_input() as pipe_input:
+    output = DummyOutput()
+    # Bind the ambient app session to this input and output. Without it, prompt-toolkit
+    # builds a real one on demand for calls such as patch_stdout() in _read_raw_input(),
+    # which needs a Windows console that CI does not provide.
+    with create_pipe_input() as pipe_input, create_app_session(input=pipe_input, output=output):
+        app = RPromptApp(allow_cli_args=False, enable_rprompt=True)
         app.main_session = PromptSession(
             input=pipe_input,
-            output=DummyOutput(),
+            output=output,
             rprompt=app.get_rprompt,
         )
         cmd2.cmd2.Cmd._hide_rprompt_when_done(app.main_session)

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -13,6 +13,7 @@ from typing import (
 from unittest import mock
 
 import pytest
+from prompt_toolkit.application import get_app
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import DummyCompleter
 from prompt_toolkit.input import DummyInput, create_pipe_input
@@ -4442,6 +4443,36 @@ def test_enable_rprompt() -> None:
     # Test False
     custom_app = cmd2.Cmd(enable_rprompt=False)
     assert custom_app.main_session.rprompt is None
+
+
+def test_rprompt_is_not_drawn_into_the_committed_line() -> None:
+    """The right prompt belongs to the live prompt line, not to the scrollback.
+
+    prompt-toolkit renders the right prompt as a Float with no ``~is_done`` filter,
+    unlike its bottom toolbar container, so by default it is part of the final frame
+    that gets committed to the terminal. That left a copy of the right prompt beside
+    every accepted command line in the scrollback.
+    """
+    drawn_while_done = []
+
+    class RPromptApp(cmd2.Cmd):
+        def get_rprompt(self):
+            drawn_while_done.append(get_app().is_done)
+            return [("", "RPROMPT")]
+
+    app = RPromptApp(allow_cli_args=False, enable_rprompt=True)
+    with create_pipe_input() as pipe_input:
+        app.main_session = PromptSession(
+            input=pipe_input,
+            output=DummyOutput(),
+            rprompt=app.get_rprompt,
+        )
+        cmd2.cmd2.Cmd._hide_rprompt_when_done(app.main_session)
+        pipe_input.send_text("hello\n")
+        assert app._read_raw_input("(Cmd) ", app.main_session) == "hello"
+
+    assert drawn_while_done, "the right prompt was never rendered at all"
+    assert True not in drawn_while_done, "the right prompt was drawn into the committed final frame"
 
 
 def test_get_bottom_toolbar(base_app: cmd2.Cmd) -> None:


### PR DESCRIPTION
## Problem

With `enable_rprompt=True`, the right prompt was redrawn beside **every** accepted command line in the scrollback, not just on the live prompt line:

```
myapp> echo one                            cwd=/Users/you/src/cmd2
one
myapp> echo two                            cwd=/Users/you/src/cmd2
two
```

## Cause

prompt-toolkit ends every `Application.run()` with a final render, and that frame is what stays on the terminal. `PromptSession` filters its bottom toolbar container with `~is_done` so the toolbar is excluded from it, but the right prompt is a plain `Float` with no such filter (`shortcuts/prompt.py:157-162`), so it is drawn into the committed frame once per command.

## Fix

Wrap that float in a `ConditionalContainer` with the same `~is_done` filter the toolbar already gets.

The float is located by its `"class:rprompt"` style rather than by its private `_RPrompt` type, matching how cmd2 already identifies the toolbar container by `"class:bottom-toolbar"`. A layout that does not contain it is left alone — the right prompt is cosmetic, and an upstream layout change must not stop the application from starting.

`main_session.rprompt` is untouched, so `main_session.rprompt == get_rprompt` still holds and the existing `test_enable_rprompt` passes unchanged.

## Verification

Driving `examples/getting_started.py` through a real pty:

| | accepted command lines | ...that also carry the right prompt |
| --- | --- | --- |
| `main` | 3 | **3** |
| this branch | 3 | **0** |

`tests/test_cmd2.py::test_rprompt_is_not_drawn_into_the_committed_line` asserts the right prompt is not rendered while `is_done`. Making the fix a no-op fails it with `the right prompt was drawn into the committed final frame`.

- `make check` clean (ruff, prettier, typos, `ty`, `mypy --strict`)
- `make test`: 1857 passed, 2 skipped
- `make docs-test` clean

## Provenance

Found while investigating the bottom toolbar flicker on #1748. That branch fixed this incidentally as a side effect of a much larger architecture change which does **not** fix the flicker and should not be merged; this extracts the one confirmed win as a standalone change against `main`.