### PR TITLE
Fix ty errors present in version 0.0.79 which came out yesterday

### DIFF
--- a/cmd2/annotated.py
+++ b/cmd2/annotated.py
@@ -313,6 +313,7 @@ from .rich_utils import Cmd2HelpFormatter, HelpContent
 from .types import (
     BoundCommandFunc,
     CmdOrSetT,
+    CmdOrSetT_contra,
     UnboundChoicesProvider,
     UnboundCompleter,
 )
@@ -2907,23 +2908,25 @@ class _BoundAnnotatedCommand(Protocol[_CommandParams, _CommandReturn_co]):
     def __call__(self, *args: _CommandParams.args, **kwargs: _CommandParams.kwargs) -> _CommandReturn_co: ...
 
 
-class _AnnotatedCommand(Protocol[CmdOrSetT, _CommandParams, _CommandReturn_co]):
+class _AnnotatedCommand(Protocol[CmdOrSetT_contra, _CommandParams, _CommandReturn_co]):
     """A callable command method with the metadata used by ``with_annotated``."""
 
     __name__: str
     __qualname__: str
 
     def __call__(
-        self, __self: CmdOrSetT, /, *args: _CommandParams.args, **kwargs: _CommandParams.kwargs
+        self, __self: CmdOrSetT_contra, /, *args: _CommandParams.args, **kwargs: _CommandParams.kwargs
     ) -> _CommandReturn_co: ...
 
     @overload
     def __get__(
         self, instance: None, owner: Any = ...
-    ) -> "_AnnotatedCommand[CmdOrSetT, _CommandParams, _CommandReturn_co]": ...
+    ) -> "_AnnotatedCommand[CmdOrSetT_contra, _CommandParams, _CommandReturn_co]": ...
 
     @overload
-    def __get__(self, instance: CmdOrSetT, owner: Any = ...) -> _BoundAnnotatedCommand[_CommandParams, _CommandReturn_co]: ...
+    def __get__(
+        self, instance: CmdOrSetT_contra, owner: Any = ...
+    ) -> _BoundAnnotatedCommand[_CommandParams, _CommandReturn_co]: ...
 
 
 class _WithAnnotatedDecorator(Protocol):

--- a/cmd2/types.py
+++ b/cmd2/types.py
@@ -58,6 +58,9 @@ CommandSetT = TypeVar("CommandSetT", bound="CommandSet[Any]")
 # Tracks the specific subclass instance (either a Cmd or CommandSet)
 CmdOrSetT = TypeVar("CmdOrSetT", bound=CmdOrSet)
 
+# For protocols that accept a Cmd or CommandSet instance
+CmdOrSetT_contra = TypeVar("CmdOrSetT_contra", bound=CmdOrSet, contravariant=True)
+
 # Tracks the specific class itself (either a Cmd or CommandSet class)
 CmdOrSetClassT = TypeVar("CmdOrSetClassT", bound=CmdOrSetClass)
 
@@ -88,20 +91,20 @@ class BoundCommandFunc(Protocol[P]):
 
 # An unbound cmd2 command function (e.g. the class method do_command).
 # The 'self' argument can be either a Cmd or CommandSet instance.
-class UnboundCommandFunc(Protocol[CmdOrSetT, P]):
+class UnboundCommandFunc(Protocol[CmdOrSetT_contra, P]):
     """Protocol for an unbound command function."""
 
     __name__: str
     __qualname__: str
 
-    def __call__(self, __self: CmdOrSetT, /, *args: P.args, **kwargs: P.kwargs) -> bool | None:
+    def __call__(self, __self: CmdOrSetT_contra, /, *args: P.args, **kwargs: P.kwargs) -> bool | None:
         """Invoke the unbound command function with its command instance."""
 
     @overload
-    def __get__(self, instance: None, owner: Any = ...) -> "UnboundCommandFunc[CmdOrSetT, P]": ...
+    def __get__(self, instance: None, owner: Any = ...) -> "UnboundCommandFunc[CmdOrSetT_contra, P]": ...
 
     @overload
-    def __get__(self, instance: CmdOrSetT, owner: Any = ...) -> BoundCommandFunc[P]: ...
+    def __get__(self, instance: CmdOrSetT_contra, owner: Any = ...) -> BoundCommandFunc[P]: ...
 
 
 ##################################################################################################


### PR DESCRIPTION
Added a new `CmdOrSetT_contra` contravariant typ to `types.h` for use in protocols that accept a Cmd or CommandSet instance. This is similar to the existing covariant `CmdOrSetT` type.

Also:
- Made use of this where necessary to fix type check failures