### PR TITLE
Stage 4: integrate reserved toolbar handoffs, job control, and resize recovery

### DIFF
--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -86,6 +86,7 @@ from prompt_toolkit.layout.containers import ConditionalContainer, FloatContaine
 from prompt_toolkit.output import DummyOutput, create_output
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession, choice, set_title
+from prompt_toolkit.shortcuts.choice_input import ChoiceInput
 from prompt_toolkit.styles import DynamicStyle
 from rich.console import (
     Group,
@@ -2175,7 +2176,8 @@ class Cmd:
 
         Use this context manager around application-specific calls to ``input()``, other
         terminal UIs, or subprocesses that inherit the terminal. cmd2 automatically suspends
-        its toolbar for its own input prompts, external pagers, and shell commands.
+        its toolbar for external pagers and shell commands. Managed input prompts borrow
+        the reservation without releasing the rows.
 
         In reserved mode this also gives the reserved rows back, because a program that
         inherits the terminal knows nothing about a scroll region and would find its output
@@ -3790,9 +3792,9 @@ class Cmd:
         The command display is stopped either way, but only some prompts give the terminal
         away with it. The main prompt is the one the reservation exists for: it renders
         through the reserved output, and the toolbar has to still be there while the user is
-        typing -- that is what "stable across ordinary commands" means. Any other session is
-        an application prompt cmd2 has not bound to the reservation, so it gets the terminal
-        to itself, rows included.
+        typing. Managed nested prompts on the same terminal borrow that reservation with
+        their own bridge after the command input reader stops. Other terminals and prompts
+        inside an external handoff retain the exclusive-terminal path.
 
         :param prompt: the prompt text or a callable that returns the prompt.
         :param session: the PromptSession instance to use for reading.
@@ -3800,11 +3802,13 @@ class Cmd:
         :return: the stripped input string.
         :raises EOFError: if the input stream is closed or the user signals EOF (e.g., Ctrl+D)
         """
-        owns_the_reservation = session is self.main_session
+        reserved = self._reserved_toolbar
+        owns_the_reservation = session is self.main_session or (reserved is not None and reserved.can_manage(session))
         with self._quiesce_bottom_toolbar() if owns_the_reservation else self.suspend_bottom_toolbar():
-            reserved = self._reserved_toolbar
             if owns_the_reservation and reserved is not None and reserved.bridge is not None:
                 reserved.bridge.finish_command_output()
+                with reserved.prompt_session(session):
+                    return self._read_raw_input_now(prompt, session, **prompt_kwargs)
             return self._read_raw_input_now(prompt, session, **prompt_kwargs)
 
     def _read_raw_input_now(
@@ -3932,7 +3936,7 @@ class Cmd:
 
         temp_session: PromptSession[str] = PromptSession(
             auto_suggest=self.main_session.auto_suggest,
-            bottom_toolbar=self.get_bottom_toolbar if self.main_session.bottom_toolbar is not None else None,
+            bottom_toolbar=self.main_session.bottom_toolbar,
             color_depth=self.main_session.color_depth,
             complete_style=self.main_session.complete_style,
             complete_in_thread=self.main_session.complete_in_thread,
@@ -3961,7 +3965,7 @@ class Cmd:
         :raises Exception: any other exceptions raised by prompt()
         """
         temp_session: PromptSession[str] = PromptSession(
-            bottom_toolbar=self.get_bottom_toolbar if self.main_session.bottom_toolbar is not None else None,
+            bottom_toolbar=self.main_session.bottom_toolbar,
             color_depth=self.main_session.color_depth,
             enable_suspend=self.main_session.enable_suspend,
             input=self.main_session.input,
@@ -4937,7 +4941,7 @@ class Cmd:
         self.last_result = True
         return True
 
-    @command_toolbar.suspend_toolbar
+    @command_toolbar.quiesce_toolbar
     def select(self, opts: str | Iterable[str] | Iterable[tuple[Any, str | None]], prompt: str = "Your choice? ") -> Any:
         """Present a menu to the user.
 
@@ -4972,7 +4976,22 @@ class Cmd:
             try:
                 while True:
                     with create_app_session(input=self.main_session.input, output=self.main_session.output):
-                        result = choice(message=prompt, options=fulloptions)
+                        reserved = self._reserved_toolbar
+                        if reserved is not None and reserved.can_manage(self.main_session):
+                            if reserved.bridge is not None:
+                                reserved.bridge.finish_command_output()
+                            # ChoiceInput.prompt() constructs and runs in one step. Binding
+                            # its application first gives the initial frame reserved geometry.
+                            selection = ChoiceInput(
+                                message=prompt,
+                                options=fulloptions,
+                                style=self.main_session.style,
+                                enable_suspend=self.main_session.enable_suspend,
+                            )._create_application()
+                            with reserved.prompt_application(selection):
+                                result = selection.run()
+                        else:
+                            result = choice(message=prompt, options=fulloptions)
                     if result is not None:
                         return result
             except KeyboardInterrupt:

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -2183,7 +2183,11 @@ class Cmd:
         inherits the terminal knows nothing about a scroll region and would find its output
         confined to rows it never asked for. The rows are taken again afterwards.
         """
-        with self._quiesce_bottom_toolbar():
+        reader = self._cur_pipe_proc_reader
+        with (
+            reader.borrow_terminal() if reader is not None else contextlib.nullcontext(),
+            self._quiesce_bottom_toolbar(),
+        ):
             reserved = self._reserved_toolbar
 
             if reserved is None:
@@ -3531,9 +3535,8 @@ class Cmd:
             subproc_stdin = open(read_fd, encoding="utf-8")  # noqa: SIM115
             new_stdout: TextIO = cast(TextIO, open(write_fd, "w", encoding="utf-8"))  # noqa: SIM115
 
-            # Captured pipelines use isolated groups for ordered Ctrl-C forwarding.
-            # Terminal-attached POSIX pipelines must instead belong to our foreground
-            # job, so Ctrl-Z and the shell's fg stop/resume every terminal reader together.
+            # Isolate pipeline signals from cmd2. Terminal pipelines receive the
+            # foreground terminal; ProcReader relays their job-control stops.
             kwargs: dict[str, Any] = {}
             if sys.platform == "win32":
                 kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
@@ -3553,10 +3556,18 @@ class Cmd:
             )
             pipe_stderr = None if isinstance(sys.stderr, utils.StdSim) else command_toolbar.pipe_target(sys.stderr)
 
+            terminal_fd = None
             if sys.platform != "win32":
-                kwargs["start_new_session"] = not any(
-                    stream is not None and stream.isatty() for stream in (pipe_stdout, pipe_stderr)
-                )
+                for stream in (pipe_stdout, pipe_stderr):
+                    if stream is not None and stream.isatty():
+                        with contextlib.suppress(OSError, ValueError):
+                            if os.tcgetpgrp(stream.fileno()) == os.getpgrp():
+                                terminal_fd = stream.fileno()
+                                break
+                if terminal_fd is None:
+                    kwargs["start_new_session"] = True
+                else:
+                    kwargs["process_group"] = 0
 
             with contextlib.ExitStack() as terminal_stack:
                 # The toolbar can neither draw nor hold the keyboard while a pipe process owns
@@ -3572,21 +3583,36 @@ class Cmd:
                     shell=True,
                     **kwargs,
                 )
+                if terminal_fd is not None:
+                    import signal
+
+                    # The producer may still write diagnostics while the consumer owns
+                    # the terminal. Block SIGTTOU after Popen so the child retains normal
+                    # job-control behavior, and restore our mask with the handoff.
+                    previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGTTOU})
+                    terminal_stack.callback(signal.pthread_sigmask, signal.SIG_SETMASK, previous_mask)
+                    cmd_pipe_proc_reader = utils.ProcReader(proc, self.stdout, sys.stderr, terminal_fd=terminal_fd)
 
                 # Popen was called with shell=True so the user can chain pipe commands and redirect their output
                 # like: !ls -l | grep user | wc -l > out.txt. But this makes it difficult to know if the pipe process
                 # started OK, since the shell itself always starts. Therefore, we will wait a short time and check
                 # if the pipe process is still running.
                 with contextlib.suppress(subprocess.TimeoutExpired):
-                    proc.wait(0.2)
+                    if cmd_pipe_proc_reader is None:
+                        proc.wait(0.2)
+                    else:
+                        cmd_pipe_proc_reader.wait_for_exit(0.2)
 
                 # Check if the pipe process already exited
                 if proc.returncode is not None:
+                    if cmd_pipe_proc_reader is not None:
+                        cmd_pipe_proc_reader.wait()
                     subproc_stdin.close()
                     new_stdout.close()
                     raise RedirectionError(f"Pipe process exited with code {proc.returncode} before command could run")
                 redir_saved_state.redirecting = True
-                cmd_pipe_proc_reader = utils.ProcReader(proc, self.stdout, sys.stderr)
+                if cmd_pipe_proc_reader is None:
+                    cmd_pipe_proc_reader = utils.ProcReader(proc, self.stdout, sys.stderr)
 
                 self.stdout = new_stdout
 
@@ -3807,7 +3833,11 @@ class Cmd:
         """
         reserved = self._reserved_toolbar
         owns_the_reservation = session is self.main_session or (reserved is not None and reserved.can_manage(session))
-        with self._quiesce_bottom_toolbar() if owns_the_reservation else self.suspend_bottom_toolbar():
+        reader = self._cur_pipe_proc_reader
+        with (
+            reader.borrow_terminal() if reader is not None else contextlib.nullcontext(),
+            self._quiesce_bottom_toolbar() if owns_the_reservation else self.suspend_bottom_toolbar(),
+        ):
             if owns_the_reservation and reserved is not None and reserved.bridge is not None:
                 reserved.bridge.finish_command_output()
                 with reserved.prompt_session(session):

--- a/cmd2/cmd2.py
+++ b/cmd2/cmd2.py
@@ -3531,15 +3531,13 @@ class Cmd:
             subproc_stdin = open(read_fd, encoding="utf-8")  # noqa: SIM115
             new_stdout: TextIO = cast(TextIO, open(write_fd, "w", encoding="utf-8"))  # noqa: SIM115
 
-            # Create pipe process in a separate group to isolate our signals from it. If a Ctrl-C event occurs,
-            # our sigint handler will forward it only to the most recent pipe process. This makes sure pipe
-            # processes close in the right order (most recent first).
+            # Captured pipelines use isolated groups for ordered Ctrl-C forwarding.
+            # Terminal-attached POSIX pipelines must instead belong to our foreground
+            # job, so Ctrl-Z and the shell's fg stop/resume every terminal reader together.
             kwargs: dict[str, Any] = {}
             if sys.platform == "win32":
                 kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
             else:
-                kwargs["start_new_session"] = True
-
                 # Attempt to run the pipe process in the user's preferred shell instead of the default behavior of using sh.
                 shell = os.environ.get("SHELL")
                 if shell:
@@ -3554,6 +3552,11 @@ class Cmd:
                 else command_toolbar.pipe_target(self.stdout)
             )
             pipe_stderr = None if isinstance(sys.stderr, utils.StdSim) else command_toolbar.pipe_target(sys.stderr)
+
+            if sys.platform != "win32":
+                kwargs["start_new_session"] = not any(
+                    stream is not None and stream.isatty() for stream in (pipe_stdout, pipe_stderr)
+                )
 
             with contextlib.ExitStack() as terminal_stack:
                 # The toolbar can neither draw nor hold the keyboard while a pipe process owns

--- a/cmd2/command_toolbar.py
+++ b/cmd2/command_toolbar.py
@@ -721,7 +721,9 @@ class CommandToolbar:
         # Measuring the toolbar can invoke its callback; keep that work on the
         # UI thread along with rendering and layout changes.
         toolbar_height = self._call_in_ui(lambda: self.toolbar.preferred_height(size.columns, size.rows).preferred)
-        if output_fits(text, size.columns, max(0, size.rows - toolbar_height), chop=chop):
+        reserved = self.cmd.reserved_toolbar
+        available_rows = size.rows if reserved is not None and reserved.is_active else max(0, size.rows - toolbar_height)
+        if output_fits(text, size.columns, available_rows, chop=chop):
             self.cmd.stdout.write(text)
             self.cmd.stdout.flush()
             return
@@ -736,6 +738,7 @@ class CommandToolbar:
         entered = False
         restored = False
         close_error: BaseException | None = None
+        handoff = contextlib.ExitStack()
 
         def restore() -> None:
             """Give the application back to the display, whichever thread is doing it.
@@ -763,6 +766,10 @@ class CommandToolbar:
             # duration -- otherwise the pager swaps in its layout and nothing is ever painted.
             self._set_render_suppressed(False)
             self.app.renderer.erase()
+            if reserved is not None:
+                # The very first pager layout must see the physical size. Releasing from
+                # enter_alternate_screen during replay is too late: that frame was measured.
+                handoff.enter_context(reserved.suspended())
             self.app.layout = layout
             self.app.key_bindings = pager.bindings
             self.app.editing_mode = EditingMode.EMACS
@@ -776,8 +783,20 @@ class CommandToolbar:
             entered = False
             try:
                 self.app.renderer.erase()
+            except BaseException:
+                # An erase can fail before quitting the alternate screen. Complete upstream's
+                # mode/buffer cleanup before returning the main-screen reservation; never
+                # retry the erase itself, which may already have changed visible output.
+                with contextlib.suppress(Exception):
+                    transaction = (
+                        reserved.lock.transaction("pager cleanup") if reserved is not None else contextlib.nullcontext()
+                    )
+                    with transaction:
+                        self.app.renderer.reset()
+                raise
             finally:
                 restore()
+                handoff.__exit__(*sys.exc_info())
             self.app.renderer.request_absolute_cursor_position()
             self.app.invalidate()
 
@@ -813,6 +832,7 @@ class CommandToolbar:
                 # the full-screen flag and editing mode would carry into the next prompt.
                 if not restored:
                     restore()
+                handoff.__exit__(*sys.exc_info())
         # A reservation abandoned while the pager was open deferred its legacy fallback until
         # the pager closed; now that it has, on the main screen, finish it.
         if self._legacy_fallback_pending and self.thread_is_alive:

--- a/cmd2/command_toolbar.py
+++ b/cmd2/command_toolbar.py
@@ -769,7 +769,7 @@ class CommandToolbar:
             if reserved is not None:
                 # The very first pager layout must see the physical size. Releasing from
                 # enter_alternate_screen during replay is too late: that frame was measured.
-                handoff.enter_context(reserved.suspended())
+                handoff.enter_context(reserved.suspended(defer_band_clear=True))
             self.app.layout = layout
             self.app.key_bindings = pager.bindings
             self.app.editing_mode = EditingMode.EMACS

