### PR TITLE
Reserved-row toolbar Stage 2a: terminal ownership, geometry model, and the Output adapter

### DIFF
--- a/cmd2/reserved_output.py
+++ b/cmd2/reserved_output.py
@@ -1,0 +1,309 @@
+"""A virtual :class:`~prompt_toolkit.output.Output` that hides the reserved rows.
+
+The application renders through this adapter and sees a terminal one reservation shorter
+than the real one. Everything it cannot reach is delegated to the backend unchanged.
+
+Two rules shape the whole module.
+
+**Explicit implementation, not ``__getattr__``.** ``Output`` is an abstract base class, so a
+class that answers by attribute lookup alone is not instantiable and, worse, silently
+acquires whatever a future prompt-toolkit adds without anyone deciding what the reservation
+means for it. Every abstract method is written out here.
+
+**The wrapped backend is never modified.** The earlier spike installed bounded erases by
+assigning over the backend's bound methods, which made restoration a matter of putting the
+right objects back in the right order and lost a caller's own override if one was already
+there. Wrapping instead means the backend a caller handed in is byte-for-byte the object
+they get back, whatever happened in between.
+
+The bounded erases are only sound from column zero: ``ED`` preserves the cursor line's
+prefix while ``DL`` deletes the whole line, and on tmux 3.7c a ``DL`` from a nonzero column
+destroyed committed text to its left. All three renderer paths that reach ``erase_down``
+move to column zero first, which is what makes the substitution valid for them -- a
+precondition, not an assumption, and the reason the replacement lives on an adapter that
+exists only while a reservation is installed rather than being installed on the backend
+permanently.
+"""
+
+from typing import TYPE_CHECKING
+
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.output import Output
+
+from .scroll_region import bounded_erase_down_sequence, bounded_erase_screen_sequence
+
+if TYPE_CHECKING:  # pragma: no cover
+    from prompt_toolkit.cursor_shapes import CursorShape
+    from prompt_toolkit.output import ColorDepth
+    from prompt_toolkit.styles import Attrs
+
+    from .terminal_display import TerminalDisplay
+
+
+class ReservedOutput(Output):
+    """Presents the usable region of a reserved terminal as if it were the whole terminal."""
+
+    #: Marks this object as an adapter so the physical layer can refuse to wrap it and read
+    #: sizes that have already had the reservation subtracted once.
+    is_reserved_adapter = True
+
+    def __init__(self, wrapped: Output, display: "TerminalDisplay") -> None:
+        """Wrap a backend for the duration of a reservation.
+
+        :param wrapped: the original backend, which this object never modifies
+        :param display: the owner of the current geometry
+        """
+        self._wrapped = wrapped
+        self._display = display
+        # A plain attribute rather than a property: Output declares stdout as writable, and
+        # code that reaches for the real stream must find the backend's, not a copy of it.
+        self.stdout = getattr(wrapped, "stdout", None)
+
+    @property
+    def wrapped(self) -> Output:
+        """The backend being wrapped."""
+        return self._wrapped
+
+    @property
+    def _usable_rows(self) -> int:
+        """Height of the usable region for the current generation."""
+        geometry = self._display.geometry
+        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+            return self._wrapped.get_size().rows
+        return geometry.usable_rows
+
+    # -- geometry -------------------------------------------------------------------------
+
+    def get_size(self) -> Size:
+        """Report the usable region as the terminal's size.
+
+        :return: the virtual size, one reservation shorter than the physical terminal
+        """
+        geometry = self._display.geometry
+        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+            return self._wrapped.get_size()
+        return geometry.virtual_size
+
+    def get_rows_below_cursor_position(self) -> int:
+        """Report the distance from the cursor to the bottom of the *usable* region.
+
+        Windows answers this natively from viewport and cursor data, so adapting
+        :meth:`get_size` alone would leave the renderer believing it can draw over the
+        reserved rows. POSIX backends raise :class:`NotImplementedError` here, which is
+        delegated unchanged so the renderer falls back to CPR exactly as it would have.
+
+        :return: rows below the cursor within the usable region, never negative
+        """
+        below = self._wrapped.get_rows_below_cursor_position()
+        geometry = self._display.geometry
+        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+            return below
+        return max(0, below - geometry.reserved_rows)
+
+    # -- erases ---------------------------------------------------------------------------
+
+    def erase_down(self) -> None:
+        """Clear from the cursor to the bottom margin, leaving the reserved rows intact."""
+        self._wrapped.write_raw(bounded_erase_down_sequence(self._usable_rows))
+
+    def erase_screen(self) -> None:
+        """Clear the usable region and home within it, leaving the reserved rows intact.
+
+        Homing is part of the contract rather than an extra: ``DL`` clears downward from the
+        cursor, so covering the whole usable area means starting at its top. ``Renderer.clear()``
+        homes immediately afterwards anyway, which is the path Ctrl-L takes.
+        """
+        self._wrapped.write_raw(bounded_erase_screen_sequence(self._usable_rows))
+
+    def erase_end_of_line(self) -> None:
+        """Clear to the end of the current line, which is bounded by the line already."""
+        self._wrapped.erase_end_of_line()
+
+    # -- screen buffers -------------------------------------------------------------------
+
+    def enter_alternate_screen(self) -> None:
+        """Hand the terminal over to the alternate buffer with full margins restored.
+
+        The two buffers keep separate margin state, and the application taking over knows
+        nothing about a reservation. Margins are restored before the switch so the main
+        buffer is left in the state the shell expects if the switch is never undone.
+        """
+        self._display.release_region_for_handoff()
+        self._wrapped.enter_alternate_screen()
+
+    def quit_alternate_screen(self) -> None:
+        """Return to the main buffer and re-establish the reservation for its geometry."""
+        self._wrapped.quit_alternate_screen()
+        self._display.reacquire_region_after_handoff()
+
+    def scroll_buffer_to_prompt(self) -> None:
+        """Scroll the Windows viewport to the prompt, then re-check the viewport origin.
+
+        This can move the viewport, and a moved viewport makes absolute row numbers address
+        different cells even when width and height are unchanged, so the geometry generation
+        has to be revalidated afterwards rather than assumed still current.
+        """
+        self._wrapped.scroll_buffer_to_prompt()
+        self._display.revalidate_viewport()
+
+    # -- straight delegation --------------------------------------------------------------
+
+    def fileno(self) -> int:
+        """Return the file descriptor of the underlying backend."""
+        return self._wrapped.fileno()
+
+    def encoding(self) -> str:
+        """Return the backend's encoding."""
+        return self._wrapped.encoding()
+
+    def write(self, data: str) -> None:
+        """Write text through the backend.
+
+        :param data: the text to write
+        """
+        self._wrapped.write(data)
+
+    def write_raw(self, data: str) -> None:
+        """Write unescaped data through the backend.
+
+        :param data: the raw data to write
+        """
+        self._wrapped.write_raw(data)
+
+    def set_title(self, title: str) -> None:
+        """Set the terminal title.
+
+        :param title: the title to set
+        """
+        self._wrapped.set_title(title)
+
+    def clear_title(self) -> None:
+        """Clear the terminal title."""
+        self._wrapped.clear_title()
+
+    def flush(self) -> None:
+        """Flush the backend's buffer.
+
+        This calls the backend's own ``flush``, which on Windows enables VT processing for
+        the write and restores the previous console mode afterwards. Flushing its inner VT
+        object directly would skip that.
+        """
+        self._wrapped.flush()
+
+    def set_attributes(self, attrs: "Attrs", color_depth: "ColorDepth") -> None:
+        """Apply text attributes.
+
+        :param attrs: the attributes to apply
+        :param color_depth: the color depth to render them at
+        """
+        self._wrapped.set_attributes(attrs, color_depth)
+
+    def reset_attributes(self) -> None:
+        """Reset text attributes to their defaults."""
+        self._wrapped.reset_attributes()
+
+    def disable_autowrap(self) -> None:
+        """Turn off automatic line wrapping."""
+        self._wrapped.disable_autowrap()
+
+    def enable_autowrap(self) -> None:
+        """Turn on automatic line wrapping."""
+        self._wrapped.enable_autowrap()
+
+    def cursor_goto(self, row: int = 0, column: int = 0) -> None:
+        """Move the cursor to a position within the usable region.
+
+        :param row: zero-based row, as prompt-toolkit counts them
+        :param column: zero-based column
+        """
+        self._wrapped.cursor_goto(row, column)
+
+    def cursor_up(self, amount: int) -> None:
+        """Move the cursor up.
+
+        :param amount: rows to move
+        """
+        self._wrapped.cursor_up(amount)
+
+    def cursor_down(self, amount: int) -> None:
+        """Move the cursor down.
+
+        :param amount: rows to move
+        """
+        self._wrapped.cursor_down(amount)
+
+    def cursor_forward(self, amount: int) -> None:
+        """Move the cursor right.
+
+        :param amount: columns to move
+        """
+        self._wrapped.cursor_forward(amount)
+
+    def cursor_backward(self, amount: int) -> None:
+        """Move the cursor left.
+
+        :param amount: columns to move
+        """
+        self._wrapped.cursor_backward(amount)
+
+    def hide_cursor(self) -> None:
+        """Hide the cursor."""
+        self._wrapped.hide_cursor()
+
+    def show_cursor(self) -> None:
+        """Show the cursor."""
+        self._wrapped.show_cursor()
+
+    def set_cursor_shape(self, cursor_shape: "CursorShape") -> None:
+        """Set the cursor shape.
+
+        :param cursor_shape: the shape to set
+        """
+        self._wrapped.set_cursor_shape(cursor_shape)
+
+    def reset_cursor_shape(self) -> None:
+        """Restore the default cursor shape."""
+        self._wrapped.reset_cursor_shape()
+
+    def enable_mouse_support(self) -> None:
+        """Turn on mouse reporting."""
+        self._wrapped.enable_mouse_support()
+
+    def disable_mouse_support(self) -> None:
+        """Turn off mouse reporting."""
+        self._wrapped.disable_mouse_support()
+
+    def enable_bracketed_paste(self) -> None:
+        """Turn on bracketed paste."""
+        self._wrapped.enable_bracketed_paste()
+
+    def disable_bracketed_paste(self) -> None:
+        """Turn off bracketed paste."""
+        self._wrapped.disable_bracketed_paste()
+
+    def reset_cursor_key_mode(self) -> None:
+        """Restore the default cursor-key mode."""
+        self._wrapped.reset_cursor_key_mode()
+
+    def ask_for_cpr(self) -> None:
+        """Ask the terminal for a cursor-position report.
+
+        The reply comes back in *physical* coordinates while the renderer compares it against
+        the virtual height. That arithmetic is correct only because the region is anchored at
+        row 1, which makes the usable height the last usable physical row index as well.
+        Validating the reply against the band belongs to the bridge, in Stage 2b.
+        """
+        self._wrapped.ask_for_cpr()
+
+    @property
+    def responds_to_cpr(self) -> bool:
+        """Whether the backend answers cursor-position reports."""
+        return self._wrapped.responds_to_cpr
+
+    def bell(self) -> None:
+        """Sound the terminal bell."""
+        self._wrapped.bell()
+
+    def get_default_color_depth(self) -> "ColorDepth":
+        """Return the backend's default color depth."""
+        return self._wrapped.get_default_color_depth()

--- a/cmd2/reserved_output.py
+++ b/cmd2/reserved_output.py
@@ -75,14 +75,6 @@ class ReservedOutput(Output):
         """
         return self._display.geometry is not None
 
-    @property
-    def _usable_rows(self) -> int:
-        """Height of the usable region for the current generation."""
-        geometry = self._display.geometry
-        if geometry is None:
-            return self._wrapped.get_size().rows
-        return geometry.usable_rows
-
     # -- geometry -------------------------------------------------------------------------
 
     def get_size(self) -> Size:
@@ -122,10 +114,11 @@ class ReservedOutput(Output):
         is only sound inside an active reservation, so outside one the backend's own erase is
         what runs.
         """
-        if not self.is_reserved:
+        geometry = self._display.geometry
+        if geometry is None:
             self._wrapped.erase_down()
             return
-        self._wrapped.write_raw(bounded_erase_down_sequence(self._usable_rows))
+        self._wrapped.write_raw(bounded_erase_down_sequence(geometry.usable_rows))
 
     def erase_screen(self) -> None:
         """Clear the usable region and home within it, leaving the reserved rows intact.
@@ -137,10 +130,11 @@ class ReservedOutput(Output):
         Outside an active reservation this defers to the backend, for the reason given on
         :meth:`erase_down`.
         """
-        if not self.is_reserved:
+        geometry = self._display.geometry
+        if geometry is None:
             self._wrapped.erase_screen()
             return
-        self._wrapped.write_raw(bounded_erase_screen_sequence(self._usable_rows))
+        self._wrapped.write_raw(bounded_erase_screen_sequence(geometry.usable_rows))
 
     def erase_end_of_line(self) -> None:
         """Clear to the end of the current line, which is bounded by the line already."""

