### PR TITLE
Write redirected and piped output as UTF-8, and stop the suite inheriting colour settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 4.2.4 (TBD)
 
 - Bug Fixes
+    - Fixed output redirection and piping failing on systems whose default encoding is not UTF-8,
+      such as a Windows console using a legacy code page. Command output is rendered by Rich and
+      routinely contains non-ASCII, so redirecting it raised `UnicodeEncodeError` and left an empty
+      file behind. Redirection targets and pipes now use UTF-8 explicitly
     - Fixed the right prompt being redrawn beside every accepted command line in the scrollback.
       prompt-toolkit includes it in the final frame of each prompt, which is the frame left on the
       terminal; it is now hidden there, as the bottom toolbar already was, and stays on the live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 4.2.4 (TBD)
 
 - Bug Fixes
-    - Fixed output redirection and piping failing on systems whose default encoding is not UTF-8,
-      such as a Windows console using a legacy code page. Command output is rendered by Rich and
-      routinely contains non-ASCII, so redirecting it raised `UnicodeEncodeError` and left an empty
-      file behind. Redirection targets and pipes now use UTF-8 explicitly
+    - Fixed output redirection and piping raising `UnicodeEncodeError` and leaving an empty file
+      behind. Command output is rendered by Rich and contains box-drawing characters, which no
+      `cp125x` Windows ANSI code page can represent, so redirecting or piping it failed. This
+      affects current Windows 11 with default settings on Python 3.11 through 3.14, not only older
+      systems. Redirection targets and pipes now use UTF-8 explicitly
     - Fixed the right prompt being redrawn beside every accepted command line in the scrollback.
       prompt-toolkit includes it in the final frame of each prompt, which is the frame left on the
       terminal; it is now hidden there, as the bottom toolbar already was, and stays on the live

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3324,9 +3324,11 @@ class Cmd:
             # Create a pipe with read and write sides
             read_fd, write_fd = os.pipe()
 
-            # Open each side of the pipe
-            subproc_stdin = open(read_fd)  # noqa: SIM115
-            new_stdout: TextIO = cast(TextIO, open(write_fd, "w"))  # noqa: SIM115
+            # Open each side of the pipe. Both ends are given an explicit encoding:
+            # command output is rendered by Rich and routinely contains non-ASCII, which
+            # the locale encoding cannot always represent.
+            subproc_stdin = open(read_fd, encoding="utf-8")  # noqa: SIM115
+            new_stdout: TextIO = cast(TextIO, open(write_fd, "w", encoding="utf-8"))  # noqa: SIM115
 
             # Create pipe process in a separate group to isolate our signals from it. If a Ctrl-C event occurs,
             # our sigint handler will forward it only to the most recent pipe process. This makes sure pipe
@@ -3375,8 +3377,15 @@ class Cmd:
                 # statement.output can only contain REDIRECTION_APPEND or REDIRECTION_OUTPUT
                 mode = "a" if statement.redirector == constants.REDIRECTION_APPEND else "w"
                 try:
-                    # Use line buffering
-                    new_stdout = cast(TextIO, open(su.strip_quotes(statement.redirect_to), mode=mode, buffering=1))  # noqa: SIM115
+                    # Use line buffering. The encoding is explicit rather than the
+                    # locale's: command output is rendered by Rich and routinely contains
+                    # non-ASCII, so on a non-UTF-8 system -- a default Windows console,
+                    # for instance -- redirection would otherwise fail and leave an empty
+                    # file behind.
+                    new_stdout = cast(
+                        TextIO,
+                        open(su.strip_quotes(statement.redirect_to), mode=mode, buffering=1, encoding="utf-8"),  # noqa: SIM115
+                    )
                 except OSError as ex:
                     raise RedirectionError("Failed to redirect output") from ex
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,23 @@ def run_cmd(app: cmd2.Cmd, cmd: str) -> tuple[list[str], list[str]]:
     return normalize(out), normalize(err)
 
 