--- a/cmd2/managed_output.py
+++ b/cmd2/managed_output.py
@@ -63,6 +63,9 @@ class SerializedTerminalWriter:
         """
         with self._lock.transaction("managed write"):
             try:
+                before_write = getattr(self.bridge, "before_managed_write", None)
+                if before_write is not None:
+                    before_write()
                 if self._output is None:
                     written = self._stream.write(data)
                 else:

--- a/cmd2/prompt_toolkit_bridge.py
+++ b/cmd2/prompt_toolkit_bridge.py
@@ -300,6 +300,13 @@ class PromptToolkitBridge:
         """
         self._unfinished_command_output = False
 
+    def before_managed_write(self) -> None:
+        """Remove retained pager-startup cells before output can scroll them into history.
+
+        Called inside the writer's transaction, before emitting any command text.
+        """
+        self._display.clear_deferred_band()
+
     def finish_command_output(self) -> None:
         """Start the next prompt on a fresh line if command output left one unfinished.
 
@@ -831,6 +838,9 @@ class PromptToolkitBridge:
                 self.require_resynchronization("the frame was laid out for a different size")
                 return False
             try:
+                # Preparation may be expensive for a large pager. Its main-screen bar is
+                # retained until this validated batch is ready to replace the screen.
+                self._display.clear_deferred_band()
                 prepared.batch.replay(self._display.output)
                 self._display.output.flush()
             except Exception as error:  # noqa: BLE001 - the terminal's state is now unknown

--- a/cmd2/reserved_output.py
+++ b/cmd2/reserved_output.py
@@ -55,6 +55,7 @@ class ReservedOutput(Output):
         """
         self._wrapped = wrapped
         self._display = display
+        self._alternate_handoff_owned = False
         # A plain attribute rather than a property: Output declares stdout as writable, and
         # code that reaches for the real stream must find the backend's, not a copy of it.
         self.stdout = getattr(wrapped, "stdout", None)
@@ -158,13 +159,17 @@ class ReservedOutput(Output):
         nothing about a reservation. Margins are restored before the switch so the main
         buffer is left in the state the shell expects if the switch is never undone.
         """
-        self._display.release_region_for_handoff()
+        self._alternate_handoff_owned = not self._display.handoff_active
+        if self._alternate_handoff_owned:
+            self._display.release_region_for_handoff()
         self._wrapped.enter_alternate_screen()
 
     def quit_alternate_screen(self) -> None:
         """Return to the main buffer and re-establish the reservation for its geometry."""
         self._wrapped.quit_alternate_screen()
-        self._display.reacquire_region_after_handoff()
+        if self._alternate_handoff_owned:
+            self._alternate_handoff_owned = False
+            self._display.reacquire_region_after_handoff()
 
     def scroll_buffer_to_prompt(self) -> None:
         """Scroll the Windows viewport to the prompt, then re-check the viewport origin.

--- a/cmd2/reserved_toolbar.py
+++ b/cmd2/reserved_toolbar.py
@@ -17,14 +17,18 @@ The toolbar's content is read through a callable rather than captured, so a call
 new ``bottom_toolbar`` to the session still reaches the band.
 """
 
-from contextlib import contextmanager, suppress
+import os
+import signal
+from contextlib import ExitStack, contextmanager, suppress
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Self
 
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.application import run_in_terminal
+from prompt_toolkit.filters import Condition, Never
 from prompt_toolkit.layout import HSplit, Window
 from prompt_toolkit.layout.containers import ConditionalContainer
 from prompt_toolkit.styles import DynamicStyle
+from prompt_toolkit.utils import suspend_to_background_supported
 
 from .prompt_toolkit_bridge import PromptToolkitBridge
 from .reserved_output import ReservedOutput
@@ -107,6 +111,9 @@ class ReservedToolbar:
         self._original_filter: Any = None
         self._installed_filter: Any = None
         self.stopped_handler: Callable[[], None] | None = None
+        self._job_control_stack = ExitStack()
+        self._nested_stacks: list[ExitStack] = []
+        self._nested_bridges: list[PromptToolkitBridge] = []
 
     @property
     def is_active(self) -> bool:
@@ -132,7 +139,7 @@ class ReservedToolbar:
     @property
     def bridge(self) -> PromptToolkitBridge | None:
         """The renderer bridge while active, else ``None``."""
-        return self._bridge
+        return self._nested_bridges[-1] if self._nested_bridges else self._bridge
 
     @property
     def painter(self) -> ToolbarPainter | None:
@@ -195,6 +202,7 @@ class ReservedToolbar:
             # From here the application's own renders go through prepare and commit, which is
             # what puts them in the same queue as command output and toolbar paints.
             self._bridge.bind(app)
+            self._job_control_stack.enter_context(self._job_control(app))
             # When the bridge abandons reserved rendering it cannot resume anything itself:
             # the rows are still withheld and the renderer is still routed through it. Giving
             # them back is this object's job, and it is what lets compatibility rendering
@@ -240,6 +248,94 @@ class ReservedToolbar:
         return error
 
     @contextmanager
+    def _job_control(self, app: Any) -> "Iterator[None]":
+        """Release the physical reservation inside upstream's cooked-mode handoff."""
+        original = app.suspend_to_background
+
+        def suspend_to_background(suspend_group: bool = True) -> None:
+            if not suspend_to_background_supported():
+                return
+
+            def suspend_process() -> None:
+                # run_in_terminal has stopped rendering and detached input before this runs.
+                # A signal callback itself must never acquire the terminal transaction.
+                with self.suspended():
+                    os.kill(0 if suspend_group else os.getpid(), signal.SIGTSTP)
+
+            run_in_terminal(suspend_process)
+
+        app.suspend_to_background = suspend_to_background
+        try:
+            yield
+        finally:
+            if app.suspend_to_background is suspend_to_background:
+                app.suspend_to_background = original
+
+    def can_manage(self, session: "PromptSession[Any]") -> bool:
+        """Whether a temporary prompt uses this terminal and its managed input reader."""
+        return (
+            self._display is not None
+            and not self._display.handoff_active
+            and session.input is self._session.input
+            and session.app.output in (self._bound_output, self._display.terminal.output)
+            and native_toolbar_container(session) is not None
+        )
+
+    @contextmanager
+    def prompt_session(self, session: "PromptSession[Any]") -> "Iterator[None]":
+        """Lend the reservation to a temporary prompt after the command reader has stopped."""
+        if session is self._session:
+            yield
+            return
+        native = native_toolbar_container(session)
+        if native is None:
+            raise RuntimeError("cannot locate the nested session's bottom toolbar window")
+        with self.prompt_application(session.app, native):
+            yield
+
+    @contextmanager
+    def prompt_application(self, app: Any, native: ConditionalContainer | None = None) -> "Iterator[None]":
+        """Bind a managed input application while retaining the physical reservation."""
+        previous_output, previous_renderer_output = app.output, app.renderer.output
+        previous_filter = native.filter if native is not None else Never()
+        output = self._bound_output
+        installed_filter = previous_filter & Condition(lambda: not self.is_active)
+        bridge = PromptToolkitBridge(renderer=app.renderer, display=self.display, lock=self._lock)
+        previous_bridge = self.bridge
+        if previous_bridge is not None:
+            previous_bridge.forget_prompt_anchor()
+            previous_bridge.note_owner_change()
+
+        def restore() -> None:
+            bridge.unbind()
+            if bridge in self._nested_bridges:
+                self._nested_bridges.remove(bridge)
+            if app.output is output:
+                app.output = previous_output
+            if app.renderer.output is output:
+                app.renderer.output = previous_renderer_output
+            if native is not None and native.filter is installed_filter:
+                native.filter = previous_filter
+            if previous_bridge is not None:
+                previous_bridge.forget_prompt_anchor()
+                previous_bridge.require_resynchronization("a nested prompt returned the terminal")
+
+        with ExitStack() as stack:
+            stack.callback(restore)
+            # Abandonment restores the guest immediately, before native rendering resumes.
+            self._nested_stacks.append(stack)
+            stack.callback(self._nested_stacks.remove, stack)
+            app.output = app.renderer.output = output
+            if native is not None:
+                native.filter = installed_filter
+            self._nested_bridges.append(bridge)
+            bridge.bind(app)
+            bridge.set_frame_committed_handler(self.refresh)
+            bridge.set_emission_stopped_handler(self._emission_stopped)
+            stack.enter_context(self._job_control(app))
+            yield
+
+    @contextmanager
     def suspended(self) -> "Iterator[None]":
         """Give the rows back for the duration of the block, and take them again after.
 
@@ -267,8 +363,9 @@ class ReservedToolbar:
             yield
             return
 
-        outermost = self._suspend_depth == 0
+        outermost = self._suspend_depth == 0 and not display.handoff_active
         self._suspend_depth += 1
+        body_failed = False
         try:
             if outermost:
                 with self._lock.transaction("suspend"):
@@ -279,13 +376,25 @@ class ReservedToolbar:
                     # paint over their output.
                     self._invalidate_ownership("the terminal was handed to another program")
             yield
+        except BaseException:
+            body_failed = True
+            raise
         finally:
             self._suspend_depth -= 1
             if outermost:
-                with self._lock.transaction("resume"):
-                    display.reacquire_region_after_handoff()
-                    self._invalidate_ownership("the terminal came back from another program")
-                self.refresh()
+                try:
+                    with self._lock.transaction("resume"):
+                        display.reacquire_region_after_handoff()
+                        self._invalidate_ownership("the terminal came back from another program")
+                    self.refresh()
+                except Exception as error:
+                    self._pending_error = error
+                    with suppress(Exception):
+                        self.stop()
+                    # A failed guest (including Ctrl-C/termination) remains the reason for
+                    # unwinding; cleanup failure is available through take_pending_error().
+                    if not body_failed:
+                        raise
 
     def _invalidate_ownership(self, reason: str) -> None:
         """Discard everything that described the screen before ownership changed.
@@ -298,6 +407,9 @@ class ReservedToolbar:
             self._bridge.forget_prompt_anchor()
             self._bridge.forget_unfinished_command_output()
             self._bridge.require_resynchronization(reason)
+        for bridge in self._nested_bridges:
+            bridge.forget_prompt_anchor()
+            bridge.require_resynchronization(reason)
 
     def refresh(self) -> bool:
         """Evaluate the toolbar's content and paint whatever changed.
@@ -335,8 +447,8 @@ class ReservedToolbar:
         The error the bridge is holding is taken here rather than left with it: the bridge is
         dropped a moment later, and an error the user never sees is the same as none.
         """
-        if self._bridge is not None and self._pending_error is None:
-            self._pending_error = self._bridge.take_pending_error()
+        if self.bridge is not None and self._pending_error is None:
+            self._pending_error = self.bridge.take_pending_error()
         with suppress(Exception):
             self.stop()
 
@@ -357,8 +469,8 @@ class ReservedToolbar:
         """
         self._pending_error = error
         self._consecutive_paint_failures += 1
-        if self._bridge is not None:
-            self._bridge.require_resynchronization("a toolbar paint failed; the cursor's position is unknown")
+        if self.bridge is not None:
+            self.bridge.require_resynchronization("a toolbar paint failed; the cursor's position is unknown")
         if self._consecutive_paint_failures >= _MAX_CONSECUTIVE_PAINT_FAILURES:
             with suppress(Exception):
                 self.stop()
@@ -371,6 +483,9 @@ class ReservedToolbar:
         other.
         """
         display, self._display = self._display, None
+        for stack in reversed(tuple(self._nested_stacks)):
+            stack.close()
+        self._job_control_stack.close()
         if self._bridge is not None:
             self._bridge.unbind()
         self._bridge = None

--- a/cmd2/reserved_toolbar.py
+++ b/cmd2/reserved_toolbar.py
@@ -253,14 +253,15 @@ class ReservedToolbar:
         original = app.suspend_to_background
 
         def suspend_to_background(suspend_group: bool = True) -> None:
-            if not suspend_to_background_supported():
+            suspend_signal = getattr(signal, "SIGTSTP", None)
+            if suspend_signal is None or not suspend_to_background_supported():
                 return
 
             def suspend_process() -> None:
                 # run_in_terminal has stopped rendering and detached input before this runs.
                 # A signal callback itself must never acquire the terminal transaction.
                 with self.suspended():
-                    os.kill(0 if suspend_group else os.getpid(), signal.SIGTSTP)
+                    os.kill(0 if suspend_group else os.getpid(), suspend_signal)
 
             run_in_terminal(suspend_process)
 

--- a/cmd2/reserved_toolbar.py
+++ b/cmd2/reserved_toolbar.py
@@ -336,7 +336,7 @@ class ReservedToolbar:
             yield
 
     @contextmanager
-    def suspended(self) -> "Iterator[None]":
+    def suspended(self, *, defer_band_clear: bool = False) -> "Iterator[None]":
         """Give the rows back for the duration of the block, and take them again after.
 
         A program that inherits the terminal -- a shell command, an editor, an external pager
@@ -357,6 +357,9 @@ class ReservedToolbar:
         says nothing about whose terminal it is: the guest the outer block handed it to still
         has it, and reinstalling margins or painting a band over their screen would be the
         same mistake as never releasing at all.
+
+        :param defer_band_clear: keep the main-screen bar visible during managed pager
+            preparation; external terminal users must retain the default immediate clear.
         """
         display = self._display
         if display is None:
@@ -367,9 +370,12 @@ class ReservedToolbar:
         self._suspend_depth += 1
         body_failed = False
         try:
+            if not defer_band_clear:
+                with self._lock.transaction("clear retained toolbar"):
+                    display.clear_deferred_band()
             if outermost:
                 with self._lock.transaction("suspend"):
-                    display.release_region_for_handoff()
+                    display.release_region_for_handoff(defer_band_clear=defer_band_clear)
                     # Forgotten as the terminal changes hands, not after the guest has
                     # finished with it. From this moment the remembered row describes a screen
                     # someone else is writing on, and anything that rendered against it would

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -347,6 +347,11 @@ class TerminalDisplay:
         return self._geometry is not None
 
     @property
+    def handoff_active(self) -> bool:
+        """Whether another terminal owner holds the screen, even below the height floor."""
+        return self._handoff_active
+
+    @property
     def output(self) -> "Output":
         """The output callers should render through: the adapter while reserved, else the backend."""
         if self._adapter is not None and self._geometry is not None:

--- a/cmd2/terminal_display.py
+++ b/cmd2/terminal_display.py
@@ -330,6 +330,7 @@ class TerminalDisplay:
         self._depth = 0
         self._adapter: Any = None
         self._handoff_active = False