--- a/cmd2/reserved_output.py
+++ b/cmd2/reserved_output.py
@@ -65,10 +65,21 @@ class ReservedOutput(Output):
         return self._wrapped
 
     @property
+    def is_reserved(self) -> bool:
+        """Whether a reservation is installed right now.
+
+        The adapter does outlive its reservation. A handoff to the alternate screen restores
+        full margins while deliberately keeping the lease, and prompt-toolkit holds the output
+        object it was created with, so this object keeps receiving calls with no region
+        installed. Every operation whose correctness depends on the margins has to ask.
+        """
+        return self._display.geometry is not None
+
+    @property
     def _usable_rows(self) -> int:
         """Height of the usable region for the current generation."""
         geometry = self._display.geometry
-        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+        if geometry is None:
             return self._wrapped.get_size().rows
         return geometry.usable_rows
 
@@ -80,7 +91,7 @@ class ReservedOutput(Output):
         :return: the virtual size, one reservation shorter than the physical terminal
         """
         geometry = self._display.geometry
-        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+        if geometry is None:
             return self._wrapped.get_size()
         return geometry.virtual_size
 
@@ -96,14 +107,24 @@ class ReservedOutput(Output):
         """
         below = self._wrapped.get_rows_below_cursor_position()
         geometry = self._display.geometry
-        if geometry is None:  # pragma: no cover - the adapter does not outlive its reservation
+        if geometry is None:
             return below
         return max(0, below - geometry.reserved_rows)
 
     # -- erases ---------------------------------------------------------------------------
 
     def erase_down(self) -> None:
-        """Clear from the cursor to the bottom margin, leaving the reserved rows intact."""
+        """Clear from the cursor to the bottom margin, leaving the reserved rows intact.
+
+        With no reservation installed there are no margins to be bounded by, so ``DL`` would
+        run against the whole screen and delete complete lines -- including the text to the
+        left of a nonzero cursor column, which ``ED`` would have preserved. The substitution
+        is only sound inside an active reservation, so outside one the backend's own erase is
+        what runs.
+        """
+        if not self.is_reserved:
+            self._wrapped.erase_down()
+            return
         self._wrapped.write_raw(bounded_erase_down_sequence(self._usable_rows))
 
     def erase_screen(self) -> None:
@@ -112,7 +133,13 @@ class ReservedOutput(Output):
         Homing is part of the contract rather than an extra: ``DL`` clears downward from the
         cursor, so covering the whole usable area means starting at its top. ``Renderer.clear()``
         homes immediately afterwards anyway, which is the path Ctrl-L takes.
+
+        Outside an active reservation this defers to the backend, for the reason given on
+        :meth:`erase_down`.
         """
+        if not self.is_reserved:
+            self._wrapped.erase_screen()
+            return
         self._wrapped.write_raw(bounded_erase_screen_sequence(self._usable_rows))
 
     def erase_end_of_line(self) -> None:

--- a/cmd2/scroll_region.py
+++ b/cmd2/scroll_region.py
@@ -25,6 +25,12 @@ tmux 3.7c, where a cursor at row 10 landed at row 1 after each. Every margin cha
 therefore wrapped in a save/restore pair (``ESC 7`` / ``ESC 8``), or entering the region below
 existing output would send later rendering to the top of the screen and overwrite it.
 
+This module is pure: it builds sequences and validates them, and installs nothing. Ownership
+of the terminal -- when a region may be established, how geometry is sampled, and which output
+the application renders through -- belongs to :mod:`cmd2.terminal_display` and
+:mod:`cmd2.reserved_output`. The bounded erase must not be installed on a backend outside an
+active reservation, which is why nothing here can install it.
+
 The caller is responsible for the cursor not being inside the reserved band when the region is
 established: this helper cannot discover the cursor's row without a cursor-position report,
 which needs input it does not have. Placing the prompt within the usable area belongs to the
@@ -36,14 +42,6 @@ its previous margins -- measured on tmux 3.7c, where output then scrolled throug
 reserved row and destroyed it. The failure is total rather than degraded, so callers must
 release the reservation below this floor rather than narrow it.
 """
-
-from types import TracebackType
-from typing import TYPE_CHECKING, Self
-
-if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Callable
-
-    from prompt_toolkit.output import Output
 
 #: Smallest region a terminal will honour. ``ESC [ 1 ; 1 r`` is ignored outright.
 MIN_USABLE_ROWS = 2
@@ -119,84 +117,3 @@ def bounded_erase_down_sequence(rows: int = _MAX_ROWS) -> str:
     :return: the escape sequence clearing from the cursor to the bottom margin
     """
     return f"\x1b[{rows}M"
-
-
-class ReservedBottomRows:
-    """Context manager reserving bottom rows and bounding the renderer's erase.
-
-    On entry it sets the scroll region and replaces the output's ``erase_down`` with a
-    margin-bounded equivalent; on exit it restores both, even if the body raises.
-    """
-
-    def __init__(self, output: "Output", reserved_rows: int = 1) -> None:
-        """Initialize the region.
-
-        :param output: the prompt_toolkit output to reserve rows on
-        :param reserved_rows: number of bottom rows to keep out of the scroll region
-        """
-        self._output = output
-        self._reserved_rows = reserved_rows
-        self._total_rows = output.get_size().rows
-        # Validate eagerly so a bad reservation fails at construction, not on entry.
-        self._region_sequence = scroll_region_sequence(self._total_rows, reserved_rows)
-        self._previous: dict[str, Callable[[], None] | None] = {}
-
-    @property
-    def usable_rows(self) -> int:
-        """Number of rows available to the application, excluding the reserved rows."""
-        return self._total_rows - self._reserved_rows
-
-    def _bounded_erase_down(self) -> None:
-        """Erase from the cursor to the bottom margin, leaving the reserved rows intact."""
-        self._output.write_raw(bounded_erase_down_sequence(self.usable_rows))
-
-    def _bounded_erase_screen(self) -> None:
-        """Erase the usable region and home within it, leaving the reserved rows intact.
-
-        Homing is part of this contract; see :func:`bounded_erase_screen_sequence`.
-        """
-        self._output.write_raw(bounded_erase_screen_sequence(self.usable_rows))
-
-    def _write_preserving_cursor(self, sequence: str) -> None:
-        """Emit a margin change without moving the cursor.
-
-        :param sequence: the margin sequence to emit
-        """
-        self._output.write_raw(f"{cursor_save_sequence()}{sequence}{cursor_restore_sequence()}")
-        # write_raw only appends to the output's own buffer, so this has to reach the
-        # terminal here rather than waiting for whatever flushes next.
-        self._output.flush()
-
-    def __enter__(self) -> Self:
-        """Set the scroll region and install the bounded erase."""
-        self._write_preserving_cursor(self._region_sequence)
-        # Shadow the bound methods with instance attributes. setattr keeps this legible to
-        # type checkers, which otherwise reject assigning over a method. Capture any
-        # override already installed by a caller so exit can put it back rather than
-        # leaving ours in place. Both destructive paths need bounding: the renderer's
-        # erase() reaches erase_down, and its clear() -- Ctrl-L -- reaches erase_screen.
-        for name, bounded in (
-            ("erase_down", self._bounded_erase_down),
-            ("erase_screen", self._bounded_erase_screen),
-        ):
-            self._previous[name] = vars(self._output).get(name)
-            setattr(self._output, name, bounded)
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Restore the original erase and full-screen scroll margins."""
-        for name, previous in self._previous.items():
-            if previous is None:
-                delattr(self._output, name)  # fall back to the class implementation
-            else:
-                setattr(self._output, name, previous)
-        self._previous.clear()
-        # Restoration has to reach the terminal here. A body that exits without another
-        # renderer operation -- an exception, or application shutdown -- would otherwise
-        # leave the margins restricted and later shell output scrolling inside them.
-        self._write_preserving_cursor(reset_scroll_region_sequence())

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -371,8 +371,10 @@ class TerminalDisplay:
     def reconfigure(self) -> bool:
         """Resample the terminal and re-establish the reservation for the new geometry.
 
-        Used after a resize. A terminal that has shrunk below the floor releases rather than
-        narrowing, and one that has grown back above it reacquires.
+        Used after a resize, and on the way back from a handoff. A terminal that has shrunk
+        below the floor releases rather than narrowing, and one that has grown back above it
+        reacquires. An unqualified backend never installs anything: a refused acquisition
+        still holds a lease, so capability is re-checked here rather than assumed settled.
 
         :return: whether a reservation is installed after this call
         """
@@ -428,15 +430,12 @@ class TerminalDisplay:
         if not self._handoff_active or self._depth == 0:
             return
         self._handoff_active = False
