### PR TITLE
Remove Windows development papercuts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "lf",
   "printWidth": 100,
   "proseWrap": "always",
   "overrides": [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,14 +191,19 @@ def pr_none():
     # Put the new process into a separate group so its signal are isolated from ours
     kwargs = {}
     if sys.platform.startswith("win"):
-        command = "timeout -t 5 /nobreak"
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
-        command = "sleep 5"
         kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(command, shell=True, **kwargs)
-    return cu.ProcReader(proc, None, None)
+    # The child restores the default SIGINT action so that, like `sleep`, it dies with -SIGINT on POSIX
+    child_code = "import signal, time; signal.signal(signal.SIGINT, signal.SIG_DFL); print('ready', flush=True); time.sleep(5)"
+    proc = subprocess.Popen([sys.executable, "-c", child_code], stdout=subprocess.PIPE, **kwargs)
+
+    # Wait for the child to report that it is running before returning it to a test. Signaling a Windows console
+    # process before it has finished initializing makes it fail with STATUS_DLL_INIT_FAILED (0xc0000142) and pop up
+    # an "Application Error" dialog that blocks the test run until someone clicks OK.
+    assert proc.stdout.readline().strip() == b"ready"
+    return cu.ProcReader(proc, sys.stdout, sys.stderr)
 
 
 def test_proc_reader_send_sigint(pr_none) -> None:

--- a/ty.toml
+++ b/ty.toml
@@ -1,5 +1,7 @@
 [environment]
 python-version = "3.11"
+# Check every platform's branches (rather than the host's) so ty behaves identically on Linux, macOS, and Windows.
+python-platform = "all"
 
 [src]
 include = ["cmd2"]


### PR DESCRIPTION
Make the development workflow behave the same on Windows as it does on Linux and macOS, so Windows contributors can run make check and make test without surprises.

`.prettierrc`: set endOfLine to `lf` so prettier does not rewrite files with CRLF line endings on Windows checkouts, which showed up as spurious diffs.

`ty.toml`: set `python-platform` to `"all"`. ty was inferring the host platform, so on Windows it reported 8 unresolved-attribute errors for the POSIX-only termios and signal.SIGTTOU code in cmd2.py, which is already gated at runtime by _initial_termios_settings being None on Windows. Checking every platform's branches makes ty deterministic on all OSes and matches CI.

`tests/test_utils.py`: fix the `pr_none` fixture so make test no longer pops up a "cmd.exe - Application Error (0xc0000142)" dialog on Windows that blocks the run until someone clicks OK. The fixture returned a freshly spawned cmd.exe and test_proc_reader_send_sigint sent CTRL_BREAK_EVENT before it finished initializing, which Windows reports as STATUS_DLL_INIT_FAILED. The fixture now launches a Python child directly and waits for it to print "ready" before handing it to the test. It also restores the default SIGINT action so POSIX still sees -SIGINT/-SIGTERM, and it removes the shell=True dependence on which "timeout" is on PATH.