+        self._deferred_band: Geometry | None = None
 
     @property
     def terminal(self) -> PhysicalTerminal:
@@ -433,6 +434,7 @@ class TerminalDisplay:
 
     def _teardown(self) -> None:
         """Restore full-screen margins and drop the adapter."""
+        self.clear_deferred_band()
         self._adapter = None
         self._handoff_active = False
         if self._geometry is None:
@@ -493,7 +495,7 @@ class TerminalDisplay:
             self._adapter = self._make_adapter()
         return True
 
-    def release_region_for_handoff(self) -> None:
+    def release_region_for_handoff(self, *, defer_band_clear: bool = False) -> None:
         """Restore full-screen margins for a program taking the terminal over.
 
         The reservation is remembered rather than dropped: the lease is still held, and
@@ -505,6 +507,9 @@ class TerminalDisplay:
         that had shrunk below the floor is released but still ours, and a guest can take it
         from that state just as readily; tying the record to the geometry snapshot would let
         a later resize reinstall margins over the guest's screen.
+
+        :param defer_band_clear: retain the bar while a managed pager prepares its first
+            frame. The bridge clears it before commit; recovery and teardown clear it too.
         """
         if self._depth == 0:
             return
@@ -512,7 +517,19 @@ class TerminalDisplay:
         if self._geometry is None:
             return
         geometry, self._geometry = self._geometry, None
-        self._terminal.release_region(geometry)
+        if defer_band_clear:
+            # A managed pager can prepare its full-screen frame while the old bar remains
+            # visible. Clear it only when that frame is ready to replace the main screen.
+            self._deferred_band = geometry
+            self._terminal.release_region()
+        else:
+            self._terminal.release_region(geometry)
+
+    def clear_deferred_band(self) -> None:
+        """Clear a pager's retained main-screen bar before emission, recovery, or shutdown."""
+        geometry, self._deferred_band = self._deferred_band, None
+        if geometry is not None:
+            self._terminal.release_region(geometry)
 
     def reacquire_region_after_handoff(self) -> None:
         """Re-establish the reservation after a program hands the terminal back.
@@ -523,6 +540,7 @@ class TerminalDisplay:
         """
         if not self._handoff_active or self._depth == 0:
             return
+        self.clear_deferred_band()
         self._handoff_active = False
         # Coming back is an ordinary reconfiguration, so it goes through the one path that
         # does the whole job: re-check backend capability, measure, install only if the

--- a/cmd2/toolbar_painter.py
+++ b/cmd2/toolbar_painter.py
@@ -355,7 +355,7 @@ class ToolbarPainter:
         self._autowrap_after_paint = autowrap_after_paint
         self._last_frame: ToolbarFrame | None = None
         self._last_attrs: Mapping[str, Attrs] | None = None
-        self._last_band: tuple[int, int, int, object] | None = None
+        self._last_band: tuple[int, int, int, object, int] | None = None
         self._pending_error: BaseException | None = None
 
     @property
@@ -438,7 +438,16 @@ class ToolbarPainter:
                 return False
 
             frame = prepared.frame
-            band = (geometry.physical_rows, geometry.columns, geometry.reserved_rows, geometry.buffer_id)
+            # Identical coordinates do not imply retained cells. A shrink below the
+            # reservation floor can erase the band, then growth can reacquire exactly
+            # the same dimensions and viewport. The new generation needs a full paint.
+            band = (
+                geometry.physical_rows,
+                geometry.columns,
+                geometry.reserved_rows,
+                geometry.buffer_id,
+                geometry.generation,
+            )
             previous = self._last_frame if band == self._last_band else None
             previous_attrs = self._last_attrs if previous is not None else None
             runs = _changed_runs(previous, previous_attrs, frame, prepared.attrs)

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -573,7 +573,11 @@ class ProcReader:
             # the whole process group to make sure it propagates further than the shell
             try:
                 group_id = os.getpgid(self._proc.pid)
-                os.killpg(group_id, signal.SIGINT)
+                # Terminal-attached pipelines share our foreground group and already
+                # received the keyboard signal. Forwarding to it would invoke cmd2's
+                # handler recursively. Captured pipelines still need forwarding.
+                if group_id != os.getpgrp():
+                    os.killpg(group_id, signal.SIGINT)
             except ProcessLookupError:
                 return
 

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -13,6 +13,7 @@ import threading
 from collections.abc import (
     Callable,
     Iterable,
+    Iterator,
     MutableSequence,
 )
 from difflib import SequenceMatcher
@@ -539,16 +540,33 @@ class ProcReader:
     If neither are pipes, then the process will run normally and no output will be captured.
     """
 
-    def __init__(self, proc: PopenTextIO, stdout: StdSim | TextIO, stderr: StdSim | TextIO) -> None:
+    def __init__(
+        self, proc: PopenTextIO, stdout: StdSim | TextIO, stderr: StdSim | TextIO, *, terminal_fd: int | None = None
+    ) -> None:
         """ProcReader initializer.
 
         :param proc: the Popen process being read from
         :param stdout: the stream to write captured stdout
         :param stderr: the stream to write captured stderr.
+        :param terminal_fd: controlling terminal to lend to a POSIX process in its own group
         """
         self._proc = proc
         self._stdout = stdout
         self._stderr = stderr
+        self._terminal_fd = terminal_fd
+        self._process_done = threading.Event()
+        self._sigint_forwarded = False
+        self._terminal_available = threading.Event()
+        self._terminal_available.set()
+        if terminal_fd is not None:
+            import signal
+
+            self._original_group = os.tcgetpgrp(terminal_fd)
+            self._set_foreground_group(terminal_fd, proc.pid)
+            # The child may have tried to read before we could give it the terminal.
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGCONT)
+            threading.Thread(name="pipe_job", target=self._wait_for_job, args=(terminal_fd,), daemon=True).start()
 
         self._out_thread = threading.Thread(name="out_thread", target=self._reader_thread_func, kwargs={"read_stdout": True})
 
@@ -573,26 +591,114 @@ class ProcReader:
             # the whole process group to make sure it propagates further than the shell
             try:
                 group_id = os.getpgid(self._proc.pid)
-                if group_id == os.getpgrp():
-                    # A process-directed SIGINT may not have reached the pipeline.
-                    # Ignore our own forwarded signal to avoid recursive handling,
-                    # then restore the handler even if the group has exited.
-                    original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-                    try:
-                        os.killpg(group_id, signal.SIGINT)
-                    finally:
-                        signal.signal(signal.SIGINT, original_handler)
-                else:
+                # Pipelines have their own group. Never re-signal our own group:
+                # other ProcReader callers may share it and already received Ctrl-C.
+                if group_id != os.getpgrp():
+                    self._sigint_forwarded = True
                     os.killpg(group_id, signal.SIGINT)
             except ProcessLookupError:
                 return
 
     def terminate(self) -> None:
         """Terminate the process."""
-        self._proc.terminate()
+        if self._terminal_fd is None:
+            self._proc.terminate()
+        else:
+            import signal
+
+            # Popen.terminate() polls first, which would compete with our waitpid thread.
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(self._proc.pid, signal.SIGTERM)
+
+    @staticmethod
+    def _set_foreground_group(terminal_fd: int, group_id: int) -> None:
+        """Transfer the terminal without stopping this background thread with SIGTTOU."""
+        import signal
+
+        previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGTTOU})
+        try:
+            os.tcsetpgrp(terminal_fd, group_id)
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    @contextlib.contextmanager
+    def borrow_terminal(self) -> Iterator[None]:
+        """Let an input prompt or shell command in cmd2 temporarily use the pipeline's terminal."""
+        terminal_fd = self._terminal_fd
+        if terminal_fd is None or os.tcgetpgrp(terminal_fd) != self._proc.pid:
+            yield
+            return
+        self._terminal_available.clear()
+        try:
+            self._set_foreground_group(terminal_fd, self._original_group)
+            yield
+        finally:
+            try:
+                if self._proc.returncode is None:
+                    self._set_foreground_group(terminal_fd, self._proc.pid)
+            finally:
+                self._terminal_available.set()
+
+    def _wait_for_job(self, terminal_fd: int) -> None:
+        """Reap a foreground pipeline and relay its stops to the outer shell's job.
+
+        This is the only waitpid caller for a terminal pipeline. Watching on a separate
+        thread also catches Ctrl-Z while the command is blocked writing to its pipe.
+        """
+        import signal
+
+        try:
+            while True:
+                _, status = os.waitpid(self._proc.pid, os.WUNTRACED)
+                if not os.WIFSTOPPED(status):
+                    self._proc.returncode = os.waitstatus_to_exitcode(status)
+                    return
+                if os.WSTOPSIG(status) in (signal.SIGTTIN, signal.SIGTTOU):
+                    # A cmd2 prompt can borrow the terminal while the producer runs.
+                    # Defer the pipeline's terminal reads until that prompt returns.
+                    self._terminal_available.wait()
+                    if os.tcgetpgrp(terminal_fd) == self._proc.pid:
+                        # This also handles a pending stop from the startup handoff.
+                        os.killpg(self._proc.pid, signal.SIGCONT)
+                        continue
+
+                if os.tcgetpgrp(terminal_fd) == self._proc.pid:
+                    self._set_foreground_group(terminal_fd, self._original_group)
+                # Stop every terminal reader before returning control to the outer shell.
+                os.killpg(self._proc.pid, signal.SIGSTOP)
+                os.killpg(os.getpgrp(), signal.SIGSTOP)
+                # Execution resumes here when the outer shell continues cmd2. A `bg`
+                # must not steal the terminal from that shell.
+                if os.tcgetpgrp(terminal_fd) == self._original_group:
+                    self._set_foreground_group(terminal_fd, self._proc.pid)
+                os.killpg(self._proc.pid, signal.SIGCONT)
+        finally:
+            try:
+                if os.tcgetpgrp(terminal_fd) == self._proc.pid:
+                    self._set_foreground_group(terminal_fd, self._original_group)
+                if self._proc.returncode in (-signal.SIGINT, 128 + signal.SIGINT) and not self._sigint_forwarded:
+                    # Ctrl-C killed the consumer. Interrupt a command still producing
+                    # output (or sleeping) too. The consumer has been reaped, so the
+                    # main thread's handler cannot forward this signal back to it.
+                    os.kill(os.getpid(), signal.SIGINT)
+            finally:
+                self._process_done.set()
+
+    def wait_for_exit(self, timeout: float | None = None) -> None:
+        """Wait for process exit without competing with the terminal job's waitpid thread.
+
+        :param timeout: maximum seconds to wait, or None to wait indefinitely
+        :raises subprocess.TimeoutExpired: if the process is still running after timeout
+        """
+        if self._terminal_fd is None:
+            self._proc.wait(timeout)
+        elif not self._process_done.wait(timeout) and timeout is not None:
+            raise subprocess.TimeoutExpired(self._proc.args, timeout)
 
     def wait(self) -> None:
         """Wait for the process to finish."""
+        if self._terminal_fd is not None:
+            self.wait_for_exit()
         if self._out_thread.is_alive():
             self._out_thread.join()
         if self._err_thread.is_alive():
@@ -624,7 +730,7 @@ class ProcReader:
             raise ValueError("read_stream is None")
 
         # Run until process completes
-        while self._proc.poll() is None:
+        while (self._proc.poll() if self._terminal_fd is None else self._proc.returncode) is None:
             available = read_stream.peek()  # type: ignore[attr-defined, ty:unresolved-attribute]
             if available:
                 read_stream.read(len(available))

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -666,7 +666,10 @@ class ProcReader:
                     self._set_foreground_group(terminal_fd, self._original_group)
                 # Stop every terminal reader before returning control to the outer shell.
                 os.killpg(self._proc.pid, signal.SIGSTOP)
-                os.killpg(os.getpgrp(), signal.SIGSTOP)
+                # Target this thread so the whole process stops before this call returns.
+                # killpg can deliver SIGSTOP to another thread on Linux, allowing this
+                # worker to run ahead and resume the pipeline before cmd2 has stopped.
+                signal.raise_signal(signal.SIGSTOP)
                 # Execution resumes here when the outer shell continues cmd2. A `bg`
                 # must not steal the terminal from that shell.
                 if os.tcgetpgrp(terminal_fd) == self._original_group:
@@ -692,7 +695,13 @@ class ProcReader:
         """
         if self._terminal_fd is None:
             self._proc.wait(timeout)
-        elif not self._process_done.wait(timeout) and timeout is not None:
+        elif timeout is None:
+            # A process-directed signal may reach a worker thread. Python still runs
+            # its handler on the main thread, so periodically return from the wait
+            # to dispatch it even when the main thread's system call was not interrupted.
+            while not self._process_done.wait(0.1):
+                pass
+        elif not self._process_done.wait(timeout):
             raise subprocess.TimeoutExpired(self._proc.args, timeout)
 
     def wait(self) -> None:

--- a/cmd2/utils.py
+++ b/cmd2/utils.py
@@ -573,10 +573,16 @@ class ProcReader:
             # the whole process group to make sure it propagates further than the shell
             try:
                 group_id = os.getpgid(self._proc.pid)
-                # Terminal-attached pipelines share our foreground group and already
-                # received the keyboard signal. Forwarding to it would invoke cmd2's
-                # handler recursively. Captured pipelines still need forwarding.
-                if group_id != os.getpgrp():
+                if group_id == os.getpgrp():
+                    # A process-directed SIGINT may not have reached the pipeline.
+                    # Ignore our own forwarded signal to avoid recursive handling,
+                    # then restore the handler even if the group has exited.
+                    original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+                    try:
+                        os.killpg(group_id, signal.SIGINT)
+                    finally:
+                        signal.signal(signal.SIGINT, original_handler)
+                else:
                     os.killpg(group_id, signal.SIGINT)
             except ProcessLookupError:
                 return

--- a/examples/getting_started.py
+++ b/examples/getting_started.py
@@ -60,6 +60,7 @@ class BasicApp(cmd2.Cmd):
             bottom_toolbar_mode=cmd2.ToolbarMode.AUTO,
             enable_rprompt=True,
             include_ipy=True,
+            include_py=True,
             persistent_history_file="cmd2_history.dat",
             refresh_interval=0.5,  # refresh the UI twice a second to keep the bottom toolbar timestamp current
             shortcuts=shortcuts,

--- a/examples/scripts/raise_exception.py
+++ b/examples/scripts/raise_exception.py
@@ -1,0 +1,1 @@
+raise ValueError("An example exception")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ warn_unused_ignores = false
 testpaths = ["tests"]
 addopts = [
     "-n=auto",
+    # Spread slow terminal cases across workers instead of queuing them in one batch.
+    "--maxschedchunk=1",
     "--cov=cmd2",
     "--cov-config=pyproject.toml",
     "--cov-report=xml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ addopts = [
 ]
 
 [tool.coverage.run]
+# Include the cmd2 applications launched by the terminal integration tests.
+patch = ["subprocess"]
 # Use sys.monitoring on Python 3.12+; coverage falls back with a warning on 3.11.
 core = "sysmon"
 source = ["cmd2"]

--- a/tests/test_cmd2.py
+++ b/tests/test_cmd2.py
@@ -865,7 +865,11 @@ def test_pipe_to_shell_and_redirect(redirection_app, running_pipe_process) -> No
     os.remove(filename)
 
 
-def test_pipe_to_shell_error(redirection_app, mocker, capsys) -> None:
+@pytest.mark.parametrize(
+    "terminal",
+    [False, pytest.param(True, marks=pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal job control"))],
+)
+def test_pipe_to_shell_error(redirection_app, mocker, capsys, terminal) -> None:
     """An already-exited pipe process must be reported before the command runs.
 
     A real nonexistent command may take longer than the startup probe under load.