-        geometry = self._measure()
-        if not geometry.is_eligible:
-            # The terminal shrank while the guest had it. Nothing is installed, so callers
-            # go back to the plain backend -- which they do by way of the geometry check in
-            # `output`, rather than by unbinding the adapter here, so that a terminal which
-            # grows again reuses the same object.
-            return
-        self._terminal.install_region(geometry)
-        self._geometry = geometry
+        # Coming back is an ordinary reconfiguration, so it goes through the one path that
+        # does the whole job: re-check backend capability, measure, install only if the
+        # result is eligible, and rebind the adapter. Reinstalling margins here directly
+        # would leave a reserved terminal whose callers still hold the plain backend, and
+        # therefore unbounded erases running over the reserved row.
+        self.reconfigure()
 
     def revalidate_viewport(self) -> bool:
         """Re-check the viewport origin and rebuild the region if it moved.

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -1,0 +1,443 @@
+"""Terminal ownership, geometry generations and the bottom-row reservation.
+
+The reservation is a property of the *physical* terminal, so everything here reads size
+from the backend prompt-toolkit originally selected and never from the virtual adapter
+layered over it. Sizing the region from a view that has already had the reservation
+subtracted removes it twice, and the toolbar is then painted over by the last usable row.
+
+Three responsibilities live here:
+
+:class:`Geometry`
+    One immutable snapshot per generation. ``usable_rows`` is derived rather than stored so
+    that no caller can pass in a height with the reservation already removed.
+
+:class:`PhysicalTerminal`
+    The unwrapped source of true size, the writer of margin sequences, and the place where
+    backend capability is decided. Capability is decided by backend identity, never by shell
+    name, ``TERM``, or ``isinstance(output, Output)`` -- ``Windows10_Output`` is a
+    *registered virtual* subclass of ``Output`` and satisfies that check without inheriting
+    the interface, and legacy ``Win32Output`` satisfies it too while having no VT scroll
+    margins at all.
+
+:class:`TerminalDisplay`
+    Acquisition, nested leases, idempotent release and restoration of the original binding.
+
+The reservation is never installed below :data:`~cmd2.scroll_region.MIN_USABLE_ROWS` usable
+rows. That floor is total rather than degraded: a terminal silently ignores a degenerate
+region and then scrolls straight through the reserved row, destroying the toolbar. Below the
+floor the display releases and reports full geometry, and it reacquires when the terminal
+grows back.
+"""
+
+from dataclasses import dataclass
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Self
+
+from prompt_toolkit.data_structures import Size
+
+from .scroll_region import (
+    MIN_USABLE_ROWS,
+    cursor_restore_sequence,
+    cursor_save_sequence,
+    reset_scroll_region_sequence,
+    scroll_region_sequence,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from prompt_toolkit.output import Output
+
+#: Backends whose reserved-row support is qualified, by fully qualified class name. Membership
+#: is deliberately explicit: an unrecognized backend gets compatibility behavior rather than
+#: raw DECSTBM, because a wrong guess corrupts the user's screen rather than merely rendering
+#: poorly. See design §11.
+_QUALIFIED_BACKENDS = frozenset(
+    {
+        "prompt_toolkit.output.vt100.Vt100_Output",
+        "prompt_toolkit.output.windows10.Windows10_Output",
+    }
+)
+
+#: Backends known *not* to support the reservation, with the reason reported by diagnostics.
+_DISQUALIFIED_BACKENDS = {
+    "prompt_toolkit.output.win32.Win32Output": "legacy Win32 console has no VT scroll margins",
+    "prompt_toolkit.output.plain_text.PlainTextOutput": "plain-text output emits no control sequences",
+    "prompt_toolkit.output.DummyOutput": "dummy output is not a terminal",
+    "prompt_toolkit.output.base.DummyOutput": "dummy output is not a terminal",
+}
+
+
+def _class_name(obj: object) -> str:
+    """Build the fully qualified class name of an object.
+
+    :param obj: the object to name
+    :return: ``module.QualName`` for the object's type
+    """
+    cls = type(obj)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+@dataclass(frozen=True)
+class Geometry:
+    """An immutable snapshot of the terminal as one generation saw it.
+
+    ``usable_rows`` is a derived property rather than a field. Storing it would let a caller
+    supply a height that already had the reservation removed, which subtracts it twice: at 24
+    physical rows with one reserved row every component must see 23 usable rows, never 22.
+    """
+
+    #: Monotonic generation counter; a new snapshot is a new generation, never a mutation.
+    generation: int
+
+    #: True viewport height, read from the unwrapped backend.
+    physical_rows: int
+
+    #: Terminal width. Toolbar height is measured against this, so a width change is a new
+    #: generation even when the height is unchanged.
+    columns: int
+
+    #: Rows withheld from the scroll region at the bottom of the screen.
+    reserved_rows: int
+
+    #: Identity of the screen buffer and viewport origin. A viewport-origin change invalidates
+    #: the generation even when width and height are identical, because absolute row numbers
+    #: then address different cells. ``None`` where the backend exposes no such notion.
+    buffer_id: object = None
+
+    @property
+    def usable_rows(self) -> int:
+        """Rows available to the application, excluding the reservation."""
+        return self.physical_rows - self.reserved_rows
+
+    @property
+    def is_eligible(self) -> bool:
+        """Whether this geometry leaves enough room to install a reservation at all."""
+        return self.reserved_rows >= 1 and self.usable_rows >= MIN_USABLE_ROWS
+
+    @property
+    def virtual_size(self) -> Size:
+        """The size the application is shown while the reservation is installed."""
+        return Size(rows=self.usable_rows, columns=self.columns)
+
+    @property
+    def physical_size(self) -> Size:
+        """The true size of the terminal, reservation included."""
+        return Size(rows=self.physical_rows, columns=self.columns)
+
+
+class PhysicalTerminal:
+    """The unwrapped backend: true geometry, margin operations and capability selection.
+
+    This never consults the virtual adapter. Its whole purpose is to be the one place that
+    still sees the terminal as it really is.
+    """
+
+    def __init__(self, output: "Output") -> None:
+        """Bind to the backend prompt-toolkit selected.
+
+        :param output: the original, unwrapped output object
+        :raises TypeError: if handed an adapter rather than a real backend, which would make
+            every size reading a reservation short
+        """
+        if getattr(output, "is_reserved_adapter", False):
+            raise TypeError("PhysicalTerminal must wrap the original backend, not the reserved adapter")
+        self._output = output
+
+    @property
+    def output(self) -> "Output":
+        """The original backend object."""
+        return self._output
+
+    @property
+    def backend_name(self) -> str:
+        """Fully qualified class name of the selected backend."""
+        return _class_name(self._output)
+
+    def capability(self) -> tuple[bool, str]:
+        """Decide whether this backend supports a reserved row, and say why.
+
+        :return: whether the reservation is supported, and a reason suitable for diagnostics
+        """
+        name = self.backend_name
+        if name in _DISQUALIFIED_BACKENDS:
+            return False, _DISQUALIFIED_BACKENDS[name]
+        if name in _QUALIFIED_BACKENDS:
+            return True, "qualified backend"
+        return False, f"{name} is not a qualified backend; using compatibility rendering"
+
+    @property
+    def supports_reservation(self) -> bool:
+        """Whether this backend is qualified for the reservation."""
+        return self.capability()[0]
+
+    def physical_size(self) -> Size:
+        """Read the true viewport size from the backend.
+
+        On Windows this is served natively by the outer output object; its inner VT output
+        carries a zero-size stub and must never be asked.
+
+        :return: the true terminal size
+        """
+        return self._output.get_size()
+
+    def buffer_id(self) -> object:
+        """Identify the screen buffer and viewport origin, where the backend exposes them.
+
+        :return: an opaque identity comparable across generations, or ``None``
+        """
+        info_getter = getattr(self._output, "get_win32_screen_buffer_info", None)
+        if info_getter is None:
+            return None
+        try:
+            info = info_getter()
+        except (OSError, AttributeError, NotImplementedError):  # pragma: no cover - diagnostic only
+            return None
+        return (info.srWindow.Left, info.srWindow.Top, info.dwSize.X, info.dwSize.Y)
+
+    def measure(self, generation: int, reserved_rows: int) -> Geometry:
+        """Take a fresh geometry snapshot.
+
+        Sampling happens at every activation and reconfiguration. Geometry frozen at
+        construction is wrong the moment the window is resized.
+
+        :param generation: the generation number to stamp on the snapshot
+        :param reserved_rows: rows to withhold at the bottom
+        :return: the snapshot
+        """
+        size = self.physical_size()
+        return Geometry(
+            generation=generation,
+            physical_rows=size.rows,
+            columns=size.columns,
+            reserved_rows=reserved_rows,
+            buffer_id=self.buffer_id(),
+        )
+
+    def write_margin_change(self, sequence: str) -> None:
+        """Emit a margin change without moving the cursor.
+
+        DECSTBM homes the cursor on set *and* on reset, so an unwrapped margin change drops
+        rendering at the top of the screen and overwrites what is already there.
+
+        :param sequence: the margin sequence to emit
+        """
+        self._output.write_raw(f"{cursor_save_sequence()}{sequence}{cursor_restore_sequence()}")
+        # write_raw only appends to the backend's own buffer; the terminal has to see this
+        # now rather than whenever something else happens to flush.
+        self._output.flush()
+
+    def install_region(self, geometry: Geometry) -> None:
+        """Install the scroll region described by ``geometry``.
+
+        :param geometry: the snapshot to install margins for
+        :raises ValueError: if the geometry is not eligible for a reservation
+        """
+        self.write_margin_change(scroll_region_sequence(geometry.physical_rows, geometry.reserved_rows))
+
+    def release_region(self) -> None:
+        """Restore full-screen scroll margins."""
+        self.write_margin_change(reset_scroll_region_sequence())
+
+
+class TerminalDisplay:
+    """Owns the reservation for the lifetime of one command loop.
+
+    Acquisition is re-entrant: nested leases share one reservation and only the outermost
+    release tears it down. Release is idempotent, runs on the exception path, and always
+    restores full-screen margins -- leaving them installed would make every later line of
+    shell output scroll inside a region the shell knows nothing about.
+    """
+
+    def __init__(self, output: "Output", reserved_rows: int = 1) -> None:
+        """Prepare a display over the given backend.
+
+        :param output: the original, unwrapped output object
+        :param reserved_rows: rows to withhold at the bottom of the screen
+        :raises ValueError: if fewer than one row is reserved
+        """
+        if reserved_rows < 1:
+            raise ValueError(f"reserved_rows must be at least 1, got {reserved_rows}")
+        self._terminal = PhysicalTerminal(output)
+        self._reserved_rows = reserved_rows
+        self._generation = 0
+        self._geometry: Geometry | None = None
+        self._depth = 0
+        self._adapter: Any = None
+        self._handoff_geometry: Geometry | None = None
+
+    @property
+    def terminal(self) -> PhysicalTerminal:
+        """The unwrapped physical terminal."""
+        return self._terminal
+
+    @property
+    def geometry(self) -> Geometry | None:
+        """The current geometry snapshot, or ``None`` while released."""
+        return self._geometry
+
+    @property
+    def is_reserved(self) -> bool:
+        """Whether a reservation is currently installed."""
+        return self._geometry is not None
+
+    @property
+    def output(self) -> "Output":
+        """The output callers should render through: the adapter while reserved, else the backend."""
+        if self._adapter is not None:
+            return self._adapter  # type: ignore[no-any-return]
+        return self._terminal.output
+
+    @property
+    def lease_depth(self) -> int:
+        """How many nested leases are currently held."""
+        return self._depth
+
+    def _measure(self) -> Geometry:
+        """Take the next geometry snapshot, advancing the generation.
+
+        :return: the new snapshot
+        """
+        self._generation += 1
+        return self._terminal.measure(self._generation, self._reserved_rows)
+
+    def acquire(self) -> bool:
+        """Install the reservation, or take a nested lease on one already installed.
+
+        A terminal too short for the floor is not an error and not a degraded mode: the lease
+        is granted, no region is installed, and callers see full geometry through the
+        original backend until the terminal grows.
+
+        :return: whether a reservation is installed after this call
+        """
+        self._depth += 1
+        if self._depth > 1:
+            return self.is_reserved
+        if not self._terminal.supports_reservation:
+            return False
+
+        geometry = self._measure()
+        if not geometry.is_eligible:
+            return False
+
+        try:
+            self._terminal.install_region(geometry)
+        except Exception:
+            # Never leave margins half-installed; a failed acquisition falls back to ordinary
+            # full-screen rendering rather than to an unknown terminal state.
+            self._terminal.release_region()
+            self._depth -= 1
+            raise
+
+        self._geometry = geometry
+        self._adapter = self._make_adapter()
+        return True
+
+    def _make_adapter(self) -> Any:
+        """Build the virtual output for the active reservation.
+
+        :return: the adapter to render through
+        """
+        from .reserved_output import ReservedOutput
+
+        return ReservedOutput(self._terminal.output, self)
+
+    def release(self) -> None:
+        """Drop one lease, tearing the reservation down when the last one goes.
+
+        Calling this while already released does nothing, so cleanup paths may call it freely.
+        """
+        if self._depth == 0:
+            return
+        self._depth -= 1
+        if self._depth > 0:
+            return
+        self._teardown()
+
+    def _teardown(self) -> None:
+        """Restore full-screen margins and drop the adapter."""
+        self._adapter = None
+        self._handoff_geometry = None
+        if self._geometry is None:
+            return
+        self._geometry = None
+        self._terminal.release_region()
+
+    def reconfigure(self) -> bool:
+        """Resample the terminal and re-establish the reservation for the new geometry.
+
+        Used after a resize. A terminal that has shrunk below the floor releases rather than
+        narrowing, and one that has grown back above it reacquires.
+
+        :return: whether a reservation is installed after this call
+        """
+        if self._depth == 0:
+            return False
+        geometry = self._measure()
+        if not geometry.is_eligible or not self._terminal.supports_reservation:
+            if self._geometry is not None:
+                self._geometry = None
+                self._adapter = None
+                self._terminal.release_region()
+            return False
+        self._terminal.install_region(geometry)
+        self._geometry = geometry
+        if self._adapter is None:
+            self._adapter = self._make_adapter()
+        return True
+
+    def release_region_for_handoff(self) -> None:
+        """Restore full-screen margins for a program taking the terminal over.
+
+        The reservation is remembered rather than dropped: the lease is still held, and
+        :meth:`reacquire_region_after_handoff` puts the region back afterwards. The two screen
+        buffers keep separate margin state and the program taking over knows nothing about a
+        reservation, so the main buffer is left as the shell expects it.
+        """
+        if self._geometry is None:
+            return
+        self._handoff_geometry = self._geometry
+        self._geometry = None
+        self._terminal.release_region()
+
+    def reacquire_region_after_handoff(self) -> None:
+        """Re-establish the reservation after a program hands the terminal back.
+
+        Geometry is measured afresh rather than restored from the snapshot taken before the
+        handoff: the program in between may have resized the window, and a region installed
+        from a stale height puts the toolbar somewhere other than the bottom row.
+        """
+        if self._handoff_geometry is None or self._depth == 0:
+            return
+        self._handoff_geometry = None
+        geometry = self._measure()
+        if not geometry.is_eligible:
+            return
+        self._terminal.install_region(geometry)
+        self._geometry = geometry
+
+    def revalidate_viewport(self) -> bool:
+        """Re-check the viewport origin and rebuild the region if it moved.
+
+        A moved viewport makes absolute row numbers address different cells even when width
+        and height have not changed, so it invalidates the generation on its own.
+
+        :return: whether a reservation is installed after this call
+        """
+        if self._geometry is None:
+            return False
+        if self._terminal.buffer_id() == self._geometry.buffer_id:
+            return True
+        return self.reconfigure()
+
+    def __enter__(self) -> Self:
+        """Acquire a lease."""
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release the lease, including when the body raised."""
+        self.release()

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -263,7 +263,7 @@ class TerminalDisplay:
         self._geometry: Geometry | None = None
         self._depth = 0
         self._adapter: Any = None
-        self._handoff_geometry: Geometry | None = None
+        self._handoff_active = False
 
     @property
     def terminal(self) -> PhysicalTerminal:
@@ -362,7 +362,7 @@ class TerminalDisplay:
     def _teardown(self) -> None:
         """Restore full-screen margins and drop the adapter."""
         self._adapter = None
-        self._handoff_geometry = None
+        self._handoff_active = False
         if self._geometry is None:
             return
         self._geometry = None
@@ -378,11 +378,11 @@ class TerminalDisplay:
         """
         if self._depth == 0:
             return False
-        if self._handoff_geometry is not None:
+        if self._handoff_active:
             # A handoff keeps the lease deliberately, so lease depth alone does not mean the
             # terminal is ours. Reinstalling margins here would restrict the screen of the
             # program currently owning it. The resize is not lost: the return path measures
-            # afresh rather than restoring the snapshot taken before the handoff.
+            # afresh rather than restoring whatever was installed before the handoff.
             return False
         geometry = self._measure()
         if not geometry.is_eligible or not self._terminal.supports_reservation:
@@ -404,23 +404,30 @@ class TerminalDisplay:
         :meth:`reacquire_region_after_handoff` puts the region back afterwards. The two screen
         buffers keep separate margin state and the program taking over knows nothing about a
         reservation, so the main buffer is left as the shell expects it.
+
+        Ownership is recorded whether or not a region happened to be installed. A terminal
+        that had shrunk below the floor is released but still ours, and a guest can take it
+        from that state just as readily; tying the record to the geometry snapshot would let
+        a later resize reinstall margins over the guest's screen.
         """