+#: Environment variables that change how Rich and cmd2 render output. Left inherited,
+#: they make unrelated tests fail depending on who runs the suite: NO_COLOR fails 15
+#: tests, FORCE_COLOR and TTY_COMPATIBLE 53 each.
+COLOR_ENVIRONMENT = ("NO_COLOR", "FORCE_COLOR", "TTY_COMPATIBLE", "TTY_INTERACTIVE")
+
+
+@pytest.fixture(autouse=True)
+def neutral_color_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Render output the same way regardless of the caller's environment.
+
+    Tests that exercise these variables set them explicitly, which still works because
+    a test's own monkeypatching runs after this fixture.
+    """
+    for name in COLOR_ENVIRONMENT:
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture
 def base_app() -> cmd2.Cmd:
     return cmd2.Cmd(include_py=True, include_ipy=True)

--- a/tests/test_run_pyscript.py
+++ b/tests/test_run_pyscript.py
@@ -246,7 +246,7 @@ def test_run_pyscript_print_redirection(base_app, request, tmp_path, capsys) -> 
     out, err = capsys.readouterr()
 
     # Verify the output file contains what we expect from print()
-    content = pathlib.Path(out_file).read_text()
+    content = pathlib.Path(out_file).read_text(encoding="utf-8")
 
     # Look for everything written to self.stdout
     assert len(content.splitlines()) == 4

--- a/tests/test_suite_environment.py
+++ b/tests/test_suite_environment.py
@@ -6,6 +6,7 @@ which is expensive to diagnose because the failures look like product regression
 """
 
 import os
+import sys
 
 import pytest
 
@@ -45,9 +46,14 @@ def test_redirection_to_a_file_uses_utf8(tmp_path) -> None:
     assert "ENCODING=utf-8" in target.read_text(encoding="utf-8")
 
 
+#: A pass-through filter, run with this interpreter so the test does not depend on Unix
+#: utilities being installed. `cmd.exe` has no `cat`, and this fix exists for Windows.
+PASS_THROUGH = "import sys; sys.stdin.reconfigure(encoding='utf-8'); sys.stdout.write(sys.stdin.read())"
+
+
 def test_piping_uses_utf8(tmp_path) -> None:
     """The same applies to the pipe the subprocess reads from."""
     app = EncodingProbe(allow_cli_args=False)
     target = tmp_path / "piped.txt"
-    app.onecmd_plus_hooks(f'show_encoding | cat > "{target}"')
+    app.onecmd_plus_hooks(f'show_encoding | "{sys.executable}" -c "{PASS_THROUGH}" > "{target}"')
     assert "ENCODING=utf-8" in target.read_text(encoding="utf-8")

--- a/tests/test_suite_environment.py
+++ b/tests/test_suite_environment.py
@@ -1,0 +1,22 @@
+"""Guards that the suite renders output independently of the developer's environment.
+
+Rich and cmd2 both consult environment variables when deciding whether to emit styling.
+Inheriting them makes large numbers of unrelated tests fail depending on who runs them,
+which is expensive to diagnose because the failures look like product regressions.
+"""
+
+import os
+
+import pytest
+
+#: Variables that change how output is rendered. Rich reads all of these; cmd2 reads
+#: NO_COLOR directly. Tests that exercise them set them explicitly instead.
+COLOR_ENVIRONMENT = ("NO_COLOR", "FORCE_COLOR", "TTY_COMPATIBLE", "TTY_INTERACTIVE")
+
+
+@pytest.mark.parametrize("name", COLOR_ENVIRONMENT)
+def test_color_environment_does_not_leak_into_tests(name: str) -> None:
+    """A developer exporting any of these must not change the suite's results."""
+    assert name not in os.environ, (
+        f"{name} leaked into the test environment; output-rendering assertions would depend on who is running the suite"
+    )

--- a/tests/test_suite_environment.py
+++ b/tests/test_suite_environment.py
@@ -9,6 +9,8 @@ import os
 
 import pytest
 
+import cmd2
+
 #: Variables that change how output is rendered. Rich reads all of these; cmd2 reads
 #: NO_COLOR directly. Tests that exercise them set them explicitly instead.
 COLOR_ENVIRONMENT = ("NO_COLOR", "FORCE_COLOR", "TTY_COMPATIBLE", "TTY_INTERACTIVE")
@@ -20,3 +22,32 @@ def test_color_environment_does_not_leak_into_tests(name: str) -> None:
     assert name not in os.environ, (
         f"{name} leaked into the test environment; output-rendering assertions would depend on who is running the suite"
     )
+
+
+class EncodingProbe(cmd2.Cmd):
+    """Reports the encoding of whatever stream output is currently going to."""
+
+    def do_show_encoding(self, _: str) -> None:
+        """Print the current output stream's encoding."""
+        self.poutput(f"ENCODING={getattr(self.stdout, 'encoding', None)}")
+
+
+def test_redirection_to_a_file_uses_utf8(tmp_path) -> None:
+    """cmd2 renders non-ASCII, so a redirect target must not use the locale encoding.
+
+    Opened with the locale encoding, redirecting styled output raises UnicodeEncodeError
+    on any non-UTF-8 system -- which includes a default Windows console -- leaving the
+    user an empty file and an error.
+    """
+    app = EncodingProbe(allow_cli_args=False)
+    target = tmp_path / "out.txt"
+    app.onecmd_plus_hooks(f'show_encoding > "{target}"')
+    assert "ENCODING=utf-8" in target.read_text(encoding="utf-8")
+
+
+def test_piping_uses_utf8(tmp_path) -> None:
+    """The same applies to the pipe the subprocess reads from."""
+    app = EncodingProbe(allow_cli_args=False)
+    target = tmp_path / "piped.txt"
+    app.onecmd_plus_hooks(f'show_encoding | cat > "{target}"')
+    assert "ENCODING=utf-8" in target.read_text(encoding="utf-8")