@@ -876,12 +880,35 @@ def test_pipe_to_shell_error(redirection_app, mocker, capsys) -> None:
     process = popen.return_value
     process.returncode = 127
     process.wait.return_value = 127
+    if terminal:
+        target = mocker.Mock()
+        target.isatty.return_value = True
+        target.fileno.return_value = 10
+        mocker.patch("cmd2.command_toolbar.pipe_target", return_value=target)
+        mocker.patch("os.tcgetpgrp", return_value=os.getpgrp())
+        sigmask = mocker.patch("signal.pthread_sigmask", return_value=set())
+        reader = mocker.patch("cmd2.utils.ProcReader").return_value
 
-    out, err = run_cmd(redirection_app, "print_output | foobarbaz.this_does_not_exist")
+    if terminal:
+        # run_cmd captures stderr in a StdSim, which deliberately disables terminal handoff.
+        redirection_app.onecmd_plus_hooks("print_output | foobarbaz.this_does_not_exist")
+        out, error_text = capsys.readouterr()
+        err = error_text.splitlines()
+    else:
+        out, err = run_cmd(redirection_app, "print_output | foobarbaz.this_does_not_exist")
     assert not out
     assert "Pipe process exited with code 127 before command could run" in " ".join(err)
     assert capsys.readouterr().out == ""
-    process.wait.assert_called_once()
+    if terminal:
+        reader.wait_for_exit.assert_called_once_with(0.2)
+        reader.wait.assert_called_once_with()
+        process.wait.assert_not_called()
+        assert sigmask.call_args_list == [
+            mock.call(signal.SIG_BLOCK, {signal.SIGTTOU}),
+            mock.call(signal.SIG_SETMASK, set()),
+        ]
+    else:
+        process.wait.assert_called_once()
     assert popen.call_args.kwargs["stdin"].closed
 
 

--- a/tests/test_command_toolbar.py
+++ b/tests/test_command_toolbar.py
@@ -1,6 +1,7 @@
 """Command toolbar lifecycle and terminal integration tests."""
 
 import contextlib
+import subprocess
 import sys
 import threading
 import time
@@ -117,6 +118,22 @@ class FileTerminal:
 
     def __getattr__(self, name):
         return getattr(self.file, name)
+
+
+@pytest.mark.parametrize(("stdout_tty", "stderr_tty"), [(False, False), (True, False), (False, True), (True, True)])
+def test_pipeline_process_group_selection(toolbar_app, tmp_path, monkeypatch, running_pipe_process, stdout_tty, stderr_tty):
+    app, _, _ = toolbar_app
+    with (tmp_path / "stdout").open("w+") as out, (tmp_path / "stderr").open("w+") as err:
+        app.stdout = FileTerminal(out) if stdout_tty else out
+        monkeypatch.setattr(sys, "stderr", FileTerminal(err) if stderr_tty else err)
+        with mock.patch("subprocess.Popen", wraps=subprocess.Popen) as popen:
+            app.onecmd_plus_hooks(f'help | "{sys.executable}" -S -c "import sys; print(sys.stdin.read())"')
+        options = popen.call_args.kwargs
+        if sys.platform == "win32":
+            assert options["creationflags"] == subprocess.CREATE_NEW_PROCESS_GROUP
+            assert "start_new_session" not in options
+        else:
+            assert options["start_new_session"] == (not (stdout_tty or stderr_tty))
 
 
 @pytest.mark.parametrize("builtin_pager", [False, True])

--- a/tests/test_command_toolbar.py
+++ b/tests/test_command_toolbar.py
@@ -133,7 +133,10 @@ def test_pipeline_process_group_selection(toolbar_app, tmp_path, monkeypatch, ru
             assert options["creationflags"] == subprocess.CREATE_NEW_PROCESS_GROUP
             assert "start_new_session" not in options
         else:
-            assert options["start_new_session"] == (not (stdout_tty or stderr_tty))
+            # A stream claiming isatty() is insufficient: these files do not
+            # refer to our controlling terminal, so no foreground handoff is safe.
+            assert options["start_new_session"]
+            assert "process_group" not in options
 
 
 @pytest.mark.parametrize("builtin_pager", [False, True])

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -98,6 +98,19 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
                 return
         pytest.fail(f"terminal condition timed out:\n{transcript}")
 
+    def stopped(*pids: int) -> bool:
+        """Whether every process is stopped, not merely deprived of the terminal.
+
+        The shell takes the terminal back as soon as its child stops, but a grandchild still
+        blocked in a one-byte terminal read is woken by the stop signal and, if a keystroke
+        has arrived by then, consumes it before it stops. Typing has to wait for the whole job.
+        """
+        listing = subprocess.run(
+            ["ps", "-o", "stat=", "-p", ",".join(map(str, pids))], capture_output=True, text=True, check=False
+        )
+        states = listing.stdout.split()
+        return len(states) == len(pids) and all(state.startswith("T") for state in states)
+
     job_group = None
     try:
         wait_until(lambda: "OUTER> " in transcript)
@@ -107,9 +120,11 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         send(f"help -v | {shlex.quote(sys.executable)} {shlex.quote(str(pager))}\n")
         # Whole lines only: a traceback naming the marker must not satisfy the wait.
         wait_until(lambda: "PAGER_READY\r\n" in transcript)
+        pager_process = int(pager_pid.read_text())
         for rows in (12, 24):
             send("\x1a")
             wait_until(lambda: os.tcgetpgrp(master) == process.pid)
+            wait_until(lambda: stopped(job_group, pager_process))
             start = len(transcript)
             # A child left running can steal these keystrokes from the shell.
             send("printf 'SHELL_%s\\n' OWNS_INPUT\n")

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -19,9 +19,17 @@ import pytest
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX job control")
 
 
-@pytest.mark.parametrize("finish", ["q", "\x03", "process_sigint", "group_sigint", "exit_sigint", "read_input", "shell_input"])
-@pytest.mark.parametrize("stop_job", [False, True])
-@pytest.mark.parametrize("shell_child", [False, True])
+@pytest.mark.parametrize(
+    ("finish", "stop_job", "shell_child"),
+    [
+        pytest.param("interrupts", True, False, id="direct-signals-and-job-control"),
+        pytest.param("interrupts", True, True, id="shell-signals-and-job-control"),
+        pytest.param("exit_sigint", False, False, id="interrupt-busy-producer"),
+        pytest.param("exit_sigint", True, True, id="stop-and-interrupt-busy-producer"),
+        pytest.param("read_input", False, False, id="nested-prompt"),
+        pytest.param("shell_input", False, True, id="shell-input"),
+    ],
+)
 def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_job, shell_child) -> None:
     import fcntl
     import pty
@@ -65,9 +73,12 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
         encoding="utf-8",
     )
     application = tmp_path / "application.py"
+    application_pid = tmp_path / "application.pid"
+    interrupt_request = tmp_path / "interrupt.request"
     application.write_text(
         "from cmd2 import Cmd, ToolbarMode\n"
-        "import os, time\n"
+        "import os, pathlib, signal, threading, time\n"
+        f"pathlib.Path({str(application_pid)!r}).write_text(str(os.getpid()))\n"
         "class App(Cmd):\n"
         "    def do_busy(self, statement):\n"
         "        os.write(2, b'BUSY_READY\\n')\n"
@@ -77,6 +88,17 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
         "app = App(bottom_toolbar_mode=ToolbarMode.RESERVED)\n"
         "app.prompt = 'TEST> '\n"
         "app.main_session.bottom_toolbar = 'STATUS'\n"
+        f"if {finish == 'interrupts'!r}:\n"
+        "    def interrupt_from_worker():\n"
+        f"        request = pathlib.Path({str(interrupt_request)!r})\n"
+        "        for _ in range(2):\n"
+        "            while not request.exists():\n"
+        "                time.sleep(0.01)\n"
+        "            request.unlink()\n"
+        # A process-directed signal can be delivered to any unblocked thread.
+        # Force that case so an indefinite main-thread wait cannot pass by luck.
+        "            signal.pthread_kill(threading.get_ident(), signal.SIGINT)\n"
+        "    threading.Thread(target=interrupt_from_worker, daemon=True).start()\n"
         "app.cmdloop()\n",
         encoding="utf-8",
     )
@@ -137,7 +159,13 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
         wait_until(lambda: "OUTER> " in transcript)
         send(f"{shlex.quote(sys.executable)} {shlex.quote(str(application))}\n")
         wait_until(lambda: screen.display[-1].startswith("STATUS"))
-        job_group = os.tcgetpgrp(master)
+        # A foreground-group query is an observation, not the child's identity.
+        # It can change during startup and handoffs. Never use an unverified
+        # foreground query as a kill()/killpg() destination.
+        job_group = int(application_pid.read_text())
+        assert job_group > 1
+        assert os.getpgid(job_group) == job_group
+        wait_until(lambda: os.tcgetpgrp(master) == job_group)
         command = "busy" if finish == "exit_sigint" else "help -v"
         if finish == "read_input":
             command = "ask"
@@ -159,7 +187,9 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
         if finish == "exit_sigint":
             wait_until(lambda: "BUSY_READY\r\n" in transcript)
         pager_process = int(pager_pid.read_text())
-        pipeline_group = os.tcgetpgrp(master)
+        pipeline_group = os.getpgid(pager_process)
+        assert pipeline_group > 1
+        assert pipeline_group != job_group
         for rows in (12, 24) if stop_job else ():
             send("\x1a")
             wait_until(lambda: os.tcgetpgrp(master) == process.pid)
@@ -181,15 +211,20 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
             assert os.tcgetpgrp(master) == pipeline_group
         if finish == "exit_sigint":
             send("\x03")
-        elif finish in ("\x03", "process_sigint", "group_sigint"):
-            for expected_count in (1, 2):
-                if finish == "process_sigint":
+        elif finish == "interrupts":
+            # Exercise every signal route on this live pipeline, avoiding a fresh
+            # interpreter and terminal setup for each overlapping matrix combination.
+            sources = ("terminal", "terminal", "process", "process", "thread", "thread", "group", "group")
+            for expected_count, source in enumerate(sources, start=1):
+                if source == "process":
                     # Signal cmd2 alone, as with `kill -INT <cmd2-pid>`.
                     os.kill(job_group, signal.SIGINT)
-                elif finish == "group_sigint":
+                elif source == "thread":
+                    interrupt_request.touch()
+                elif source == "group":
                     os.killpg(pipeline_group, signal.SIGINT)
                 else:
-                    send(finish)
+                    send("\x03")
                 wait_until(lambda count=expected_count: transcript.count("PAGER_INTERRUPT\r\n") >= count)
                 # Keep the handler alive long enough to observe a duplicate delivery,
                 # then also check that a second real interrupt is not suppressed.
@@ -215,6 +250,8 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_jo
         if pipeline_group is not None:
             with contextlib.suppress(ProcessLookupError):
                 os.killpg(pipeline_group, signal.SIGKILL)
+        # Release the PTY before reaping its session leader. On macOS, waiting
+        # while the master is still open can leave terminal teardown blocked.
+        os.close(master)
         process.kill()
         process.wait(timeout=5)
-        os.close(master)

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -19,8 +19,10 @@ import pytest
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX job control")
 
 
-@pytest.mark.parametrize("finish", ["q", "\x03", "process_sigint"])
-def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None:
+@pytest.mark.parametrize("finish", ["q", "\x03", "process_sigint", "group_sigint", "exit_sigint", "read_input", "shell_input"])
+@pytest.mark.parametrize("stop_job", [False, True])
+@pytest.mark.parametrize("shell_child", [False, True])
+def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish, stop_job, shell_child) -> None:
     import fcntl
     import pty
     import struct
@@ -31,10 +33,11 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         pytest.skip("requires an interactive bash shell")
     pager = tmp_path / "pager.py"
     pager_pid = tmp_path / "pager.pid"