+        if self._depth == 0:
+            return
+        self._handoff_active = True
         if self._geometry is None:
             return
-        self._handoff_geometry = self._geometry
         self._geometry = None
         self._terminal.release_region()
 
     def reacquire_region_after_handoff(self) -> None:
         """Re-establish the reservation after a program hands the terminal back.
 
-        Geometry is measured afresh rather than restored from the snapshot taken before the
-        handoff: the program in between may have resized the window, and a region installed
-        from a stale height puts the toolbar somewhere other than the bottom row.
+        Geometry is measured afresh rather than restored from whatever was installed before
+        the handoff: the program in between may have resized the window, and a region
+        installed from a stale height puts the toolbar somewhere other than the bottom row.
         """
-        if self._handoff_geometry is None or self._depth == 0:
+        if not self._handoff_active or self._depth == 0:
             return
-        self._handoff_geometry = None
+        self._handoff_active = False
         geometry = self._measure()
         if not geometry.is_eligible:
             # The terminal shrank while the guest had it. Nothing is installed, so callers

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -29,6 +29,7 @@ floor the display releases and reports full geometry, and it reacquires when the
 grows back.
 """
 
+from contextlib import suppress
 from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Self
@@ -282,7 +283,7 @@ class TerminalDisplay:
     @property
     def output(self) -> "Output":
         """The output callers should render through: the adapter while reserved, else the backend."""
-        if self._adapter is not None:
+        if self._adapter is not None and self._geometry is not None:
             return self._adapter  # type: ignore[no-any-return]
         return self._terminal.output
 
@@ -314,17 +315,23 @@ class TerminalDisplay:
         if not self._terminal.supports_reservation:
             return False
 
-        geometry = self._measure()
-        if not geometry.is_eligible:
-            return False
-
         try:
+            geometry = self._measure()
+            if not geometry.is_eligible:
+                return False
             self._terminal.install_region(geometry)
-        except Exception:
-            # Never leave margins half-installed; a failed acquisition falls back to ordinary
-            # full-screen rendering rather than to an unknown terminal state.
-            self._terminal.release_region()
+        except BaseException:
+            # Give the lease back *first*. Cleanup can fail too -- a terminal that could not
+            # be measured or written to may well refuse the reset as well -- and a lease
+            # stranded by that failure makes every later acquire() a no-op at depth two,
+            # which never retries the installation and never reports why.
             self._depth -= 1
+            # Never leave margins half-installed; a failed acquisition falls back to ordinary
+            # full-screen rendering rather than to an unknown terminal state. If even that
+            # write fails there is nothing further to try, and the original error is the one
+            # worth propagating.
+            with suppress(Exception):
+                self._terminal.release_region()
             raise
 
         self._geometry = geometry
@@ -371,6 +378,12 @@ class TerminalDisplay:
         """
         if self._depth == 0:
             return False
+        if self._handoff_geometry is not None:
+            # A handoff keeps the lease deliberately, so lease depth alone does not mean the
+            # terminal is ours. Reinstalling margins here would restrict the screen of the
+            # program currently owning it. The resize is not lost: the return path measures
+            # afresh rather than restoring the snapshot taken before the handoff.
+            return False
         geometry = self._measure()
         if not geometry.is_eligible or not self._terminal.supports_reservation:
             if self._geometry is not None:
@@ -410,6 +423,10 @@ class TerminalDisplay:
         self._handoff_geometry = None
         geometry = self._measure()
         if not geometry.is_eligible:
+            # The terminal shrank while the guest had it. Nothing is installed, so callers
+            # go back to the plain backend -- which they do by way of the geometry check in
+            # `output`, rather than by unbinding the adapter here, so that a terminal which
+            # grows again reuses the same object.
             return
         self._terminal.install_region(geometry)
         self._geometry = geometry