### PR DESCRIPTION
Two independent fixes, both already reviewed and merged to `consolidated_toolbar` in #1752.
Ported here because `main` is the next patch release and both problems are present on it
today. The third commit from #1752 — a `CommandToolbar` race — is **not** included, because
that module does not exist on `main`.

## 1. Redirection and piping fail on current Windows  *(user-visible data loss)*

Command output is rendered by Rich and contains box-drawing characters, but redirection
targets and pipes are opened with the locale's encoding. On Windows that is the ANSI code
page, and **no `cp125x` code page can represent them**, so redirecting raises
`UnicodeEncodeError` and the user is left with an empty file plus advice to set
`PYTHONIOENCODING`.

Measured on `main` at `ca0ddbe7`, running `help > out.txt` under a non-UTF-8 default encoding:

```
file size: 1 bytes
contains help text: False
```

After this change the same probe writes 153 bytes containing the help text.

### Who this affects

This is **not** limited to old systems. A fully updated Windows 11 with default settings is
affected. The character that breaks is `U+2500` (`─`), and encodability by code page is:

| Windows ANSI code page | Encodes `U+2500`? |
| --- | --- |
| cp1252 US / Western European | **No** |
| cp1250 Central European | **No** |
| cp1251 Cyrillic | **No** |
| cp1253–1258 Greek, Turkish, Hebrew, Arabic, Baltic, Vietnamese | **No** |
| cp932 / cp936 / cp949 / cp950 CJK | Yes |

Only the CJK double-byte code pages escape, because they happen to include box drawing.

By interpreter, `sys.flags.utf8_mode` is `0` on Python 3.11, 3.12, 3.13 and 3.14, and `1`
on 3.15 — PEP 686 makes UTF-8 mode the default there. So every Python version this project
currently supports below 3.15 is affected.

The other escapes are Windows' *"Beta: Use Unicode UTF-8 for worldwide language support"*
option, which is off by default, and setting `PYTHONUTF8=1` or `-X utf8`.

In short: a user on Windows 11, US locale, Python 3.13, typing `help > out.txt` in any cmd2
app loses their output. That is the common case, not an edge case.

`main`'s own tests do not catch this — nothing there redirects Rich-heavy output and reads it
back, so the suite passes while the product is broken. This PR adds tests that do.

## 2. The suite inherits the caller's colour environment

Rich and cmd2 consult several environment variables when deciding whether to emit styling,
and the suite inherits them. Exporting any one makes large numbers of unrelated tests fail
depending on who runs the suite — measured on `main`:

| Variable | Tests failed |
| --- | ---: |
| `NO_COLOR=1` | 15 |
| `FORCE_COLOR=1` | 53 |
| `TTY_COMPATIBLE=1` | 53 |

The failures look like product regressions, which makes them expensive to diagnose; this
cost a reviewer and me a full round trip before the cause was found. An autouse fixture now
neutralizes them, and a guard test fails if any reaches a test again. Tests that exercise
these variables still set them explicitly, because a test's own monkeypatching runs after
the fixture.

## Verification

Full suite under every environment that previously broke it:

```
baseline           1863 passed, 2 skipped
NO_COLOR=1         1863 passed, 2 skipped
FORCE_COLOR=1      1863 passed, 2 skipped
TTY_COMPATIBLE=1   1863 passed, 2 skipped
non-UTF8 locale    1863 passed, 2 skipped
```

`make check`, `make test` and `make docs-test` all pass. Reverting either encoding change
fails the new tests.

The pipe test runs its filter through `sys.executable` rather than `cat`, matching the
convention in the existing pipe tests — `cmd.exe` has no `cat`, and this fix exists for
Windows. Note that CI would not have caught that: GitHub's Windows runners have Git for
Windows' utilities on `PATH`.

## Note for merging

These commits also exist on `consolidated_toolbar` via #1752, so the same change appears in
both histories. The content is identical, so the eventual merge resolves cleanly.