+    interrupts = tmp_path / "interrupts"
     pager.write_text(
         "import os, pathlib, signal, sys, termios, tty\n"
         f"pathlib.Path({str(pager_pid)!r}).write_text(str(os.getpid()))\n"
-        "sys.stdin.read()\n"
+        f"if {finish != 'exit_sigint'!r}: sys.stdin.read()\n"
         # Like less, use an inherited terminal descriptor for keyboard input when
         # stdin is a pipe. This also works in the broken detached-session case.
         "with os.fdopen(os.dup(sys.stderr.fileno()), 'rb', buffering=0) as terminal:\n"
@@ -46,6 +49,12 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         "        tty.setcbreak(terminal)\n"
         "        os.write(1, b'PAGER_RESUMED\\n')\n"
         "    signal.signal(signal.SIGCONT, resume)\n"
+        "    def interrupt(*args):\n"
+        f"        fd = os.open({str(interrupts)!r}, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)\n"
+        "        os.write(fd, b'I')\n"
+        "        os.close(fd)\n"
+        "        os.write(1, b'PAGER_INTERRUPT\\n')\n"
+        f"    signal.signal(signal.SIGINT, {'signal.SIG_DFL' if finish == 'exit_sigint' else 'interrupt'})\n"
         "    try:\n"
         "        tty.setcbreak(terminal)\n"
         "        os.write(1, b'PAGER_READY\\n')\n"
@@ -58,7 +67,14 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
     application = tmp_path / "application.py"
     application.write_text(
         "from cmd2 import Cmd, ToolbarMode\n"
-        "app = Cmd(bottom_toolbar_mode=ToolbarMode.RESERVED)\n"
+        "import os, time\n"
+        "class App(Cmd):\n"
+        "    def do_busy(self, statement):\n"
+        "        os.write(2, b'BUSY_READY\\n')\n"
+        "        time.sleep(30)\n"
+        "    def do_ask(self, statement):\n"
+        "        self.poutput(self.read_input('INPUT> '))\n"
+        "app = App(bottom_toolbar_mode=ToolbarMode.RESERVED)\n"
         "app.prompt = 'TEST> '\n"
         "app.main_session.bottom_toolbar = 'STATUS'\n"
         "app.cmdloop()\n",
@@ -66,6 +82,10 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
     )
     master, slave = pty.openpty()
     fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+    if finish == "exit_sigint":
+        settings = termios.tcgetattr(slave)
+        settings[3] |= termios.TOSTOP
+        termios.tcsetattr(slave, termios.TCSANOW, settings)
     # Establish a controlling terminal in a fresh interpreter, avoiding preexec_fn
     # (unsafe when pytest or its plugins have started threads).
     bootstrap = (
@@ -112,16 +132,35 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         return len(states) == len(pids) and all(state.startswith("T") for state in states)
 
     job_group = None
+    pipeline_group = None
     try:
         wait_until(lambda: "OUTER> " in transcript)
         send(f"{shlex.quote(sys.executable)} {shlex.quote(str(application))}\n")
         wait_until(lambda: screen.display[-1].startswith("STATUS"))
         job_group = os.tcgetpgrp(master)
-        send(f"help -v | {shlex.quote(sys.executable)} {shlex.quote(str(pager))}\n")
+        command = "busy" if finish == "exit_sigint" else "help -v"
+        if finish == "read_input":
+            command = "ask"
+        elif finish == "shell_input":
+            input_script = tmp_path / "input.py"
+            input_script.write_text("import os\nos.write(2, b'INPUT> ')\ninput()\n", encoding="utf-8")
+            command = f"shell {shlex.quote(sys.executable)} {shlex.quote(str(input_script))}"
+        pipe_command = f"{shlex.quote(sys.executable)} {shlex.quote(str(pager))}"
+        if shell_child:
+            # Keep a shell between Popen and the terminal reader, rather than allowing
+            # the final command to replace it with exec.
+            pipe_command = f"{shlex.quote(shell)} -c {shlex.quote(pipe_command + '; :')}"
+        send(f"{command} | {pipe_command}\n")
+        if finish in ("read_input", "shell_input"):
+            wait_until(lambda: any(line.startswith("INPUT>") for line in screen.display))
+            send("answer\n")
         # Whole lines only: a traceback naming the marker must not satisfy the wait.
         wait_until(lambda: "PAGER_READY\r\n" in transcript)
+        if finish == "exit_sigint":
+            wait_until(lambda: "BUSY_READY\r\n" in transcript)
         pager_process = int(pager_pid.read_text())
-        for rows in (12, 24):
+        pipeline_group = os.tcgetpgrp(master)
+        for rows in (12, 24) if stop_job else ():
             send("\x1a")
             wait_until(lambda: os.tcgetpgrp(master) == process.pid)
             wait_until(lambda: stopped(job_group, pager_process))
@@ -139,13 +178,26 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
             start = len(transcript)
             send("fg\n")
             wait_until(lambda start=start: "PAGER_RESUMED\r\n" in transcript[start:])
-            assert os.tcgetpgrp(master) == job_group
-        if finish == "process_sigint":
-            # Signal cmd2 alone, as with `kill -INT <cmd2-pid>`. Its pipeline
-            # shares the terminal group but must receive a forwarded SIGINT.
-            os.kill(job_group, signal.SIGINT)
-        else:
-            send(finish)
+            assert os.tcgetpgrp(master) == pipeline_group
+        if finish == "exit_sigint":
+            send("\x03")
+        elif finish in ("\x03", "process_sigint", "group_sigint"):
+            for expected_count in (1, 2):
+                if finish == "process_sigint":
+                    # Signal cmd2 alone, as with `kill -INT <cmd2-pid>`.
+                    os.kill(job_group, signal.SIGINT)
+                elif finish == "group_sigint":
+                    os.killpg(pipeline_group, signal.SIGINT)
+                else:
+                    send(finish)
+                wait_until(lambda count=expected_count: transcript.count("PAGER_INTERRUPT\r\n") >= count)
+                # Keep the handler alive long enough to observe a duplicate delivery,
+                # then also check that a second real interrupt is not suppressed.
+                deadline = time.monotonic() + 0.1
+                wait_until(lambda deadline=deadline: time.monotonic() >= deadline)
+                assert interrupts.read_text() == "I" * expected_count
+        if finish != "exit_sigint":
+            send("q")
         wait_until(lambda: screen.display[-1].startswith("STATUS") and "TEST>" in "\n".join(screen.display))
         start = len(transcript)
         send("help quit\n")
@@ -160,6 +212,9 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         if job_group is not None:
             with contextlib.suppress(ProcessLookupError):
                 os.killpg(job_group, signal.SIGKILL)
+        if pipeline_group is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(pipeline_group, signal.SIGKILL)
         process.kill()
         process.wait(timeout=5)
         os.close(master)

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -39,13 +39,16 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         # stdin is a pipe. This also works in the broken detached-session case.
         "with os.fdopen(os.dup(sys.stderr.fileno()), 'rb', buffering=0) as terminal:\n"
         "    saved = termios.tcgetattr(terminal)\n"
+        # os.write rather than print: a signal handler that uses buffered stdout raises
+        # "reentrant call inside <_io.BufferedWriter>" when the signal lands mid-write,
+        # which happens when the job is stopped while still reporting readiness.
         "    def resume(*args):\n"
         "        tty.setcbreak(terminal)\n"
-        "        print('PAGER_RESUMED', flush=True)\n"
+        "        os.write(1, b'PAGER_RESUMED\\n')\n"
         "    signal.signal(signal.SIGCONT, resume)\n"
         "    try:\n"
         "        tty.setcbreak(terminal)\n"
-        "        print('PAGER_READY', flush=True)\n"
+        "        os.write(1, b'PAGER_READY\\n')\n"
         "        while os.read(terminal.fileno(), 1) != b'q':\n"
         "            pass\n"
         "    finally:\n"
@@ -102,7 +105,8 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
         wait_until(lambda: screen.display[-1].startswith("STATUS"))
         job_group = os.tcgetpgrp(master)
         send(f"help -v | {shlex.quote(sys.executable)} {shlex.quote(str(pager))}\n")
-        wait_until(lambda: "PAGER_READY" in transcript)
+        # Whole lines only: a traceback naming the marker must not satisfy the wait.
+        wait_until(lambda: "PAGER_READY\r\n" in transcript)
         for rows in (12, 24):
             send("\x1a")
             wait_until(lambda: os.tcgetpgrp(master) == process.pid)
@@ -119,7 +123,7 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
             wait_until(lambda start=start, rows=rows: re.search(rf"[\r\n]{rows} 80\r\n", transcript[start:]) is not None)
             start = len(transcript)
             send("fg\n")
-            wait_until(lambda start=start: "PAGER_RESUMED" in transcript[start:])
+            wait_until(lambda start=start: "PAGER_RESUMED\r\n" in transcript[start:])
             assert os.tcgetpgrp(master) == job_group
         send(finish)
         wait_until(lambda: screen.display[-1].startswith("STATUS") and "TEST>" in "\n".join(screen.display))

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -19,7 +19,7 @@ import pytest
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX job control")
 
 
-@pytest.mark.parametrize("finish", ["q", "\x03"])
+@pytest.mark.parametrize("finish", ["q", "\x03", "process_sigint"])
 def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None:
     import fcntl
     import pty
@@ -140,7 +140,12 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
             send("fg\n")
             wait_until(lambda start=start: "PAGER_RESUMED\r\n" in transcript[start:])
             assert os.tcgetpgrp(master) == job_group
-        send(finish)
+        if finish == "process_sigint":
+            # Signal cmd2 alone, as with `kill -INT <cmd2-pid>`. Its pipeline
+            # shares the terminal group but must receive a forwarded SIGINT.
+            os.kill(job_group, signal.SIGINT)
+        else:
+            send(finish)
         wait_until(lambda: screen.display[-1].startswith("STATUS") and "TEST>" in "\n".join(screen.display))
         start = len(transcript)
         send("help quit\n")

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -1,0 +1,138 @@
+"""Exercise pipeline job control through a real controlling terminal and outer shell."""
+
+import codecs
+import contextlib
+import os
+import select
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pyte
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX job control")
+
+
+@pytest.mark.parametrize("finish", ["q", "\x03"])
+def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None:
+    import fcntl
+    import pty
+    import struct
+    import termios
+
+    shell = shutil.which("bash")
+    if shell is None:
+        pytest.skip("requires an interactive bash shell")
+    pager = tmp_path / "pager.py"
+    pager_pid = tmp_path / "pager.pid"
+    pager.write_text(
+        "import os, pathlib, signal, sys, termios, tty\n"
+        f"pathlib.Path({str(pager_pid)!r}).write_text(str(os.getpid()))\n"
+        "sys.stdin.read()\n"
+        # Like less, use an inherited terminal descriptor for keyboard input when
+        # stdin is a pipe. This also works in the broken detached-session case.
+        "with os.fdopen(os.dup(sys.stderr.fileno()), 'rb', buffering=0) as terminal:\n"
+        "    saved = termios.tcgetattr(terminal)\n"
+        "    def resume(*args):\n"
+        "        tty.setcbreak(terminal)\n"
+        "        print('PAGER_RESUMED', flush=True)\n"
+        "    signal.signal(signal.SIGCONT, resume)\n"
+        "    try:\n"
+        "        tty.setcbreak(terminal)\n"
+        "        print('PAGER_READY', flush=True)\n"
+        "        while os.read(terminal.fileno(), 1) != b'q':\n"
+        "            pass\n"
+        "    finally:\n"
+        "        termios.tcsetattr(terminal, termios.TCSANOW, saved)\n",
+        encoding="utf-8",
+    )
+    application = tmp_path / "application.py"
+    application.write_text(
+        "from cmd2 import Cmd, ToolbarMode\n"
+        "app = Cmd(bottom_toolbar_mode=ToolbarMode.RESERVED)\n"
+        "app.prompt = 'TEST> '\n"
+        "app.main_session.bottom_toolbar = 'STATUS'\n"
+        "app.cmdloop()\n",
+        encoding="utf-8",
+    )
+    master, slave = pty.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+    # Establish a controlling terminal in a fresh interpreter, avoiding preexec_fn
+    # (unsafe when pytest or its plugins have started threads).
+    bootstrap = (
+        "import os, fcntl, termios; os.setsid(); "
+        "fcntl.ioctl(0, termios.TIOCSCTTY, 0); "
+        "os.execv(os.environ['TEST_SHELL'], ['bash', '--noprofile', '--norc', '-i'])"
+    )
+    env = dict(os.environ, TERM="xterm-256color", PS1="OUTER> ", TEST_SHELL=shell)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    process = subprocess.Popen([sys.executable, "-c", bootstrap], stdin=slave, stdout=slave, stderr=slave, env=env)
+    os.close(slave)
+    screen = pyte.Screen(80, 24)
+    screen.write_process_input = lambda data: os.write(master, data.encode())
+    stream = pyte.Stream(screen)
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    transcript = ""
+
+    def send(data):
+        os.write(master, data.encode())
+
+    def wait_until(predicate):
+        nonlocal transcript
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if select.select([master], [], [], 0.05)[0]:
+                data = decoder.decode(os.read(master, 65536))
+                transcript += data
+                stream.feed(data)
+            if predicate():
+                return
+        pytest.fail(f"terminal condition timed out:\n{transcript}")
+
+    job_group = None
+    try:
+        wait_until(lambda: "OUTER> " in transcript)
+        send(f"{shlex.quote(sys.executable)} {shlex.quote(str(application))}\n")
+        wait_until(lambda: screen.display[-1].startswith("STATUS"))
+        job_group = os.tcgetpgrp(master)
+        send(f"help -v | {shlex.quote(sys.executable)} {shlex.quote(str(pager))}\n")
+        wait_until(lambda: "PAGER_READY" in transcript)
+        for rows in (12, 24):
+            send("\x1a")
+            wait_until(lambda: os.tcgetpgrp(master) == process.pid)
+            start = len(transcript)
+            # A child left running can steal these keystrokes from the shell.
+            send("printf 'SHELL_%s\\n' OWNS_INPUT\n")
+            wait_until(lambda start=start: "SHELL_OWNS_INPUT" in transcript[start:])
+            fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, 80, 0, 0))
+            screen.resize(lines=rows, columns=80)
+            start = len(transcript)
+            send("stty size\n")
+            wait_until(lambda start=start, rows=rows: f"\r\n{rows} 80\r\n" in transcript[start:])
+            start = len(transcript)
+            send("fg\n")
+            wait_until(lambda start=start: "PAGER_RESUMED" in transcript[start:])
+            assert os.tcgetpgrp(master) == job_group
+        send(finish)
+        wait_until(lambda: screen.display[-1].startswith("STATUS") and "TEST>" in "\n".join(screen.display))
+        start = len(transcript)
+        send("help quit\n")
+        wait_until(lambda: "Exit this application" in transcript[start:])
+        send("quit\n")
+        wait_until(lambda: os.tcgetpgrp(master) == process.pid)
+    finally:
+        # Kill only this test's job, including stopped descendants, on assertion failure.
+        if pager_pid.exists():
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(int(pager_pid.read_text()), signal.SIGKILL)
+        if job_group is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(job_group, signal.SIGKILL)
+        process.kill()
+        process.wait(timeout=5)
+        os.close(master)

--- a/tests/test_pipeline_job_control.py
+++ b/tests/test_pipeline_job_control.py
@@ -3,6 +3,7 @@
 import codecs
 import contextlib
 import os
+import re
 import select
 import shlex
 import shutil
@@ -113,7 +114,9 @@ def test_pipeline_stops_with_cmd2_and_returns_terminal(tmp_path, finish) -> None
             screen.resize(lines=rows, columns=80)
             start = len(transcript)
             send("stty size\n")
-            wait_until(lambda start=start, rows=rows: f"\r\n{rows} 80\r\n" in transcript[start:])
+            # Bash 5.1+ turns bracketed paste off with "\x1b[?2004l\r" before running the
+            # command, so the reply may follow a bare "\r" rather than "\r\n".
+            wait_until(lambda start=start, rows=rows: re.search(rf"[\r\n]{rows} 80\r\n", transcript[start:]) is not None)
             start = len(transcript)
             send("fg\n")
             wait_until(lambda start=start: "PAGER_RESUMED" in transcript[start:])