--- a/tests/test_reserved_output.py
+++ b/tests/test_reserved_output.py
@@ -21,6 +21,24 @@ def make_output(rows: int = 24, cols: int = 80) -> tuple[Vt100_Output, io.String
     return Vt100_Output(stream, lambda: Size(rows=rows, columns=cols)), stream
 
 
+class Screen:
+    """A terminal size that can change between reads."""
+
+    def __init__(self, rows: int, columns: int) -> None:
+        self.rows = rows
+        self.columns = columns
+
+    def size(self) -> Size:
+        return Size(rows=self.rows, columns=self.columns)
+
+
+def make_shrinkable_output(rows: int = 24, columns: int = 80) -> tuple[Vt100_Output, io.StringIO, Screen]:
+    """Build a real Vt100_Output whose size can be changed later."""
+    stream = io.StringIO()
+    screen = Screen(rows, columns)
+    return Vt100_Output(stream, screen.size), stream, screen
+
+
 def make_reserved(rows: int = 24, cols: int = 80, reserved: int = 1) -> tuple[ReservedOutput, io.StringIO, TerminalDisplay]:
     """Acquire a reservation and return the adapter to render through."""
     output, stream = make_output(rows, cols)
@@ -353,6 +371,7 @@ class TestScreenBufferTransitions:
     def test_leaving_the_alternate_screen_re_establishes_the_region(self) -> None:
         adapter, stream, display = make_reserved(rows=24)
         adapter.enter_alternate_screen()
+        adapter.flush()
         stream.truncate(0), stream.seek(0)
         adapter.quit_alternate_screen()
         assert display.is_reserved
@@ -390,3 +409,78 @@ class TestFileDescriptorAndCursorShape:
         adapter = ReservedOutput(recorder, TerminalDisplay(recorder))
         adapter.set_cursor_shape(CursorShape.BLOCK)
         assert seen == [CursorShape.BLOCK]
+
+
+class TestSuspendedReservation:
+    """The adapter outlives its reservation, so every margin-dependent operation must ask.
+
+    A handoff to the alternate screen restores full margins while deliberately keeping the
+    lease, and prompt-toolkit holds the output object it was created with. This object
+    therefore keeps receiving calls with no region installed.
+    """
+
+    def test_erase_down_defers_to_the_backend_while_suspended(self) -> None:
+        """DL against an unbounded screen deletes whole lines, including the text to the left
+        of a nonzero cursor column that ED would have preserved."""
+        adapter, stream, display = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        adapter.flush()
+        stream.truncate(0), stream.seek(0)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[J"
+        assert "M" not in stream.getvalue()
+        assert not display.is_reserved
+
+    def test_erase_screen_defers_to_the_backend_while_suspended(self) -> None:
+        adapter, stream, _ = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        adapter.flush()
+        stream.truncate(0), stream.seek(0)
+        adapter.erase_screen()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[2J"
+
+    def test_the_physical_size_is_reported_while_suspended(self) -> None:
+        """Nothing is reserved, so nothing should be hidden."""
+        adapter, _, _ = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        assert adapter.get_size() == Size(rows=24, columns=80)
+
+    def test_rows_below_the_cursor_is_unadapted_while_suspended(self) -> None:
+        output = WindowsLikeOutput(rows=21, columns=92, rows_below=5)
+        display = TerminalDisplay(output)  # type: ignore[arg-type]
+        adapter = ReservedOutput(output, display)  # type: ignore[arg-type]
+        assert not adapter.is_reserved
+        assert adapter.get_rows_below_cursor_position() == 5
+
+    def test_the_bounded_erase_comes_back_when_the_region_does(self) -> None:
+        adapter, stream, _ = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        adapter.quit_alternate_screen()
+        adapter.flush()
+        stream.truncate(0), stream.seek(0)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[23M"
+
+    def test_a_stale_adapter_stays_safe_after_the_terminal_shrinks(self) -> None:
+        """The guest resized the window below the floor. Anything still holding the adapter
+        must not keep emitting bounded erases against a terminal with no region."""
+        output, stream, screen = make_shrinkable_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        assert isinstance(adapter, ReservedOutput)
+
+        adapter.enter_alternate_screen()
+        screen.rows = 2
+        adapter.quit_alternate_screen()
+        adapter.flush()
+
+        assert not display.is_reserved
+        assert not isinstance(display.output, ReservedOutput), "callers were left on the adapter"
+        stream.truncate(0), stream.seek(0)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[J"

--- a/tests/test_reserved_output.py
+++ b/tests/test_reserved_output.py
@@ -179,7 +179,6 @@ class WindowsLikeOutput:
         self._size = Size(rows=rows, columns=columns)
         self._rows_below = rows_below
         self.flushes = 0
-        self.raw: list[str] = []
 
     def get_size(self) -> Size:
         return self._size
@@ -189,9 +188,6 @@ class WindowsLikeOutput:
 
     def flush(self) -> None:
         self.flushes += 1
-
-    def write_raw(self, data: str) -> None:
-        self.raw.append(data)
 
 
 class TestWindowsOuterOutput:

--- a/tests/test_reserved_output.py
+++ b/tests/test_reserved_output.py
@@ -1,0 +1,392 @@
+"""Tests for the virtual output layered over a reserved terminal.
+
+The adapter's whole job is to be honest about two different things at once: the application
+must see a terminal one reservation shorter, and the backend must be handed operations that
+are correct for the real one.
+"""
+
+import io
+
+import pytest
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.output import ColorDepth, DummyOutput, Output
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from cmd2.reserved_output import ReservedOutput
+from cmd2.terminal_display import Geometry, PhysicalTerminal, TerminalDisplay
+
+
+def make_output(rows: int = 24, cols: int = 80) -> tuple[Vt100_Output, io.StringIO]:
+    stream = io.StringIO()
+    return Vt100_Output(stream, lambda: Size(rows=rows, columns=cols)), stream
+
+
+def make_reserved(rows: int = 24, cols: int = 80, reserved: int = 1) -> tuple[ReservedOutput, io.StringIO, TerminalDisplay]:
+    """Acquire a reservation and return the adapter to render through."""
+    output, stream = make_output(rows, cols)
+    display = TerminalDisplay(output, reserved_rows=reserved)
+    display.acquire()
+    stream.truncate(0), stream.seek(0)
+    adapter = display.output
+    assert isinstance(adapter, ReservedOutput)
+    return adapter, stream, display
+
+
+class TestVirtualGeometry:
+    def test_the_application_sees_the_usable_region_as_the_whole_terminal(self) -> None:
+        adapter, _, _ = make_reserved(rows=24, reserved=1)
+        assert adapter.get_size() == Size(rows=23, columns=80)
+
+    def test_multiple_reserved_rows_are_all_hidden(self) -> None:
+        adapter, _, _ = make_reserved(rows=24, reserved=3)
+        assert adapter.get_size() == Size(rows=21, columns=80)
+
+    def test_the_physical_layer_still_sees_the_true_height(self) -> None:
+        """The one place that must not be fooled. Sizing the region from the virtual view
+        subtracts the reservation twice and paints the toolbar over."""
+        adapter, _, display = make_reserved(rows=24, reserved=1)
+        assert display.terminal.physical_size() == Size(rows=24, columns=80)
+        assert adapter.get_size().rows == 23
+
+    def test_the_virtual_size_follows_a_resize(self) -> None:
+        output, _stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        # Publish a taller generation the way reconfigure() does.
+        display._geometry = Geometry(generation=99, physical_rows=40, columns=80, reserved_rows=1)
+        assert adapter.get_size() == Size(rows=39, columns=80)
+
+
+class TestBoundedErases:
+    def test_erase_down_uses_delete_line_not_erase_display(self) -> None:
+        """ED ignores the scroll margins and would destroy the reserved row."""
+        adapter, stream, _ = make_reserved(rows=24)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[23M"
+        assert "\x1b[J" not in stream.getvalue()
+
+    def test_erase_down_clears_the_whole_usable_region(self) -> None:
+        """A count of one clears one row; the region needs every usable row."""
+        adapter, stream, _ = make_reserved(rows=24, reserved=2)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[22M"
+
+    def test_erase_screen_homes_inside_the_region_first(self) -> None:
+        """Ctrl-L reaches erase_screen. DL clears downward, so covering the usable area
+        means starting at its top; an unbounded ED2 would wipe the reserved row."""
+        adapter, stream, _ = make_reserved(rows=24)
+        adapter.erase_screen()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[1;1H\x1b[23M"
+        assert "\x1b[2J" not in stream.getvalue()
+
+    def test_the_erase_count_follows_a_resize(self) -> None:
+        adapter, stream, display = make_reserved(rows=24)
+        display._geometry = Geometry(generation=2, physical_rows=40, columns=80, reserved_rows=1)
+        adapter.erase_down()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[39M"
+
+    def test_erase_end_of_line_is_left_alone(self) -> None:
+        """It is bounded by the line it is on, so the reservation has nothing to add."""
+        adapter, stream, _ = make_reserved(rows=24)
+        adapter.erase_end_of_line()
+        adapter.flush()
+        assert stream.getvalue() == "\x1b[K"
+
+
+class TestBackendIsNeverModified:
+    """The named regression ``test_reserved_output_preserves_existing_backend_methods``."""
+
+    def test_the_backend_is_the_same_object_with_the_same_methods_afterwards(self) -> None:
+        output, _ = make_output(rows=24)
+        before = {name: getattr(output, name) for name in ("erase_down", "erase_screen", "flush", "write_raw")}
+        display = TerminalDisplay(output)
+        with display, display:
+            assert display.lease_depth == 2
+        for name, original in before.items():
+            assert getattr(output, name) == original, f"{name} was replaced"
+        assert not vars(output).get("erase_down"), "an instance-level shadow was left behind"
+
+    def test_a_callers_own_override_survives_nested_leases(self) -> None:
+        """The spike replaced bound methods and had to put them back; wrapping cannot lose one."""
+        output, _ = make_output(rows=24)
+        calls: list[str] = []
+
+        def caller_override() -> None:
+            calls.append("caller")
+
+        output.erase_down = caller_override  # type: ignore[method-assign]
+        display = TerminalDisplay(output)
+        with display, display:
+            pass
+        assert output.erase_down is caller_override
+        output.erase_down()
+        assert calls == ["caller"]
+
+    def test_the_backend_survives_an_exception_inside_the_reservation(self) -> None:
+        output, _ = make_output(rows=24)
+        original = output.erase_down
+        with pytest.raises(RuntimeError), TerminalDisplay(output):
+            raise RuntimeError("boom")
+        assert output.erase_down == original
+
+    def test_the_unbounded_erase_is_back_after_release(self) -> None:
+        """The DL substitution is only sound from column zero, so it must not outlive the
+        reservation that guarantees the renderer paths reaching it."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release()
+        stream.truncate(0), stream.seek(0)
+        output.erase_down()
+        output.flush()
+        assert stream.getvalue() == "\x1b[J"
+
+
+class WindowsLikeOutput:
+    """An outer Windows output: native geometry, and an inner VT object that lies.
+
+    ``Windows10_Output`` delegates a whitelist natively and everything else to an inner
+    ``Vt100_Output`` constructed with ``lambda: Size(0, 0)``. Asking that inner object for
+    geometry returns zeros, and flushing it directly skips the console-mode handling the
+    outer flush performs.
+    """
+
+    def __init__(self, rows: int, columns: int, rows_below: int) -> None:
+        self.vt100_output = Vt100_Output(io.StringIO(), lambda: Size(rows=0, columns=0))
+        self._size = Size(rows=rows, columns=columns)
+        self._rows_below = rows_below
+        self.flushes = 0
+        self.raw: list[str] = []
+
+    def get_size(self) -> Size:
+        return self._size
+
+    def get_rows_below_cursor_position(self) -> int:
+        return self._rows_below
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+    def write_raw(self, data: str) -> None:
+        self.raw.append(data)
+
+
+class TestWindowsOuterOutput:
+    """The named regression ``test_windows_outer_output_owns_geometry_and_flush``."""
+
+    def test_geometry_comes_from_the_outer_object_not_the_inner_stub(self) -> None:
+        output = WindowsLikeOutput(rows=21, columns=92, rows_below=1)
+        assert output.vt100_output.get_size() == Size(rows=0, columns=0)
+        assert PhysicalTerminal(output).physical_size() == Size(rows=21, columns=92)  # type: ignore[arg-type]
+
+    def test_flush_goes_through_the_outer_object(self) -> None:
+        """The outer flush enables VT processing for the write and restores the console mode."""
+        output = WindowsLikeOutput(rows=21, columns=92, rows_below=1)
+        display = TerminalDisplay(output)  # type: ignore[arg-type]
+        adapter = ReservedOutput(output, display)  # type: ignore[arg-type]
+        adapter.flush()
+        assert output.flushes == 1
+
+    def test_rows_below_the_cursor_stops_at_the_usable_bottom(self) -> None:
+        """Windows answers this natively, so adapting get_size() alone would leave the
+        renderer believing it may draw over the reserved rows."""
+        output = WindowsLikeOutput(rows=21, columns=92, rows_below=5)
+        display = TerminalDisplay(output)  # type: ignore[arg-type]
+        display._geometry = Geometry(generation=1, physical_rows=21, columns=92, reserved_rows=1)
+        adapter = ReservedOutput(output, display)  # type: ignore[arg-type]
+        assert adapter.get_rows_below_cursor_position() == 4
+
+    def test_rows_below_the_cursor_is_never_negative(self) -> None:
+        """With the cursor already on the reserved row the honest answer is zero, not -1."""
+        output = WindowsLikeOutput(rows=21, columns=92, rows_below=0)
+        display = TerminalDisplay(output)  # type: ignore[arg-type]
+        display._geometry = Geometry(generation=1, physical_rows=21, columns=92, reserved_rows=1)
+        adapter = ReservedOutput(output, display)  # type: ignore[arg-type]
+        assert adapter.get_rows_below_cursor_position() == 0
+
+    def test_a_posix_backend_still_raises_so_the_renderer_falls_back_to_cpr(self) -> None:
+        adapter, _, _ = make_reserved(rows=24)
+        with pytest.raises(NotImplementedError):
+            adapter.get_rows_below_cursor_position()
+
+
+class TestCprCoordinateContract:
+    """The named regression ``test_cpr_uses_row_one_coordinate_contract``.
+
+    The renderer computes ``rows_below = U - r + 1`` from a *physical* CPR row against the
+    *virtual* height. That is correct only because the region is anchored at row 1, which
+    makes ``U`` the last usable physical row index as well as the virtual height. A top
+    offset would need an explicit translation; keeping the same subtraction would be wrong.
+    """
+
+    @pytest.mark.parametrize(("row", "expected"), [(1, 23), (12, 12), (23, 1)])
+    def test_a_valid_row_yields_exactly_u_minus_r_plus_one(self, row: int, expected: int) -> None:
+        adapter, _, _ = make_reserved(rows=24, reserved=1)
+        usable = adapter.get_size().rows
+        assert usable - row + 1 == expected
+
+    def test_the_region_is_anchored_at_row_one(self) -> None:
+        """The arithmetic above is only sound because of this."""
+        output, stream = make_output(rows=24)
+        TerminalDisplay(output).acquire()
+        assert stream.getvalue() == "\x1b7\x1b[1;23r\x1b8"
+
+    def test_a_cursor_in_the_reserved_band_gives_a_nonpositive_height(self) -> None:
+        """The R5 hazard, stated in geometry terms: rejecting it belongs to the bridge, but
+        the arithmetic that makes it detectable is settled here."""
+        geometry = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=1)
+        assert geometry.usable_rows - 24 + 1 == 0
+        two_reserved = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=2)
+        assert two_reserved.usable_rows - 24 + 1 == -1
+
+
+class TestDelegation:
+    def test_every_abstract_method_is_implemented_explicitly(self) -> None:
+        """__getattr__ would leave the class abstract, and would silently absorb whatever a
+        future prompt-toolkit adds without anyone deciding what reservation means for it."""
+        for name in Output.__abstractmethods__:
+            assert name in vars(ReservedOutput), f"{name} is not implemented explicitly"
+
+    def test_the_adapter_is_instantiable_as_an_output(self) -> None:
+        adapter, _, _ = make_reserved()
+        assert isinstance(adapter, Output)
+
+    @pytest.mark.parametrize(
+        ("method", "args"),
+        [
+            ("write", ("hello",)),
+            ("write_raw", ("\x1b[1m",)),
+            ("set_title", ("t",)),
+            ("clear_title", ()),
+            ("reset_attributes", ()),
+            ("disable_autowrap", ()),
+            ("enable_autowrap", ()),
+            ("cursor_goto", (2, 3)),
+            ("cursor_up", (1,)),
+            ("cursor_down", (1,)),
+            ("cursor_forward", (1,)),
+            ("cursor_backward", (1,)),
+            ("hide_cursor", ()),
+            ("show_cursor", ()),
+            ("reset_cursor_shape", ()),
+            ("enable_mouse_support", ()),
+            ("disable_mouse_support", ()),
+            ("enable_bracketed_paste", ()),
+            ("disable_bracketed_paste", ()),
+            ("reset_cursor_key_mode", ()),
+            ("bell", ()),
+            ("ask_for_cpr", ()),
+        ],
+    )
+    def test_unaffected_operations_reach_the_backend(self, method: str, args: tuple[object, ...]) -> None:
+        calls: list[tuple[str, tuple[object, ...]]] = []
+
+        class Recorder(DummyOutput):
+            def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
+                attr = object.__getattribute__(self, name)
+                if name == method:
+
+                    def record(*a: object) -> None:
+                        calls.append((name, a))
+
+                    return record
+                return attr
+
+        recorder = Recorder()
+        adapter = ReservedOutput(recorder, TerminalDisplay(recorder))
+        getattr(adapter, method)(*args)
+        assert calls == [(method, args)]
+
+    def test_encoding_and_color_depth_come_from_the_backend(self) -> None:
+        adapter, _, _ = make_reserved()
+        assert adapter.encoding() == adapter.wrapped.encoding()
+        assert isinstance(adapter.get_default_color_depth(), ColorDepth)
+
+    def test_responds_to_cpr_follows_the_backend(self) -> None:
+        adapter, _, _ = make_reserved()
+        assert adapter.responds_to_cpr == adapter.wrapped.responds_to_cpr
+
+    def test_stdout_is_the_backends_own_stream(self) -> None:
+        adapter, _, _ = make_reserved()
+        assert adapter.stdout is adapter.wrapped.stdout
+
+    def test_set_attributes_is_passed_through_with_its_color_depth(self) -> None:
+        from prompt_toolkit.styles import Attrs
+
+        seen: list[tuple[Attrs, ColorDepth]] = []
+
+        class Recorder(DummyOutput):
+            def set_attributes(self, attrs: Attrs, color_depth: ColorDepth) -> None:
+                seen.append((attrs, color_depth))
+
+        recorder = Recorder()
+        adapter = ReservedOutput(recorder, TerminalDisplay(recorder))
+        attrs = Attrs(
+            color=None,
+            bgcolor=None,
+            bold=True,
+            underline=False,
+            strike=False,
+            italic=False,
+            blink=False,
+            reverse=False,
+            hidden=False,
+            dim=False,
+        )
+        adapter.set_attributes(attrs, ColorDepth.DEPTH_4_BIT)
+        assert seen == [(attrs, ColorDepth.DEPTH_4_BIT)]
+
+
+class TestScreenBufferTransitions:
+    def test_entering_the_alternate_screen_restores_full_margins_first(self) -> None:
+        adapter, stream, display = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        adapter.flush()
+        assert stream.getvalue().startswith("\x1b7\x1b[r\x1b8"), "margins were left installed"
+        assert not display.is_reserved
+
+    def test_leaving_the_alternate_screen_re_establishes_the_region(self) -> None:
+        adapter, stream, display = make_reserved(rows=24)
+        adapter.enter_alternate_screen()
+        stream.truncate(0), stream.seek(0)
+        adapter.quit_alternate_screen()
+        assert display.is_reserved
+        assert "\x1b[1;23r" in stream.getvalue()
+
+    def test_scrolling_the_buffer_revalidates_the_viewport(self) -> None:
+        """A moved viewport makes absolute row numbers address different cells, so it
+        invalidates the generation even when width and height are unchanged."""
+        adapter, _, display = make_reserved(rows=24)
+        assert display.geometry is not None
+        before = display.geometry.generation
+        adapter.scroll_buffer_to_prompt()
+        # A VT backend reports no viewport origin, so nothing moved and nothing is rebuilt.
+        assert display.geometry is not None
+        assert display.geometry.generation == before
+
+
+class TestFileDescriptorAndCursorShape:
+    def test_fileno_comes_from_the_backend(self) -> None:
+        """Code that reaches for the real descriptor must not get the adapter's idea of one."""
+        adapter, _, _ = make_reserved()
+        with pytest.raises(io.UnsupportedOperation):
+            adapter.fileno()
+
+    def test_set_cursor_shape_reaches_the_backend(self) -> None:
+        from prompt_toolkit.cursor_shapes import CursorShape
+
+        seen: list[CursorShape] = []
+
+        class Recorder(DummyOutput):
+            def set_cursor_shape(self, cursor_shape: CursorShape) -> None:
+                seen.append(cursor_shape)
+
+        recorder = Recorder()
+        adapter = ReservedOutput(recorder, TerminalDisplay(recorder))
+        adapter.set_cursor_shape(CursorShape.BLOCK)
+        assert seen == [CursorShape.BLOCK]

--- a/tests/test_scroll_region.py
+++ b/tests/test_scroll_region.py
@@ -1,18 +1,12 @@
-"""Tests for the reserved-bottom-row scroll region and its margin-bounded erase."""
+"""Tests for the pure sequence builders behind the reserved bottom row.
 
-import io
+Installing these sequences, and deciding when it is legal to, belongs to
+``tests/test_terminal_display.py`` and ``tests/test_reserved_output.py``.
+"""
 
 import pytest
-from prompt_toolkit.output.vt100 import Vt100_Output
 
 from cmd2 import scroll_region as sr
-
-
-def make_output(rows: int = 24, cols: int = 80) -> tuple[Vt100_Output, io.StringIO]:
-    stream = io.StringIO()
-    return Vt100_Output(
-        stream, lambda: __import__("prompt_toolkit.data_structures", fromlist=["Size"]).Size(rows, cols)
-    ), stream
 
 
 class TestSequences:
@@ -49,141 +43,3 @@ class TestSequences:
     def test_rejects_regions_that_would_leave_too_few_usable_rows(self, total: int, reserved: int) -> None:
         with pytest.raises(ValueError, match=r"reserved_rows must be at least 1|needs at least"):
             sr.scroll_region_sequence(total, reserved)
-
-
-class TestCursorPreservation:
-    """DECSTBM homes the cursor, so every margin change must save and restore it."""
-
-    def test_entry_wraps_the_margin_change_in_save_and_restore(self) -> None:
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            assert stream.getvalue() == "\x1b7\x1b[1;23r\x1b8"
-
-    def test_exit_wraps_the_margin_reset_in_save_and_restore(self) -> None:
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            stream.truncate(0), stream.seek(0)
-        assert stream.getvalue() == "\x1b7\x1b[r\x1b8"
-
-
-class TestReservedBottomRows:
-    def test_sets_the_region_on_enter_and_resets_it_on_exit(self) -> None:
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            assert "\x1b[1;23r" in stream.getvalue()
-        # the reset is wrapped in save/restore, so it is not the final bytes
-        assert stream.getvalue().endswith("\x1b7\x1b[r\x1b8")
-
-    def test_the_region_reaches_the_terminal_on_entry(self) -> None:
-        """Callers may rely on the reservation being in force once __enter__ returns."""
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            # No flush of our own: prompt_toolkit buffers write_raw, so an unflushed
-            # region sequence would leave the reservation merely promised.
-            assert "\x1b[1;23r" in stream.getvalue()
-            assert not output._buffer
-
-    def test_the_reset_reaches_the_terminal_without_a_further_flush(self) -> None:
-        """A body that exits without another renderer operation must still be restored."""
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            output.flush()
-        assert stream.getvalue().endswith("\x1b7\x1b[r\x1b8"), "margins were left restricted"
-        assert not output._buffer, "the reset is still sitting in prompt_toolkit's buffer"
-
-    def test_erase_down_is_bounded_while_reserved(self) -> None:
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            output.flush()
-            stream.truncate(0), stream.seek(0)
-            output.erase_down()
-            output.flush()
-            written = stream.getvalue()
-        assert "\x1b[J" not in written, "unbounded ED would destroy the reserved row"
-        assert written.endswith("M")
-
-    def test_bounded_erase_clears_the_whole_usable_region(self) -> None:
-        """A DL count of 1 (or 0, which terminals read as 1) would clear one row, not the region."""
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=2) as region:
-            stream.truncate(0), stream.seek(0)
-            output.erase_down()
-            output.flush()
-            # Assert inside the region: on exit the reset is written and flushed too.
-            assert stream.getvalue() == f"\x1b[{region.usable_rows}M"
-
-    def test_erase_screen_is_bounded_while_reserved(self) -> None:
-        """Ctrl-L reaches erase_screen; an unbounded ED2 would wipe the reserved row."""
-        output, stream = make_output(rows=24)
-        with sr.ReservedBottomRows(output, reserved_rows=1) as region:
-            stream.truncate(0), stream.seek(0)
-            output.erase_screen()
-            output.flush()
-            assert "\x1b[2J" not in stream.getvalue()
-            assert stream.getvalue() == f"\x1b[1;1H\x1b[{region.usable_rows}M"
-
-    def test_original_erase_screen_is_restored_on_exit(self) -> None:
-        output, stream = make_output(rows=24)
-        original = output.erase_screen
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            assert output.erase_screen != original
-        assert output.erase_screen == original
-        stream.truncate(0), stream.seek(0)
-        output.erase_screen()
-        output.flush()
-        assert "\x1b[2J" in stream.getvalue()
-
-    def test_restores_a_pre_existing_instance_level_erase_screen(self) -> None:
-        """Same contract as erase_down: a caller's override must survive."""
-        output, _stream = make_output(rows=24)
-        calls: list[str] = []
-
-        def caller_override() -> None:
-            calls.append("caller")
-
-        output.erase_screen = caller_override  # type: ignore[method-assign]
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            pass
-        assert output.erase_screen is caller_override
-        output.erase_screen()
-        assert calls == ["caller"]
-
-    def test_original_erase_down_is_restored_on_exit(self) -> None:
-        output, stream = make_output(rows=24)
-        original = output.erase_down
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            assert output.erase_down != original
-        assert output.erase_down == original
-        stream.truncate(0), stream.seek(0)
-        output.erase_down()
-        output.flush()
-        assert "\x1b[J" in stream.getvalue()
-
-    def test_restores_a_pre_existing_instance_level_erase_down(self) -> None:
-        """A caller's own override must survive the reservation, not be replaced by ours."""
-        output, _stream = make_output(rows=24)
-        calls: list[str] = []
-
-        def caller_override() -> None:
-            calls.append("caller")
-
-        output.erase_down = caller_override  # type: ignore[method-assign]
-
-        with sr.ReservedBottomRows(output, reserved_rows=1):
-            pass
-
-        assert output.erase_down is caller_override
-        output.erase_down()
-        assert calls == ["caller"], "the caller's override must be the one that runs"
-
-    def test_region_is_reset_even_if_the_body_raises(self) -> None:
-        output, stream = make_output(rows=24)
-        with pytest.raises(RuntimeError), sr.ReservedBottomRows(output, reserved_rows=1):
-            raise RuntimeError("boom")
-        assert stream.getvalue().endswith("\x1b7\x1b[r\x1b8")
-        assert not output._buffer
-
-    def test_usable_rows_excludes_the_reserved_rows(self) -> None:
-        output, _ = make_output(rows=24)
-        region = sr.ReservedBottomRows(output, reserved_rows=2)
-        assert region.usable_rows == 22

--- a/tests/test_terminal_display.py
+++ b/tests/test_terminal_display.py
@@ -506,3 +506,120 @@ class TestReleasedStateIsInert:
         display.acquire()
         display.release()
         assert stream.getvalue() == ""
+
+
+class TestHandoffSuspendsReconfiguration:
+    """A handoff keeps the lease deliberately, so lease depth alone does not mean the
+    terminal is ours to write margins to."""
+
+    def test_reconfigure_is_inert_while_a_guest_owns_the_terminal(self) -> None:
+        """Reinstalling margins here would restrict the screen of the program that has it."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+        stream.truncate(0), stream.seek(0)
+
+        assert not display.reconfigure()
+        assert stream.getvalue() == ""
+        assert not display.is_reserved
+
+    def test_a_resize_during_a_handoff_is_applied_when_the_terminal_comes_back(self) -> None:
+        """The suppressed reconfigure loses nothing: the return path measures afresh."""
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+
+        screen.rows = 40
+        display.reconfigure()
+        stream.truncate(0), stream.seek(0)
+        display.reacquire_region_after_handoff()
+
+        assert stream.getvalue() == "\x1b7\x1b[1;39r\x1b8"
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 39
+
+    def test_an_ineligible_return_unbinds_the_adapter(self) -> None:
+        """Otherwise callers keep getting a virtual view of a terminal with no reservation."""
+        output, _stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert isinstance(display.output, ReservedOutput)
+        display.release_region_for_handoff()
+
+        screen.rows = 2
+        display.reacquire_region_after_handoff()
+
+        assert not display.is_reserved
+        assert not isinstance(display.output, ReservedOutput)
+
+    def test_callers_render_through_the_backend_while_suspended(self) -> None:
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+        assert display.output is output
+
+
+class TestFailedAcquisitionReturnsTheLease:
+    """A lease stranded by a failure makes every later acquire() a no-op at depth two, which
+    never retries the installation and never reports why."""
+
+    def test_the_lease_is_returned_when_cleanup_fails_as_well(self) -> None:
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+
+        def always_fails(_sequence: str) -> None:
+            raise OSError("terminal is gone")
+
+        display.terminal.write_margin_change = always_fails  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="terminal is gone"):
+            display.acquire()
+        assert display.lease_depth == 0
+
+    def test_a_recovered_terminal_can_be_acquired_after_a_total_failure(self) -> None:
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+
+        failing = True
+
+        def sometimes_fails(sequence: str) -> None:
+            if failing:
+                raise OSError("terminal is gone")
+            PhysicalTerminal(output).write_margin_change(sequence)
+
+        display.terminal.write_margin_change = sometimes_fails  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="terminal is gone"):
+            display.acquire()
+
+        failing = False
+        stream.truncate(0), stream.seek(0)
+        assert display.acquire()
+        assert display.lease_depth == 1
+        assert stream.getvalue() == "\x1b7\x1b[1;23r\x1b8"
+
+    def test_a_measurement_failure_returns_the_lease_too(self) -> None:
+        """Measuring sits inside the rollback: an ioctl that fails must not strand a lease."""
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+
+        def no_size() -> Size:
+            raise OSError("ioctl failed")
+
+        output.get_size = no_size  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="ioctl failed"):
+            display.acquire()
+        assert display.lease_depth == 0
+
+    def test_the_original_failure_is_what_propagates(self) -> None:
+        """A cleanup that also fails must not mask the error worth reading."""
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+
+        def install_fails(_sequence: str) -> None:
+            raise OSError("install failed")
+
+        display.terminal.write_margin_change = install_fails  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="install failed"):
+            display.acquire()

--- a/tests/test_terminal_display.py
+++ b/tests/test_terminal_display.py
@@ -1,0 +1,508 @@
+"""Tests for geometry snapshots, backend capability and reservation ownership.
+
+Several of these are the named regressions from design section 13.1. Where one is, its
+docstring says which mutation it has to catch -- a test that passes both with and without the
+defect it is named for is worse than no test, because it reports coverage that is not there.
+"""
+
+import io
+
+import pytest
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from cmd2.reserved_output import ReservedOutput
+from cmd2.terminal_display import Geometry, PhysicalTerminal, TerminalDisplay
+
+
+def make_output(rows: int = 24, cols: int = 80) -> tuple[Vt100_Output, io.StringIO]:
+    """Build a real Vt100_Output over a string buffer, with a settable size."""
+    stream = io.StringIO()
+    size = Size(rows=rows, columns=cols)
+    output = Vt100_Output(stream, lambda: size)
+    return output, stream
+
+
+class Screen:
+    """A resizable terminal size, settable between activations.
+
+    Deliberately not a Vt100_Output subclass. Backend capability is decided by exact class
+    identity, so a subclass would be treated as an unqualified backend and never reserve --
+    which is the intended posture, and would make these tests pass for the wrong reason.
+    """
+
+    def __init__(self, rows: int, columns: int) -> None:
+        self.rows = rows
+        self.columns = columns
+
+    def size(self) -> Size:
+        return Size(rows=self.rows, columns=self.columns)
+
+
+class HomegrownOutput:
+    """An output cmd2 has never qualified. Capability must not guess in its favour."""
+
+
+def make_resizable_output(rows: int = 24, columns: int = 80) -> tuple[Vt100_Output, io.StringIO, Screen]:
+    """Build a real Vt100_Output whose size can be changed later."""
+    stream = io.StringIO()
+    screen = Screen(rows, columns)
+    return Vt100_Output(stream, screen.size), stream, screen
+
+
+class TestGeometry:
+    def test_usable_rows_subtracts_the_reservation_exactly_once(self) -> None:
+        """The double-subtraction mutation: at 24 rows with 1 reserved, 22 is the wrong answer."""
+        geometry = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=1)
+        assert geometry.usable_rows == 23
+
+    def test_virtual_size_is_one_reservation_shorter_than_physical(self) -> None:
+        geometry = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=1)
+        assert geometry.physical_size == Size(rows=24, columns=80)
+        assert geometry.virtual_size == Size(rows=23, columns=80)
+
+    def test_width_is_carried_through_unchanged(self) -> None:
+        """Reserving rows must not narrow the terminal."""
+        geometry = Geometry(generation=1, physical_rows=24, columns=132, reserved_rows=2)
+        assert geometry.virtual_size.columns == 132
+
+    def test_multiple_reserved_rows_are_all_withheld(self) -> None:
+        assert Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=3).usable_rows == 21
+
+    def test_a_snapshot_cannot_be_mutated(self) -> None:
+        """Geometry is a generation, not a variable: changes make a new snapshot."""
+        geometry = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=1)
+        with pytest.raises(AttributeError):
+            geometry.physical_rows = 30  # type: ignore[misc]
+
+    @pytest.mark.parametrize(("rows", "reserved"), [(3, 1), (4, 2), (24, 1), (24, 22)])
+    def test_eligible_when_at_least_two_usable_rows_remain(self, rows: int, reserved: int) -> None:
+        assert Geometry(generation=1, physical_rows=rows, columns=80, reserved_rows=reserved).is_eligible
+
+    @pytest.mark.parametrize(("rows", "reserved"), [(2, 1), (1, 1), (3, 2), (24, 23), (24, 24), (24, 0)])
+    def test_ineligible_below_the_two_usable_row_floor(self, rows: int, reserved: int) -> None:
+        """One usable row is not a narrower region; the terminal ignores it outright."""
+        assert not Geometry(generation=1, physical_rows=rows, columns=80, reserved_rows=reserved).is_eligible
+
+
+class TestBackendCapability:
+    """Capability comes from backend identity, never from shell name, TERM, or isinstance."""
+
+    def test_vt100_backend_is_qualified(self) -> None:
+        output, _ = make_output()
+        assert PhysicalTerminal(output).supports_reservation
+
+    def test_dummy_output_is_not_a_terminal(self) -> None:
+        terminal = PhysicalTerminal(DummyOutput())
+        supported, reason = terminal.capability()
+        assert not supported
+        assert "not a terminal" in reason
+
+    def test_an_unknown_backend_gets_compatibility_rendering(self) -> None:
+        """A wrong guess corrupts the screen, so an unrecognized backend is never assumed good."""
+
+        supported, reason = PhysicalTerminal(HomegrownOutput()).capability()
+        assert not supported
+        assert "not a qualified backend" in reason
+
+    def test_isinstance_of_output_is_not_enough_on_its_own(self) -> None:
+        """Windows10_Output satisfies isinstance without inheriting the interface, and legacy
+        Win32Output satisfies it while having no VT scroll margins at all. A capability check
+        that accepted every Output would inject DECSTBM into a console that cannot honour it.
+        """
+        from prompt_toolkit.output import Output
+
+        homegrown = DummyOutput()
+        assert isinstance(homegrown, Output)
+        assert not PhysicalTerminal(homegrown).supports_reservation
+
+    def test_the_physical_layer_refuses_to_wrap_the_adapter(self) -> None:
+        """Sizing from the adapter would subtract the reservation a second time."""
+        output, _ = make_output()
+        display = TerminalDisplay(output)
+        display.acquire()
+        with pytest.raises(TypeError, match="not the reserved adapter"):
+            PhysicalTerminal(display.output)
+
+
+class TestPhysicalGeometry:
+    def test_size_comes_from_the_unwrapped_backend(self) -> None:
+        output, _ = make_output(rows=40, cols=100)
+        assert PhysicalTerminal(output).physical_size() == Size(rows=40, columns=100)
+
+    def test_measure_stamps_the_generation_and_reservation(self) -> None:
+        output, _ = make_output(rows=24)
+        geometry = PhysicalTerminal(output).measure(generation=7, reserved_rows=2)
+        assert (geometry.generation, geometry.physical_rows, geometry.reserved_rows) == (7, 24, 2)
+        assert geometry.usable_rows == 22
+
+    def test_buffer_id_is_none_where_the_backend_has_no_viewport_notion(self) -> None:
+        output, _ = make_output()
+        assert PhysicalTerminal(output).buffer_id() is None
+
+
+class TestAcquisition:
+    def test_acquiring_installs_the_region_and_flushes_it(self) -> None:
+        """A region merely buffered is a reservation only promised."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        assert display.acquire()
+        assert stream.getvalue() == "\x1b7\x1b[1;23r\x1b8"
+        assert not output._buffer
+
+    def test_releasing_restores_full_screen_margins_immediately(self) -> None:
+        """Margins left installed would trap every later line of shell output inside them."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        stream.truncate(0), stream.seek(0)
+        display.release()
+        assert stream.getvalue() == "\x1b7\x1b[r\x1b8"
+        assert not output._buffer
+
+    def test_the_region_is_reset_when_the_body_raises(self) -> None:
+        output, stream = make_output(rows=24)
+
+        def blow_up() -> None:
+            stream.truncate(0), stream.seek(0)
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"), TerminalDisplay(output):
+            blow_up()
+        assert stream.getvalue() == "\x1b7\x1b[r\x1b8"
+
+    def test_release_is_idempotent(self) -> None:
+        """Cleanup paths call this freely; a second reset would move the cursor again."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release()
+        stream.truncate(0), stream.seek(0)
+        display.release()
+        display.release()
+        assert stream.getvalue() == ""
+
+    def test_nested_leases_share_one_region(self) -> None:
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        with display:
+            stream.truncate(0), stream.seek(0)
+            with display:
+                assert display.lease_depth == 2
+            assert stream.getvalue() == "", "the inner release tore down a shared reservation"
+            assert display.is_reserved
+        assert not display.is_reserved
+
+    def test_an_unqualified_backend_is_left_alone(self) -> None:
+        """Compatibility rendering means no sequences at all, not a narrower region."""
+        display = TerminalDisplay(DummyOutput())
+        assert not display.acquire()
+        assert not display.is_reserved
+        assert display.output is display.terminal.output
+
+    def test_a_fresh_size_is_read_at_every_activation(self) -> None:
+        """Geometry frozen at construction is wrong the moment the window is resized."""
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 23
+        display.release()
+
+        screen.rows = 40
+        stream.truncate(0), stream.seek(0)
+        display.acquire()
+        assert stream.getvalue() == "\x1b7\x1b[1;39r\x1b8"
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 39
+
+    def test_each_activation_is_a_new_generation(self) -> None:
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert display.geometry is not None
+        first = display.geometry.generation
+        display.release()
+        display.acquire()
+        assert display.geometry is not None
+        assert display.geometry.generation > first
+
+    def test_reserved_rows_must_be_at_least_one(self) -> None:
+        output, _ = make_output()
+        with pytest.raises(ValueError, match="at least 1"):
+            TerminalDisplay(output, reserved_rows=0)
+
+
+class TestTwoRowFloor:
+    """The named regression ``test_one_usable_row_releases_reservation``."""
+
+    def test_one_usable_row_never_installs_a_degenerate_region(self) -> None:
+        """A terminal ignores ``1;1r`` and then scrolls straight through the reserved row.
+
+        The failure is total, not degraded, so the only correct response is to release. This
+        must catch a mutation that clamps the region to one row instead of refusing it.
+        """
+        output, stream = make_output(rows=2)
+        display = TerminalDisplay(output)
+        assert not display.acquire()
+        assert not display.is_reserved
+        assert "\x1b[1;1r" not in stream.getvalue()
+        assert stream.getvalue() == ""
+
+    def test_full_geometry_and_the_plain_backend_are_used_while_released(self) -> None:
+        output, _ = make_output(rows=2)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert display.geometry is None
+        assert display.output.get_size() == Size(rows=2, columns=80)
+        assert not isinstance(display.output, ReservedOutput)
+
+    def test_shrinking_below_the_floor_releases_an_installed_region(self) -> None:
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert display.is_reserved
+
+        screen.rows = 2
+        stream.truncate(0), stream.seek(0)
+        assert not display.reconfigure()
+        assert not display.is_reserved
+        assert stream.getvalue() == "\x1b7\x1b[r\x1b8", "margins must be restored, not narrowed"
+
+    def test_growing_back_above_the_floor_reacquires(self) -> None:
+        output, _stream, screen = make_resizable_output(rows=2, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert not display.is_reserved
+
+        screen.rows = 24
+        assert display.reconfigure()
+        assert display.is_reserved
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 23
+
+    def test_reconfigure_does_nothing_without_a_lease(self) -> None:
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        assert not display.reconfigure()
+        assert stream.getvalue() == ""
+
+
+class TestResize:
+    def test_reconfigure_installs_the_region_for_the_new_height(self) -> None:
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+
+        screen.rows = 40
+        stream.truncate(0), stream.seek(0)
+        assert display.reconfigure()
+        assert stream.getvalue() == "\x1b7\x1b[1;39r\x1b8"
+
+    def test_a_width_change_alone_is_still_a_new_generation(self) -> None:
+        """Toolbar height is measured against the width, so a rewrap can change the reservation."""
+        output, _stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        assert display.geometry is not None
+        before = display.geometry.generation
+
+        screen.columns = 40
+        display.reconfigure()
+        assert display.geometry is not None
+        assert display.geometry.columns == 40
+        assert display.geometry.generation > before
+
+
+class TestScreenBufferHandoff:
+    def test_entering_the_alternate_screen_restores_full_margins(self) -> None:
+        """The program taking over knows nothing about a reservation."""
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        stream.truncate(0), stream.seek(0)
+        display.release_region_for_handoff()
+        assert stream.getvalue() == "\x1b7\x1b[r\x1b8"
+        assert not display.is_reserved
+
+    def test_the_lease_survives_a_handoff(self) -> None:
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+        assert display.lease_depth == 1
+
+    def test_returning_measures_afresh_rather_than_restoring_the_old_snapshot(self) -> None:
+        """A program that resized the window in between would otherwise pin the toolbar
+        to a row that is no longer the bottom one."""
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+
+        screen.rows = 40
+        stream.truncate(0), stream.seek(0)
+        display.reacquire_region_after_handoff()
+        assert stream.getvalue() == "\x1b7\x1b[1;39r\x1b8"
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 39
+
+    def test_returning_to_a_terminal_below_the_floor_stays_released(self) -> None:
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+
+        screen.rows = 2
+        stream.truncate(0), stream.seek(0)
+        display.reacquire_region_after_handoff()
+        assert not display.is_reserved
+        assert stream.getvalue() == ""
+
+    def test_a_handoff_return_without_a_handoff_does_nothing(self) -> None:
+        output, stream = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.acquire()
+        stream.truncate(0), stream.seek(0)
+        display.reacquire_region_after_handoff()
+        assert stream.getvalue() == ""
+
+
+class TestFailedAcquisition:
+    def test_a_failed_install_leaves_full_screen_margins_behind(self) -> None:
+        """A half-installed region is worse than none: the shell would inherit it."""
+        output, _stream = make_output(rows=24)
+
+        def explode(_sequence: str) -> None:
+            raise OSError("write failed")
+
+        display = TerminalDisplay(output)
+        display.terminal.write_margin_change = explode  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="write failed"):
+            display.acquire()
+
+        display.terminal.write_margin_change = PhysicalTerminal(output).write_margin_change  # type: ignore[method-assign]
+        assert not display.is_reserved
+
+    def test_a_failed_install_does_not_leave_a_lease_held(self) -> None:
+        """A lease left behind would make the next release a no-op and strand the margins."""
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        calls: list[str] = []
+
+        def explode(_sequence: str) -> None:
+            calls.append("attempted")
+            if len(calls) == 1:
+                raise OSError("write failed")
+
+        display.terminal.write_margin_change = explode  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="write failed"):
+            display.acquire()
+        assert display.lease_depth == 0
+        assert calls == ["attempted", "attempted"], "the region reset was not attempted"
+
+
+class WindowsLikeScreen:
+    """A Windows output whose viewport origin can be moved between reads."""
+
+    class _Window:
+        def __init__(self, top: int) -> None:
+            self.Left = 0
+            self.Top = top
+
+    class _Size:
+        X = 92
+        Y = 21
+
+    class _Info:
+        def __init__(self, top: int) -> None:
+            self.srWindow = WindowsLikeScreen._Window(top)
+            self.dwSize = WindowsLikeScreen._Size()
+
+    def __init__(self) -> None:
+        self.top = 0
+        self.rows = 21
+        self.written: list[str] = []
+
+    def get_win32_screen_buffer_info(self) -> "WindowsLikeScreen._Info":
+        return WindowsLikeScreen._Info(self.top)
+
+    def get_size(self) -> Size:
+        return Size(rows=self.rows, columns=92)
+
+    def write_raw(self, data: str) -> None:
+        self.written.append(data)
+
+    def flush(self) -> None:
+        pass
+
+
+@pytest.fixture
+def qualified_windows_double(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat the Windows test double as a qualified backend.
+
+    Capability is decided by exact class identity, which is what keeps an unrecognized
+    backend from having DECSTBM injected into it. These tests are about viewport-origin
+    invalidation rather than capability, so the double is qualified explicitly rather than
+    by loosening the rule under test elsewhere.
+    """
+    import cmd2.terminal_display as td
+
+    name = f"{WindowsLikeScreen.__module__}.{WindowsLikeScreen.__qualname__}"
+    monkeypatch.setattr(td, "_QUALIFIED_BACKENDS", td._QUALIFIED_BACKENDS | {name})
+
+
+@pytest.mark.usefixtures("qualified_windows_double")
+class TestViewportOrigin:
+    def test_buffer_id_records_the_viewport_origin_and_buffer_size(self) -> None:
+        screen = WindowsLikeScreen()
+        assert PhysicalTerminal(screen).buffer_id() == (0, 0, 92, 21)  # type: ignore[arg-type]
+
+    def test_a_moved_viewport_invalidates_the_generation(self) -> None:
+        """Absolute row numbers address different cells after the viewport moves, even
+        though width and height are unchanged."""
+        screen = WindowsLikeScreen()
+        display = TerminalDisplay(screen)  # type: ignore[arg-type]
+        display._depth = 1
+        display._geometry = display._measure()
+        before = display.geometry.generation  # type: ignore[union-attr]
+
+        screen.top = 5
+        assert display.revalidate_viewport()
+        assert display.geometry is not None
+        assert display.geometry.generation > before
+        assert display.geometry.buffer_id == (0, 5, 92, 21)
+
+    def test_an_unmoved_viewport_rebuilds_nothing(self) -> None:
+        screen = WindowsLikeScreen()
+        display = TerminalDisplay(screen)  # type: ignore[arg-type]
+        display._depth = 1
+        display._geometry = display._measure()
+        before = display.geometry.generation  # type: ignore[union-attr]
+
+        assert display.revalidate_viewport()
+        assert display.geometry is not None
+        assert display.geometry.generation == before
+
+    def test_revalidating_while_released_reports_no_reservation(self) -> None:
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        assert not display.revalidate_viewport()
+
+
+class TestReleasedStateIsInert:
+    def test_a_handoff_release_without_a_reservation_does_nothing(self) -> None:
+        output, stream = make_output(rows=2)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff()
+        assert stream.getvalue() == ""
+
+    def test_releasing_an_unreserved_lease_emits_nothing(self) -> None:
+        """Below the floor there is no region to reset, and an unpaired reset moves the cursor."""
+        output, stream = make_output(rows=2)
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release()
+        assert stream.getvalue() == ""

--- a/tests/test_terminal_display.py
+++ b/tests/test_terminal_display.py
@@ -700,3 +700,57 @@ class TestHandoffFromAReleasedTerminal:
         display.release_region_for_handoff()
         assert display.acquire()
         assert display.is_reserved
+
+
+class TestHandoffReturnRestoresEverything:
+    """Coming back is an ordinary reconfiguration. Installing margins without rebinding the
+    adapter leaves a reserved terminal whose callers hold the plain backend -- and therefore
+    unbounded erases running over the reserved row."""
+
+    def test_the_adapter_is_rebound_when_the_region_comes_back(self) -> None:
+        output, _stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        adapter.enter_alternate_screen()
+        screen.rows = 24
+        adapter.quit_alternate_screen()
+
+        assert display.is_reserved
+        assert isinstance(display.output, ReservedOutput), "callers were left on the backend"
+        assert display.output.get_size() == Size(rows=23, columns=80)
+
+    def test_erases_through_the_returned_output_are_bounded(self) -> None:
+        """The failure this guards against destroys the reserved row outright."""
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        adapter.enter_alternate_screen()
+        screen.rows = 24
+        adapter.quit_alternate_screen()
+
+        display.output.flush()
+        stream.truncate(0), stream.seek(0)
+        display.output.erase_down()
+        display.output.flush()
+        assert stream.getvalue() == "\x1b[23M"
+        assert "\x1b[J" not in stream.getvalue()
+
+    def test_an_unqualified_backend_is_still_unqualified_after_a_handoff(self) -> None:
+        """A refused acquisition still holds a lease, so the handoff flag can be set for a
+        backend that was never eligible. Capability has to be re-checked, not assumed."""
+        display = TerminalDisplay(DummyOutput())
+        assert not display.acquire()
+        assert display.lease_depth == 1
+
+        display.release_region_for_handoff()
+        display.reacquire_region_after_handoff()
+
+        assert not display.is_reserved
+        assert display.geometry is None
+        assert display.output is display.terminal.output

--- a/tests/test_terminal_display.py
+++ b/tests/test_terminal_display.py
@@ -623,3 +623,80 @@ class TestFailedAcquisitionReturnsTheLease:
         display.terminal.write_margin_change = install_fails  # type: ignore[method-assign]
         with pytest.raises(OSError, match="install failed"):
             display.acquire()
+
+
+class TestHandoffFromAReleasedTerminal:
+    """A terminal below the floor is released but still ours, and a guest can take it from
+    that state. Recording ownership only when a region happened to be installed would let a
+    later resize reinstall margins over the guest's screen."""
+
+    def test_a_guest_can_take_a_terminal_that_is_below_the_floor(self) -> None:
+        output, _stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        assert not display.is_reserved
+
+        adapter.enter_alternate_screen()
+        screen.rows = 24
+        assert not display.reconfigure(), "margins were reinstalled over the guest's screen"
+        assert not display.is_reserved
+
+    def test_the_guest_keeps_the_whole_screen(self) -> None:
+        output, _stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        adapter.enter_alternate_screen()
+        screen.rows = 24
+        display.reconfigure()
+        assert adapter.get_size() == Size(rows=24, columns=80)
+
+    def test_no_margin_sequence_reaches_the_guest(self) -> None:
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        adapter.enter_alternate_screen()
+        adapter.flush()
+        screen.rows = 24
+        stream.truncate(0), stream.seek(0)
+
+        display.reconfigure()
+        adapter.flush()
+        assert stream.getvalue() == ""
+
+    def test_the_reservation_is_established_when_the_guest_hands_it_back(self) -> None:
+        """Suspending reconfiguration must not lose the resize that happened during it."""
+        output, stream, screen = make_resizable_output(rows=24, columns=80)
+        display = TerminalDisplay(output)
+        display.acquire()
+        adapter = display.output
+        screen.rows = 2
+        display.reconfigure()
+        adapter.enter_alternate_screen()
+        screen.rows = 24
+        display.reconfigure()
+        adapter.flush()
+        stream.truncate(0), stream.seek(0)
+
+        adapter.quit_alternate_screen()
+        adapter.flush()
+        assert display.is_reserved
+        assert "\x1b[1;23r" in stream.getvalue()
+        assert display.geometry is not None
+        assert display.geometry.usable_rows == 23
+
+    def test_a_handoff_without_a_lease_is_not_recorded(self) -> None:
+        """Nothing was ours to hand over, so nothing may be reclaimed later."""
+        output, _ = make_output(rows=24)
+        display = TerminalDisplay(output)
+        display.release_region_for_handoff()
+        assert display.acquire()
+        assert display.is_reserved


### PR DESCRIPTION
Stage 2a of the reserved-row bottom toolbar: the terminal-ownership and geometry layer, and
the concrete `Output` adapter the application renders through. **No runtime behaviour
changes** — nothing here is wired into toolbar rendering yet.

Targets the long-lived `reserved_row_toolbar` integration branch. Stage 1 closed on
2026-09-09 with iTerm2, Windows Terminal and Git Bash/mintty all qualified (#1751).

## What's here

**`cmd2/terminal_display.py`** — `Geometry`, `PhysicalTerminal`, `TerminalDisplay`.

`Geometry` is an immutable snapshot per generation. `usable_rows` is derived rather than
stored, so no caller can hand in a height that has already had the reservation removed: at 24
physical rows with one reserved, every component must see 23, never 22.

`PhysicalTerminal` is the unwrapped source of true size and the only place backend capability
is decided — by exact class identity, never by shell name, `TERM`, or `isinstance(output,
Output)`. That check is useless here: `Windows10_Output` satisfies it as a *registered
virtual* subclass without inheriting the interface, and legacy `Win32Output` satisfies it
while having no VT scroll margins at all. An unrecognized backend gets compatibility
rendering, because a wrong guess corrupts the user's screen rather than merely rendering
poorly.

`TerminalDisplay` owns acquisition, nested leases, idempotent release and restoration.

**`cmd2/reserved_output.py`** — `ReservedOutput(Output)`, the virtual view.

Every abstract method is implemented explicitly. `__getattr__` would leave the class abstract
and would silently absorb whatever a future prompt-toolkit adds without anyone deciding what
a reservation means for it. The wrapped backend is never modified, so the object a caller
hands in is the object they get back — the Stage 0 spike assigned over bound methods, which
made restoration an ordering problem and lost a caller's own erase override if one was
already installed.

`get_rows_below_cursor_position` is adapted rather than passed through: Windows answers it
natively, so adapting `get_size()` alone would leave the renderer believing it may draw over
the reserved rows.

**`ReservedBottomRows` is deleted** in this same change, as design R1 requires — one
mechanism, not two. The pure sequence helpers and their tests stay, and the module's
unconditional ED-equivalence claim is corrected.

## Two rules that shape the whole patch

**Bounded erases live and die with the reservation.** `ED` preserves the cursor line's prefix;
`DL` deletes the whole line. On tmux 3.7c a `DL` from a nonzero column destroyed committed
text to its left. The three renderer paths reaching `erase_down` move to column zero first,
which is what makes the substitution valid *for them* — a precondition, not a property. So the
replacement lives on an adapter that exists only while a region is installed, and outside one
every erase defers to the backend.

**Below two usable rows the reservation is released, not narrowed.** A terminal ignores a
degenerate `1;1r` and then scrolls straight through the reserved row. The failure is total
rather than degraded, so narrowing is never an option.

## Evidence

**Static-marker gate, driving the production adapter** — not a spike, so a pass is evidence
about shipped code. Rerun after every change below.

| Rows | Commands | Disappearances | Committed lines | Marker in history |
| --- | --- | --- | --- | --- |
| 12 | 22 | 0 | 20/20 | 0 |
| 24 | 34 | 0 | 32/32 | 0 |
| 40 | 50 | 0 | 48/48 | 0 |

**Both negative controls fail, verified from the raw pty stream** rather than the verdict —
each starts the app cleanly and then loses the marker for the intended reason. Margins without
the bounded erase emits `ESC[J`; the bounded erase without margins emits `ESC[r` then runs
`ESC[23M` against the full screen. The positive case emits `ESC7 ESC[1;23r ESC8` then `ESC[23M`
and survives.

**Seven designated mutations, each killed:** double subtraction (22 tests), sizing the region
from the already-shortened height (6), clamping to one usable row instead of releasing (5),
anchoring the region at row 2 with no coordinate translation (9), ED instead of bounded DL (3),
forgetting the reservation in the native rows-below query (1), reporting physical size to the
application (7).

Named §13.1 regressions present: `test_one_usable_row_releases_reservation`,
`test_reserved_output_preserves_existing_backend_methods`,
`test_windows_outer_output_owns_geometry_and_flush`, `test_cpr_uses_row_one_coordinate_contract`.

130 tests across the two new files; both modules at 100% line coverage. Full suite 2089 passed,
6 skipped. `make check` and `make docs-test` clean.

## Review findings, all fixed

Independent review found four P2 defects, each reproduced against the production classes
before the fix and each fix reverted afterwards to confirm the new tests fail without it.

1. **Bounded erases outlived the reservation.** A handoff restores full margins while keeping
   the lease, and prompt-toolkit holds the output object it was created with — so the adapter
   kept emitting `DL`, against the whole screen, because the fallback read the physical
   height. My own `# pragma: no cover - the adapter does not outlive its reservation` comments
   were simply false; the handoff path makes it routine.
2. **Reconfiguration reinstalled margins mid-handoff**, restricting the guest application's
   screen. Now inert for the guest's whole tenancy; the resize is picked up on return.
3. **A failed acquisition could strand its lease** — depth was decremented only after cleanup
   succeeded, and measurement sat outside the rollback, so a terminal that could be neither
   measured nor reset left every later `acquire()` a no-op at depth two.
4. **Handoff ownership was tied to the geometry snapshot**, and then the return path installed
   margins by hand — skipping both the adapter rebind and the capability re-check. A terminal
   below the floor is released but still ours, so a guest could take it from that state
   unrecorded; and a refused acquisition still holds a lease, so a `DummyOutput` could come
   back "reserved". Returning is now an ordinary reconfiguration.

## Deliberately not here

- **Stage 2b** — painter, serializer, prepare/commit bridge, recovery.
- **CPR validation.** The coordinate contract is tested, but rejecting a reply from inside the
  reserved band belongs to the bridge. `test_cpr_request_cannot_interleave_with_paint` is
  absent because Stage 2a contains no painter to prove it against.
- **The §9 alternate-screen handoff.** Entering restores margins and keeps the lease; leaving
  re-measures and re-installs. Full buffer handoff is Stage 4. Re-measuring rather than
  restoring the pre-handoff snapshot is deliberate: a program that resized the window would
  otherwise pin the toolbar to a row that is no longer the bottom.
- **First placement over a populated terminal** (§5.4) — needs the integrated implementation.

## Known follow-ups

Recorded as loose ends, none gating a stage, all to close before `main`: the outstanding
Windows validation (backing buffer taller than the viewport, conhost on the fixed probe),
removal of `scripts/toolbar_inventory.py`, the suite's pre-existing encoding sensitivity, and
`test_send_to_paste_buffer`'s dependence on the host clipboard — a pre-existing test bug that
fails on a machine with no clipboard provider and is unrelated to this patch.