--- a/tests/test_reserved_lifecycle.py
+++ b/tests/test_reserved_lifecycle.py
@@ -603,8 +603,8 @@ class TestPromptSuspension:
         finally:
             harness.close()
 
-    def test_another_session_still_gets_the_terminal_to_itself(self) -> None:
-        """A prompt cmd2 has not bound to the reservation renders outside it, for now."""
+    def test_another_session_on_the_same_terminal_borrows_the_reservation(self) -> None:
+        """Managed nested input retains the main-screen band."""
         harness = Harness(mode="reserved")
         try:
             with harness.app._reserved_toolbar_context():
@@ -616,7 +616,7 @@ class TestPromptSuspension:
 
                 harness.app._read_raw_input("> ", other)
 
-                assert seen == [False]
+                assert seen == [True]
                 assert toolbar.display.is_reserved is True
         finally:
             harness.close()

--- a/tests/test_reserved_terminal.py
+++ b/tests/test_reserved_terminal.py
@@ -300,6 +300,76 @@ class TestResize:
     attached, so the poll on ``output.get_size()`` is the only way a resize arrives there.
     """
 
+    @pytest.mark.parametrize("terminal_harness", [2, 3], indirect=True)
+    @pytest.mark.parametrize("text", ["", "typed"])
+    def test_minimum_height_reacquisition_through_idle_polling(self, terminal_harness, monkeypatch, text) -> None:
+        """Fallback can erase a cached band before growth returns to exactly the same size."""
+        harness, terminal = terminal_harness
+        ui = harness.app.main_session.app
+        ui.terminal_size_polling_interval = 0.01
+        task = None
+        polls = 0
+        errors = []
+
+        async def until(predicate):
+            async with asyncio.timeout(5):
+                while not predicate():  # noqa: ASYNC110 - observe upstream state without driving a redraw
+                    await asyncio.sleep(0.01)
+
+        async def transitions():
+            try:
+                if text:
+                    harness.pipe.send_text(text)
+                    await until(lambda: ui.current_buffer.text == text)
+                for rows, columns in ((3, 80), (2, 80), (3, 80), (4, 40), (24, 100), (3, 80), (2, 80), (3, 80)):
+                    baseline = polls
+                    # Let upstream establish/settle its size baseline before changing it.
+                    await until(lambda baseline=baseline: polls >= baseline + 2)
+                    if harness.size != Size(rows=rows, columns=columns):
+                        resize(harness, terminal, rows, columns)
+                    toolbar = harness.app.reserved_toolbar
+                    await until(lambda toolbar=toolbar, rows=rows: toolbar.is_active == (rows >= 3))
+                    if rows >= 3:
+                        await until(lambda toolbar=toolbar, rows=rows: toolbar.display.geometry.physical_rows == rows)
+                        await until(lambda: terminal.screen.display[-1].startswith("STATUS"))
+                    await until(lambda: any(row.startswith("TEST> " + text) for row in terminal.screen.display))
+                    assert ui.current_buffer.text == text
+                    assert ui.current_buffer.cursor_position == len(text)
+            except Exception as error:  # noqa: BLE001 - report outside prompt-toolkit's event loop
+                errors.append(error)
+            finally:
+                harness.pipe.send_text("\n")
+
+        def ready(app):
+            nonlocal task
+            if task is None:
+                task = ui.create_background_task(transitions())
+
+        ui.after_render += ready
+        try:
+            with harness.app._reserved_toolbar_context():
+                get_size = ui.output.get_size
+
+                def observe_size():
+                    nonlocal polls
+                    try:
+                        current = asyncio.current_task()
+                    except RuntimeError:
+                        current = None
+                    if current is not None and current.get_coro().__name__ == "_poll_output_size":
+                        polls += 1
+                    return get_size()
+
+                monkeypatch.setattr(ui.output, "get_size", observe_size)
+                assert harness.app._read_raw_input("TEST> ", harness.app.main_session) == text
+                assert task is not None
+                task.result()
+                if errors:
+                    raise errors[0]
+        finally:
+            ui.after_render -= ready
+        assert terminal.screen.margins is None
+
     @pytest.mark.parametrize("terminal_harness", [2], indirect=True)
     def test_initially_short_prompt_grows_and_accepts_visible_input(self, terminal_harness) -> None:
         harness, terminal = terminal_harness
@@ -329,6 +399,45 @@ class TestResize:
             watchdog.cancel()
             watchdog.join()
             ui.after_render -= ready
+
+    @pytest.mark.parametrize("terminal_harness", [3], indirect=True)
+    @pytest.mark.parametrize("partial", ["", "PARTIAL"])
+    def test_quiet_command_reacquires_the_same_band(self, terminal_harness, monkeypatch, partial) -> None:
+        """The command poll restores the whole band without disturbing unfinished output."""
+        harness, terminal = terminal_harness
+        harness.app.main_session.app.terminal_size_polling_interval = 0.01
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            toolbar = harness.app.reserved_toolbar
+            output = harness.app._command_toolbar.app.output
+            get_size = output.get_size
+            polls = 0
+
+            def observe_size():
+                nonlocal polls
+                try:
+                    current = asyncio.current_task()
+                except RuntimeError:
+                    current = None
+                if current is not None and current.get_coro().__name__ == "_poll_output_size":
+                    polls += 1
+                return get_size()
+
+            monkeypatch.setattr(output, "get_size", observe_size)
+            harness.app.stdout.write(partial)
+            harness.app.stdout.flush()
+            for rows in (2, 3, 4, 3, 2, 3):
+                baseline = polls
+                assert wait_for(lambda baseline=baseline: polls >= baseline + 2)
+                resize(harness, terminal, rows, 80)
+                assert wait_for(lambda rows=rows: toolbar.is_active == (rows >= 3))
+                if rows >= 3:
+                    assert wait_for(lambda rows=rows: toolbar.display.geometry.physical_rows == rows)
+                    assert wait_for(lambda: terminal.screen.display[-1].startswith("STATUS"))
+                if partial:
+                    assert any(row.startswith(partial) for row in terminal.screen.display)
+            harness.app.poutput(" COMPLETE")
+            assert any(row.startswith(partial + " COMPLETE") for row in terminal.screen.display)
+        assert terminal.screen.margins is None
 
     @pytest.mark.parametrize("terminal_harness", [2], indirect=True)
     def test_initially_short_terminal_acquires_during_a_quiet_command(self, terminal_harness, monkeypatch) -> None:

--- a/tests/test_reserved_terminal.py
+++ b/tests/test_reserved_terminal.py
@@ -818,6 +818,51 @@ def test_termination_unwinds_reserved_command_ownership(terminal_harness) -> Non
 
 
 class TestPager:
+    @pytest.mark.parametrize("action", ["resume", "output", "external"])
+    def test_retained_startup_bar_is_cleared_before_output_or_external_handoff(self, terminal_harness, action) -> None:
+        harness, terminal = terminal_harness
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            reserved = harness.app.reserved_toolbar
+            with reserved.suspended(defer_band_clear=True):
+                assert terminal.screen.display[-1].startswith("STATUS")
+                if action == "output":
+                    # Blank lines can scroll the retained bar without overwriting its text.
+                    harness.app.stdout.write("\n" * 50)
+                    harness.app.stdout.flush()
+                elif action == "external":
+                    with reserved.suspended():
+                        assert terminal.screen.display[-1].strip() == ""
+                else:
+                    assert reserved.display._deferred_band is not None
+            assert reserved.display._deferred_band is None
+            assert terminal.screen.display[-1].startswith("STATUS")
+            history = ["".join(line[x].data for x in sorted(line)) for line in terminal.screen.history.top]
+            assert not any("STATUS" in row for row in history)
+
+    def test_toolbar_remains_visible_until_the_first_pager_frame_is_prepared(self, terminal_harness, monkeypatch) -> None:
+        harness, terminal = terminal_harness
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            reserved = harness.app.reserved_toolbar
+            display = harness.app._command_toolbar
+            original_prepare = reserved.bridge.prepare
+            seen = []
+
+            def prepare(*args, **kwargs):
+                frame = original_prepare(*args, **kwargs)
+                if display._paging and frame is not None and not seen:
+                    # Observe after the expensive layout work, before commit. Checking only
+                    # the completed pager would miss the blank interval while a file loads.
+                    seen.append(terminal.screen.display[-1])
+                    assert display.app.output.get_size() == Size(24, 80)
+                return frame
+
+            monkeypatch.setattr(reserved.bridge, "prepare", prepare)
+            assert run_pager(harness, terminal)
+            assert seen
+            assert seen[0].startswith("STATUS")
+            assert reserved.display._deferred_band is None
+            assert terminal.screen.display[-1].startswith("STATUS")
+
     def test_first_pager_frame_uses_full_geometry(self, terminal_harness) -> None:
         harness, terminal = terminal_harness
         with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():

--- a/tests/test_reserved_terminal.py
+++ b/tests/test_reserved_terminal.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import io
+import signal
 import sys
 import threading
 import time
@@ -14,6 +15,8 @@ import pyte
 import pytest
 from prompt_toolkit.application import run_in_terminal
 from prompt_toolkit.data_structures import Size
+from prompt_toolkit.shortcuts import PromptSession
+from prompt_toolkit.shortcuts.choice_input import ChoiceInput
 
 from cmd2 import command_toolbar
 from cmd2.reserved_toolbar import ReservedToolbar
@@ -609,7 +612,239 @@ def run_pager(harness, terminal, while_open=None) -> bool:
     return shown.is_set()
 
 
+class TestNestedPrompts:
+    def test_abandoning_reservation_during_nested_input_restores_both_owners(self, terminal_harness) -> None:
+        harness, terminal = terminal_harness
+        session = PromptSession(input=harness.pipe, output=harness.backend, bottom_toolbar="STATUS")
+        original_render = session.app.renderer.render
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            reserved = harness.app.reserved_toolbar
+
+            def abandon():
+                reserved.stop()
+                harness.pipe.send_text("answer\n")
+
+            assert harness.app._read_raw_input("Nested: ", session, pre_run=abandon) == "answer"
+            assert reserved.bridge is None
+            assert session.app.output is harness.backend
+            assert session.app.renderer.render == original_render
+            assert harness.app._command_toolbar._proxy is not None
+            assert terminal.screen.margins is None
+
+    def test_nested_resize_and_failed_guest_restore_the_main_owner(self, terminal_harness) -> None:
+        harness, terminal = terminal_harness
+        session = PromptSession(input=harness.pipe, output=harness.backend, bottom_toolbar="STATUS")
+        original = session.app.renderer.render
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            main_bridge = harness.app.reserved_toolbar.bridge
+
+            def fail():
+                resize(harness, terminal, 12, 40)
+                session.app._on_resize()
+                raise ValueError("nested failure")
+
+            with pytest.raises(ValueError, match="nested failure"):
+                harness.app._read_raw_input("Nested: ", session, pre_run=fail)
+            assert harness.app.reserved_toolbar.bridge is main_bridge
+            assert session.app.renderer.render == original
+            assert terminal.screen.margins == pyte.screens.Margins(0, 10)
+            assert terminal.screen.display[-1].startswith("STATUS")
+            read_prompt(harness, terminal)
+
+    @pytest.mark.parametrize(
+        ("kind", "keys", "expected"),
+        [("input", "ans\t", "answer"), ("secret", "hidden-value\n", "hidden-value"), ("select", "\x1b[B\r", "two")],
+    )
+    def test_managed_input_keeps_the_band_and_one_reader(self, terminal_harness, kind, keys, expected) -> None:
+        harness, terminal = terminal_harness
+        created = []
+        seen = []
+        accepted = False
+        selected = False
+
+        def ready(app):
+            nonlocal accepted, selected
+            if not seen and app.renderer._min_available_height > 0:
+                seen.append((terminal.screen.margins, terminal.screen.display[-1]))
+                assert not harness.app._command_toolbar.thread_is_alive
+                harness.pipe.send_text(keys + ("" if kind == "input" else "trailing\n"))
+            elif kind == "input" and not selected and app.current_buffer.complete_state is not None:
+                selected = True
+                harness.pipe.send_text("\t")
+            elif kind == "input" and not accepted and app.current_buffer.text.rstrip() == "answer":
+                accepted = True
+                harness.pipe.send_text("\rtrailing\n")
+
+        def make_session(*args, **kwargs):
+            session = PromptSession(*args, **kwargs)
+            created.append(session)
+
+            session.app.after_render += ready
+            return session
+
+        original_create = ChoiceInput._create_application
+
+        def make_choice(choice):
+            app = original_create(choice)
+            app.after_render += ready
+            return app
+
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            before = len(terminal.getvalue())
+            watchdog = threading.Timer(5, harness.pipe.close)
+            watchdog.start()
+            try:
+                with (
+                    mock.patch("cmd2.cmd2.PromptSession", make_session),
+                    mock.patch.object(ChoiceInput, "_create_application", make_choice),
+                ):
+                    if kind == "input":
+                        result = harness.app.read_input("Value: ", choices=["answer"])
+                    elif kind == "secret":
+                        result = harness.app.read_secret("Secret: ")
+                    else:
+                        result = harness.app.select(["one", "two"])
+                assert result.rstrip() == expected
+                assert seen[0][0] == pyte.screens.Margins(0, 22)
+                assert seen[0][1].startswith("STATUS")
+                assert "\x1b[r" not in terminal.getvalue()[before:]
+                assert harness.app._command_toolbar.thread_is_alive
+                assert harness.app._read_raw_input("Next: ", harness.app.main_session) == "trailing"
+                assert not harness.app.reserved_toolbar._nested_bridges
+                if kind == "secret":
+                    assert "hidden-value" not in terminal.getvalue()
+            finally:
+                watchdog.cancel()
+                watchdog.join()
+
+    @pytest.mark.parametrize("keys", ["\x03", "\x04"])
+    def test_nested_input_interrupt_restores_bindings(self, terminal_harness, keys) -> None:
+        harness, terminal = terminal_harness
+        session = PromptSession(input=harness.pipe, output=harness.backend, bottom_toolbar="STATUS")
+        original_output = session.app.output
+        original_render = session.app.renderer.render
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            with pytest.raises((KeyboardInterrupt, EOFError)):
+                harness.app._read_raw_input("Nested: ", session, pre_run=lambda: harness.pipe.send_text(keys))
+            assert session.app.output is original_output
+            assert session.app.renderer.render == original_render
+            assert harness.app._command_toolbar.thread_is_alive
+            assert terminal.screen.margins == pyte.screens.Margins(0, 22)
+            assert terminal.screen.display[-1].startswith("STATUS")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX job control")
+@pytest.mark.parametrize("owner", ["command", "prompt", "pager"])
+def test_ctrl_z_releases_before_signaling_and_reacquires_after_resume(terminal_harness, monkeypatch, owner) -> None:
+    harness, terminal = terminal_harness
+    harness.app.main_session.enable_suspend = True
+    stopped = threading.Event()
+    seen = []
+
+    def stop_process(pid, sig):
+        # This is the actual key-binding -> run_in_terminal -> signal path. The signal is
+        # replaced so the test runner never suspends itself or its parent process group.
+        seen.append((pid, sig, terminal.screen.margins, harness.app.main_session.app.output.get_size()))
+        assert harness.app.main_session.app._running_in_terminal
+        resize(harness, terminal, 12, 80)
+        stopped.set()
+
+    monkeypatch.setattr("cmd2.reserved_toolbar.os.kill", stop_process)
+    with harness.app._reserved_toolbar_context():
+        original_suspend = harness.app.main_session.app.suspend_to_background
+        if owner in ("command", "pager"):
+            with harness.app._command_toolbar_context():
+                display = harness.app._command_toolbar
+
+                def suspend() -> None:
+                    harness.pipe.send_text("\x1a")
+                    assert stopped.wait(5)
+                    display._call_in_ui(lambda: None)
+
+                if owner == "pager":
+                    assert run_pager(harness, terminal, while_open=suspend)
+                else:
+                    suspend()
+                assert terminal.screen.margins == pyte.screens.Margins(0, 10)
+                assert terminal.screen.display[-1].startswith("STATUS")
+        else:
+            ui = harness.app.main_session.app
+            accepted = False
+
+            def ready(app):
+                nonlocal accepted
+                if stopped.is_set() and not accepted:
+                    accepted = True
+                    harness.pipe.send_text("\n")
+
+            ui.after_render += ready
+            watchdog = threading.Timer(5, harness.pipe.close)
+            watchdog.start()
+            try:
+                assert (
+                    harness.app._read_raw_input(
+                        "TEST> ", harness.app.main_session, pre_run=lambda: harness.pipe.send_text("\x1a")
+                    )
+                    == ""
+                )
+                assert stopped.is_set()
+                assert terminal.screen.margins == pyte.screens.Margins(0, 10)
+            finally:
+                watchdog.cancel()
+                watchdog.join()
+                ui.after_render -= ready
+        assert seen == [(0, signal.SIGTSTP, None, Size(24, 80))]
+    assert terminal.screen.margins is None
+    assert harness.app.main_session.app.suspend_to_background != original_suspend
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX termination handler")
+def test_termination_unwinds_reserved_command_ownership(terminal_harness) -> None:
+    harness, terminal = terminal_harness
+    original_output = harness.app.main_session.app.output
+    displays = []
+
+    def terminate():
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            displays.append(harness.app._command_toolbar)
+            harness.app.termination_signal_handler(signal.SIGTERM, None)
+
+    with pytest.raises(SystemExit) as exit_info:
+        terminate()
+    assert exit_info.value.code == 128 + signal.SIGTERM
+    assert not displays[0].thread_is_alive
+    assert harness.app.main_session.app.output is original_output
+    assert terminal.screen.margins is None
+
+
 class TestPager:
+    def test_first_pager_frame_uses_full_geometry(self, terminal_harness) -> None:
+        harness, terminal = terminal_harness
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            display = harness.app._command_toolbar
+            sizes = []
+
+            def before_render(app):
+                if display._paging:
+                    sizes.append(app.output.get_size())
+
+            display.app.before_render += before_render
+            try:
+                assert run_pager(harness, terminal)
+                assert sizes
+                assert all(size == Size(24, 80) for size in sizes)
+            finally:
+                display.app.before_render -= before_render
+
+    def test_exact_usable_height_does_not_open_a_pager(self, terminal_harness) -> None:
+        harness, terminal = terminal_harness
+        with harness.app._reserved_toolbar_context(), harness.app._command_toolbar_context():
+            text = "\n".join(f"line {i}" for i in range(23))
+            with mock.patch.object(command_toolbar, "Pager", side_effect=AssertionError("unnecessary pager")):
+                harness.app._command_toolbar.page(text, chop=False)
+            assert any("line 22" in row for row in terminal.screen.display)
+            assert terminal.screen.display[-1].startswith("STATUS")
+
     """The built-in pager renders a full screen of its own, so its frames must not be
     suppressed the way an ordinary command's empty frames are."""
 
@@ -771,6 +1006,7 @@ class TestPager:
             assert not forced_close.is_set(), "the quit callback failed to release page()"
             assert display.app.full_screen is False
             assert display.app.renderer.full_screen is False
+            assert display.app.renderer._in_alternate_screen is False
             assert display.app.layout is display._layout
             assert display.app.key_bindings is display._bindings or display.app.key_bindings is bindings
             assert display.app.editing_mode is editing_mode

--- a/tests/test_reserved_toolbar.py
+++ b/tests/test_reserved_toolbar.py
@@ -7,6 +7,7 @@ a backend left wrapped after the loop ends would report a short terminal to what
 """
 
 import io
+import signal
 from typing import Any
 
 import pytest
@@ -832,5 +833,65 @@ class TestAbandonedEmission:
             with harness.toolbar.suspended():
                 pass
             assert harness.written() == ""
+        finally:
+            harness.close()
+
+
+class TestNestedPrompts:
+    def test_a_nested_session_without_a_toolbar_window_is_refused(self) -> None:
+        """Lending the reservation to a layout with no toolbar window would leave two toolbars."""
+        harness = Harness()
+        try:
+            harness.toolbar.start()
+            main_bridge = harness.toolbar.bridge
+            nested: PromptSession[str] = PromptSession(input=harness.pipe, output=harness.backend)
+            nested.app.layout = Layout(Window())
+            with pytest.raises(RuntimeError, match="nested session"), harness.toolbar.prompt_session(nested):
+                pass
+            assert nested.app.output is harness.backend
+            assert harness.toolbar.bridge is main_bridge
+        finally:
+            harness.close()
+
+    def test_suspending_invalidates_a_nested_prompt_bridge_too(self) -> None:
+        """The guest program writes over the nested prompt's screen as much as the main one's."""
+        harness = Harness()
+        try:
+            harness.toolbar.start()
+            nested: PromptSession[str] = PromptSession(input=harness.pipe, output=harness.backend, bottom_toolbar="NESTED")
+            with harness.toolbar.prompt_session(nested):
+                bridge = harness.toolbar.bridge
+                assert bridge is not None
+                assert bridge is not harness.toolbar._bridge
+                bridge.set_prompt_anchor(5)
+                with harness.toolbar.suspended():
+                    assert bridge.prompt_anchor is None
+                    assert bridge.needs_resynchronization is True
+                    assert "handed to another program" in (bridge.resynchronization_reason or "")
+                assert "came back from another program" in (bridge.resynchronization_reason or "")
+        finally:
+            harness.close()
+
+
+class TestJobControl:
+    @pytest.mark.parametrize("missing", ["support", "signal"])
+    def test_suspending_to_background_does_nothing_where_it_is_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, missing: str
+    ) -> None:
+        """Without a stop signal or a supporting platform there is no process to stop."""
+        harness = Harness()
+        try:
+            harness.toolbar.start()
+            calls: list[Any] = []
+            monkeypatch.setattr("cmd2.reserved_toolbar.run_in_terminal", calls.append)
+            if missing == "support":
+                monkeypatch.setattr("cmd2.reserved_toolbar.suspend_to_background_supported", lambda: False)
+            else:
+                monkeypatch.delattr(signal, "SIGTSTP", raising=False)
+            harness.clear()
+            harness.app.suspend_to_background()
+            assert calls == []
+            assert harness.written() == ""
+            assert harness.toolbar.is_active is True
         finally:
             harness.close()

--- a/tests/test_reserved_toolbar.py
+++ b/tests/test_reserved_toolbar.py
@@ -61,6 +61,34 @@ class Harness:
         return self.session.app
 
 
+@pytest.mark.parametrize("guest_fails", [False, True])
+def test_failed_reacquisition_releases_bindings_without_masking_the_guest(monkeypatch, guest_fails) -> None:
+    harness = Harness()
+    try:
+        with harness.toolbar:
+            display = harness.toolbar.display
+
+            def fail():
+                raise OSError("resume failed")
+
+            monkeypatch.setattr(display, "reacquire_region_after_handoff", fail)
+            expected = ValueError if guest_fails else OSError
+
+            def run_guest():
+                with harness.toolbar.suspended():
+                    if guest_fails:
+                        raise ValueError("guest failed")
+
+            with pytest.raises(expected, match="guest failed" if guest_fails else "resume failed"):
+                run_guest()
+            assert harness.toolbar.bridge is None
+            assert harness.app.output is harness.backend
+            assert display.lease_depth == 0
+            assert isinstance(harness.toolbar.take_pending_error(), OSError)
+    finally:
+        harness.close()
+
+
 class TestBinding:
     def test_starting_binds_the_application_and_its_renderer(self) -> None:
         harness = Harness()

--- a/tests/test_terminal_display.py
+++ b/tests/test_terminal_display.py
@@ -52,6 +52,17 @@ def make_resizable_output(rows: int = 24, columns: int = 80) -> tuple[Vt100_Outp
 
 
 class TestGeometry:
+    def test_shutdown_clears_a_bar_retained_for_an_unfinished_pager(self) -> None:
+        output, stream = make_output()
+        display = TerminalDisplay(output)
+        display.acquire()
+        display.release_region_for_handoff(defer_band_clear=True)
+        stream.seek(0)
+        stream.truncate()
+        display.release()
+        assert "\x1b[24;1H\x1b[0m\x1b[J" in stream.getvalue()
+        assert display._deferred_band is None
+
     def test_usable_rows_subtracts_the_reservation_exactly_once(self) -> None:
         """The double-subtraction mutation: at 24 rows with 1 reserved, 22 is the wrong answer."""
         geometry = Geometry(generation=1, physical_rows=24, columns=80, reserved_rows=1)

--- a/tests/test_toolbar_painter.py
+++ b/tests/test_toolbar_painter.py
@@ -470,6 +470,23 @@ class TestPainting:
         assert harness.paint("hi") is True
         assert "\x1b[12;1Hhi   " in harness.visible()
 
+    @pytest.mark.parametrize("prepare_while_inactive", [False, True])
+    def test_reacquiring_the_same_band_repaints_all_cells(self, prepare_while_inactive: bool) -> None:
+        """Returning from fallback must not reuse cells painted before the reservation ended."""
+        harness = Harness(rows=3)
+        assert harness.paint("hi") is True
+        harness.display.resize(2)
+        assert not harness.display.is_reserved
+        if prepare_while_inactive:
+            assert harness.painter.prepare(lambda: "hi") is None
+        harness.display.resize(3)
+        harness.clear()
+        assert harness.paint("hi") is True
+        assert "\x1b[3;1Hhi   " in harness.visible()
+        harness.clear()
+        assert harness.paint("hi") is False
+        assert harness.written() == ""
+
     def test_empty_content_is_painted_rather_than_skipped(self) -> None:
         """An empty toolbar is an intentional visibility change and must reach the band."""
         harness = Harness()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,6 +249,53 @@ def test_proc_reader_terminate(pr_none) -> None:
         assert ret_code == -signal.SIGTERM
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal job control")
+@pytest.mark.parametrize("already_exited", [False, True])
+def test_proc_reader_terminate_terminal_job(already_exited) -> None:
+    proc = mock.Mock(stdout=None, stderr=None)
+    reader = cu.ProcReader(proc, sys.stdout, sys.stderr)
+    reader._terminal_fd = 10
+    with mock.patch("os.kill", side_effect=ProcessLookupError if already_exited else None) as kill:
+        reader.terminate()
+    kill.assert_called_once_with(proc.pid, signal.SIGTERM)
+    # Only the job watcher may reap this process; Popen.terminate() would poll it.
+    proc.terminate.assert_not_called()
+    proc.poll.assert_not_called()
+    proc.wait.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal job control")
+@pytest.mark.parametrize("stop_signal", ["SIGTTIN", "SIGTTOU"])
+def test_proc_reader_resumes_terminal_access_after_borrow(stop_signal) -> None:
+    proc = mock.Mock(pid=123, stdout=None, stderr=None, returncode=None)
+    reader = cu.ProcReader(proc, sys.stdout, sys.stderr)
+    reader._terminal_fd = 10
+    reader._original_group = 456
+    stopped_status = (getattr(signal, stop_signal) << 8) | 0x7F
+    with (
+        mock.patch("os.waitpid", side_effect=[(proc.pid, stopped_status), (proc.pid, 0)]),
+        mock.patch("os.tcgetpgrp", return_value=proc.pid),
+        mock.patch.object(reader, "_set_foreground_group") as foreground,
+        mock.patch.object(reader._terminal_available, "wait", return_value=True) as available,
+        mock.patch("os.killpg") as killpg,
+        mock.patch("signal.raise_signal") as stop,
+    ):
+        reader._wait_for_job(10)
+    available.assert_called_once_with()
+    killpg.assert_called_once_with(proc.pid, signal.SIGCONT)
+    stop.assert_not_called()
+    foreground.assert_called_once_with(10, reader._original_group)
+    assert proc.returncode == 0
+    assert reader._process_done.is_set()
+
+
+def test_proc_reader_wait_for_exit_without_terminal() -> None:
+    proc = mock.Mock(stdout=None, stderr=None)
+    reader = cu.ProcReader(proc, sys.stdout, sys.stderr)
+    reader.wait_for_exit(timeout=0.2)
+    proc.wait.assert_called_once_with(0.2)
+
+
 @pytest.fixture
 def context_flag():
     return cu.ContextFlag()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -220,12 +220,25 @@ def test_proc_reader_send_sigint(pr_none) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
-def test_proc_reader_does_not_resignal_its_own_group(pr_none) -> None:
-    with mock.patch("os.getpgid", return_value=os.getpgrp()), mock.patch("os.killpg") as killpg:
-        pr_none.send_sigint()
-    killpg.assert_not_called()
-    pr_none.terminate()
-    pr_none.wait()
+@pytest.mark.parametrize("group_exited", [False, True])
+def test_proc_reader_forwards_to_its_own_group(pr_none, group_exited) -> None:
+    original_handler = signal.getsignal(signal.SIGINT)
+
+    def forward(group_id, signum):
+        assert group_id == os.getpgrp()
+        assert signum == signal.SIGINT
+        assert signal.getsignal(signal.SIGINT) == signal.SIG_IGN
+        if group_exited:
+            raise ProcessLookupError
+
+    try:
+        with mock.patch("os.getpgid", return_value=os.getpgrp()), mock.patch("os.killpg", side_effect=forward) as killpg:
+            pr_none.send_sigint()
+        killpg.assert_called_once_with(os.getpgrp(), signal.SIGINT)
+        assert signal.getsignal(signal.SIGINT) == original_handler
+    finally:
+        pr_none.terminate()
+        pr_none.wait()
 
 
 def test_proc_reader_terminate(pr_none) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -220,22 +220,11 @@ def test_proc_reader_send_sigint(pr_none) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
-@pytest.mark.parametrize("group_exited", [False, True])
-def test_proc_reader_forwards_to_its_own_group(pr_none, group_exited) -> None:
-    original_handler = signal.getsignal(signal.SIGINT)
-
-    def forward(group_id, signum):
-        assert group_id == os.getpgrp()
-        assert signum == signal.SIGINT
-        assert signal.getsignal(signal.SIGINT) == signal.SIG_IGN
-        if group_exited:
-            raise ProcessLookupError
-
+def test_proc_reader_does_not_resignal_its_own_group(pr_none) -> None:
     try:
-        with mock.patch("os.getpgid", return_value=os.getpgrp()), mock.patch("os.killpg", side_effect=forward) as killpg:
+        with mock.patch("os.getpgid", return_value=os.getpgrp()), mock.patch("os.killpg") as killpg:
             pr_none.send_sigint()
-        killpg.assert_called_once_with(os.getpgrp(), signal.SIGINT)
-        assert signal.getsignal(signal.SIGINT) == original_handler
+        killpg.assert_not_called()
     finally:
         pr_none.terminate()
         pr_none.wait()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -219,6 +219,15 @@ def test_proc_reader_send_sigint(pr_none) -> None:
         assert ret_code == -signal.SIGINT
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+def test_proc_reader_does_not_resignal_its_own_group(pr_none) -> None:
+    with mock.patch("os.getpgid", return_value=os.getpgrp()), mock.patch("os.killpg") as killpg:
+        pr_none.send_sigint()
+    killpg.assert_not_called()
+    pr_none.terminate()
+    pr_none.wait()
+
+
 def test_proc_reader_terminate(pr_none) -> None:
     assert pr_none._proc.poll() is None
     pr_none.terminate()


### PR DESCRIPTION
## Summary

Complete Stage 4 of the reserved-row toolbar work: transfer terminal and input ownership correctly across nested prompts, paging, external applications, suspend/resume, and resize. This PR targets `reserved_row_toolbar`, which already contains Stage 3; it retains the current one-row reservation and opt-in mode defaults.

### What changed

- **Managed nested input:** `read_input()`, `read_secret()`, and `select()` borrow the existing reservation after the command reader stops. Temporary applications receive their own bridge, retain the current toolbar content/styles, and restore original bindings when they finish, are interrupted, or fall back. This avoids a second input reader and preserves completion, secret masking, and typeahead.
- **Embedded pager ownership and loading:** release the reservation before the first pager layout measures available space, expose full physical geometry, and avoid subtracting the toolbar height twice when deciding whether output fits. Keep the existing main-screen toolbar visible while preparing a large pager's first frame; clear it when that frame commits or when intervening output/external ownership requires it. Restore the main-screen reservation after leaving the pager, including cleanup when exit-time erasure fails.
- **Nested and external handoffs:** make release/reacquisition idempotent across nested suspension and alternate-screen ownership. Reacquire from fresh geometry, invalidate stale prompt/output accounting, and restore compatibility bindings when acquisition fails. If both the guest and cleanup fail, preserve the guest's exception and retain the cleanup error for diagnostics.
- **POSIX job control:** release rows inside prompt-toolkit's cooked-mode/input-detached handoff before stopping the foreground job, then reacquire on resume. Suspending while a pager already owns the screen does not install a reservation inside its alternate buffer. Look up `SIGTSTP` conditionally so Windows type checking and unsupported-platform behavior remain valid.
- **Interactive pipelines:** terminal-attached POSIX pipelines now share cmd2's foreground process group. Previously `help -v | less`, Ctrl-Z, and `fg` could leave `less` running while cmd2 was stopped, allowing it to steal shell input. Avoid forwarding SIGINT back into cmd2's own group; retain isolated groups for nonterminal pipelines and the existing Windows process-group behavior.
- **Minimum-height recovery:** include the reservation generation in the painter's cached-band identity. A 3 → 2 → 3 resize can erase the old cells and reacquire identical coordinates; the first new paint must redraw the entire band rather than reuse that stale cache. Unchanged content remains a no-op within a stable generation.
- **Examples and regression coverage:** enable `py` in the getting-started example and add an exception-raising script for manual testing. Add nested-input, pager, cleanup, polling, partial-output, and real-PTY job-control regressions.

### Review focus

The implementation retains the existing alternating main/command application lifecycle and serialized-output architecture. Review ownership restoration and failure ordering, especially nested suspension, alternate-screen exit, native Windows geometry, and partial output. The `ChoiceInput._create_application()` integration and polling tests depend on prompt-toolkit internals; qualification remains at exactly 3.0.53. Broader dependency/backend qualification follows in Stage 8.

## Roadmap

The additional investigations requested after Stage 4 move the former Stage 5 release qualification to Stage 8.

| Stage | Work | Status / exit criterion |
| --- | --- | --- |
| 3 | Ordinary prompt/command lifecycle, mode selection, serialization, stable toolbar and history | Completed and merged into `reserved_row_toolbar` via #1758 |
| 4 | Nested prompts, pager/external handoffs, job control, resizing and cleanup | This PR; integration regressions and real-terminal transitions verified, with PR CI/review and final evidence closure still required |
| 5 | Spike: is the embedded pager still useful and worth maintaining? | Compare capabilities, startup latency, portability and maintenance cost; review a keep/simplify/replace/remove recommendation before changing behavior |
| 6 | Toolbar package organization, test naming, and simplification | Investigate an internal `cmd2/toolbar/` package; align focused tests with production modules; keep cross-module integration suites; separate mechanical moves from justified behavior-preserving refactors |
| 7 | Configurable 0–3 reserved toolbar lines | 0 disables; 1 preserves current behavior; 2/3 use explicit newlines for subsequent reserved rows. Clip each line at terminal width with visible truncation; verify geometry, fallback and every ownership transition. Review mode consolidation separately rather than assuming removal of legacy/forced controls |
| 8 | Final integrated release qualification | Qualify the final code across required terminals/backends and dependency versions; record history/flicker evidence, compatibility and rollback. Default promotion remains a separate maintainer decision |

## Validation

At head `37645b59` on Mac:

- `make test`: **2,667 passed, 6 skipped**.
- Ruff lint/format checks on the pulled fix, mypy, documentation build, and diff whitespace checks passed. Required full checks also passed before the preceding Stage 4 commits.
- An in-memory mutation removing the generation from the painter cache makes both new painter regressions fail.
- Pipeline regression: a real controlling PTY and interactive shell exercise repeated Ctrl-Z/fg, shell input, resizing, quit/interrupt, toolbar restoration and subsequent cmd2 input. The preceding commit passed 20 PTY cases across 10 runs; removing either process-group fix fails its regression.
- Earlier Stage 4 acceptance/dynamic harness captures passed at 12/24/40 rows. These are earlier snapshots, not a claim that the final PR head has already been recaptured.

Maintainer-reported manual results: nested prompts on Mac and Windows; embedded paging and external tool/interpreter recovery; Mac job-control edge cases; clean shell return; and the exact pipeline sequence in Mac iTerm2. The Windows 2 → 3-row issue was subsequently reported fixed and pulled in `37645b59`; reviewers should repeat the exact boundary check below and attach the native result. Mac review of that commit found no blocking issues. PR CI is additional evidence, not a substitute for native terminal verification.

## Manual reviewer checklist

Run from the repository root with `uv run python examples/stage4_manual.py`. `stage4_manual.py` is a super-set of the `getting_started.py` application which adds commands for testing nested prompts via `read_input`, `read_secret`, and `select`. The example uses AUTO with a live timestamp. Record the commit, OS, terminal/version, shell, Python and prompt-toolkit versions, actual selected backend/mode, and measured viewport dimensions. AUTO can fall back: a visible native toolbar alone does not prove reserved rendering. `scripts/toolbar_inventory.py` can help identify the environment; inspect its usage first because it includes interactive probes.

Perform applicable checks on Mac/Linux and Windows Terminal. POSIX Ctrl-Z/fg is not expected in PowerShell. External TUIs intentionally hide the reserved toolbar while they own the terminal; it must return when they exit. Exact physical row counts matter, especially at the minimum height.

| Check | How to exercise it | Expected result |
| --- | --- | --- |
| Ordinary prompts and commands | Press Enter repeatedly; run `echo hello` and `work 5`; edit input and use completion/history | Stable reserved band, live timestamp, usable prompt, no duplicated/lost input or output |
| Managed text input | In the optional test app below run `nested`; use Tab and Up, resize, then accept; repeat and press Ctrl-C or EOF | Band remains reserved; completion/history work; only the active prompt consumes input; main prompt recovers |
| Secret input and selection | Run `secret` with dummy text only; run `choose` and use arrows/Enter; repeat with cancellation and resize | Secret remains masked; selection works; toolbar and main input recover without stale bindings |
| Typeahead | At `nested`, quickly enter `alpha` followed by a newline and `echo after` followed by a newline | Accepted input and following command are each consumed once by the correct owner |
| Large embedded pager | `cat cmd2/cmd2.py`; use Space/PgDn, b/PgUp, `/` search, `n`, resize and `q` | No prolonged blank-toolbar interval while loading; pager uses full geometry with its native bar; main reserved band and prompt return on exit |
| Short pager output | `cat examples/scripts/raise_exception.py` in a normal-height terminal | Short output prints normally without an unnecessary full-screen pager |
| External pager | On POSIX run `help -v \| less`; resize inside it, navigate and quit with `q` | External pager owns the full terminal; toolbar returns at current dimensions with usable input and intact output |
| External editor | Use `edit` with a disposable file and a configured editor; resize and exit | Full terminal available to the editor; reservation restored afterward |
| Embedded Python/IPython and scripts | Run `py`/`ipy`, print text and exit normally; run a normal `run_pyscript` and `run_pyscript examples/scripts/raise_exception.py` | External interpreter ownership is intentional; success and exception paths restore toolbar/input. Record unavailable optional IPython explicitly |
| Nested public suspension | Optional app: `handoff`, then `handoff fail`; resize at the guest input and complete it | No early reacquisition at an inner exit; toolbar restored after outer exit, including failure |
| POSIX prompt/command suspend | At an idle or partially typed prompt, and during `work 10`, press Ctrl-Z; run a shell command, resize, `fg`; repeat | Shell has full scrolling/input while stopped; resume restores correct geometry and preserves editable input/output |
| POSIX pager suspend | Repeat Ctrl-Z, shell command, resize and `fg` inside the embedded pager; navigate and quit afterward | No reservation installed into a guest screen; pager remains usable and restores main-screen toolbar on exit |
| POSIX pipeline ownership regression | `help -v \| less`, Ctrl-Z; type a complete shell command such as `printf 'shell owns input\n'`; `fg`; `q`; then `echo after` in cmd2 | Shell receives all keystrokes; less and cmd2 stop/resume together; reserved bar and command input return. Repeat the cycle |
| Exact minimum-height recovery | Idle main prompt: measure and resize 24 → 2 → 3 → 4 → 24; repeat with partially typed input. Also start at 2 or 3 rows and grow | At 2 rows reservation releases; at 3 there are 2 usable rows plus a fully painted toolbar on row 3; 4+ remains correct. No Enter/Ctrl-L needed to repair it |
| Quiet and partial-output resize | Optional app: `quiet`, then `partial`; resize repeatedly through 2/3/4 rows during the pause | Automatic resize detection; full bar returns when eligible; `PARTIALEND` remains intact and output never lands in the toolbar band |
| Width and handoff recovery | Narrow/widen at main/nested prompts and in a pager; repeat the height-boundary sequence after returning from an external tool | Current width/viewport used, no stale band, prompt overlap, missing input or permanent fallback |
| Compatibility and disabled mode | In a disposable copy of the example change constructor mode AUTO to LEGACY, then OFF; repeat basic commands and paging. Test RESERVED on a qualified backend | Legacy remains usable; OFF has no toolbar; RESERVED really exercises the new path. Unsupported forced prerequisites report an error rather than pretending to qualify |
| History and final shell cleanup | After the transitions, scroll through history; quit, type a shell command and generate more than one screen of output; relaunch | No toolbar leakage or unexplained lost/duplicated command output; normal shell echo/cursor and full-height scrolling; fresh loop behaves normally |

### Optional commands for managed-input and handoff checks

Run `uv run python examples/stage4_manual.py`. These commands execute inside the normal command lifecycle. Calling `read_input()` from the external `py` shell would instead exercise an already-suspended handoff.

```python
import time
from getting_started import BasicApp


class ManualApp(BasicApp):
    def do_nested(self, arg):
        value = self.read_input(
            "Value> ", choices=["alpha", "beta"], history=["alpha", "beta"]
        )
        self.poutput(repr(value))

    def do_secret(self, arg):
        self.read_secret("Dummy secret> ")
        self.poutput("Secret accepted; value not displayed")

    def do_choose(self, arg):
        self.poutput(self.select(["alpha", "beta"], "Choose> "))

    def do_quiet(self, arg):
        time.sleep(10)

    def do_partial(self, arg):
        self.stdout.write("PARTIAL")
        self.stdout.flush()
        time.sleep(10)
        self.stdout.write("END\n")
        self.stdout.flush()

    def do_handoff(self, arg):
        with self.suspend_bottom_toolbar():
            with self.suspend_bottom_toolbar():
                input("Guest owns terminal; resize, then Enter> ")
            if arg.strip() == "fail":
                raise RuntimeError("Intentional guest failure")


if __name__ == "__main__":
    ManualApp().cmdloop()
```

Fault-injection cases such as failing pager erasure, failed reacquisition and reservation abandonment are covered by automated tests; reviewers should inspect those outcomes rather than make production callbacks fail ad hoc. Record PASS/FAIL/not available per manual row, with terminal details and screenshots/diagnostic traces for failures. The broader release terminal matrix and configurable multiple reserved rows remain later-stage work.
